### PR TITLE
Move exception rescue into a wrapper

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -12,11 +12,13 @@
 
 require 'kubernetes-deploy'
 
-runner = KubernetesDeploy::Runner.new(
-  namespace: ARGV[0],
-  context: ARGV[1],
-  environment: ENV['ENVIRONMENT'],
-  current_sha: ENV['REVISION'],
-  template_folder: ENV['K8S_TEMPLATE_FOLDER']
-)
-runner.run
+KubernetesDeploy::Runner.with_friendly_errors do
+  runner = KubernetesDeploy::Runner.new(
+    namespace: ARGV[0],
+    context: ARGV[1],
+    environment: ENV['ENVIRONMENT'],
+    current_sha: ENV['REVISION'],
+    template_folder: ENV['K8S_TEMPLATE_FOLDER']
+  )
+  runner.run
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -9,6 +9,16 @@ require 'kubernetes-deploy/kubernetes_resource'
 
 module KubernetesDeploy
   class Runner
+    def self.with_friendly_errors
+      yield
+    rescue FatalDeploymentError => error
+      KubernetesDeploy.logger.fatal <<-MSG
+#{error.class}: #{error.message}
+  #{error.backtrace && error.backtrace.join("\n  ")}
+MSG
+      exit 1
+    end
+
     def initialize(namespace:, environment:, current_sha:, template_folder: nil, context:)
       @namespace = namespace
       @context = context
@@ -41,9 +51,6 @@ module KubernetesDeploy
       wait_for_completion(resources)
 
       report_final_status(resources)
-    rescue FatalDeploymentError => error
-      KubernetesDeploy.logger.fatal(error.message)
-      exit 1
     end
 
     def template_variables


### PR DESCRIPTION
We don't want to rescue and log all exceptions in tests. `with_friendly_errors` is only used for CLI. I also added the backtrace reporting to be able to find the source of error.

Before:

![screen shot 2017-01-20 at 12 22 03](https://cloud.githubusercontent.com/assets/522155/22158688/5ca61556-df0b-11e6-8f85-8a8fb739cf3b.png)

After:

![screen shot 2017-01-20 at 12 21 34](https://cloud.githubusercontent.com/assets/522155/22158691/609a240e-df0b-11e6-8573-85f127df805b.png)


review @sirupsen @ibawt @KnVerey 