### PR TITLE
Reorganization follow-up

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -8,32 +8,6 @@ require 'kubernetes-deploy/runner'
 module KubernetesDeploy
   class FatalDeploymentError < StandardError; end
 
-  # Things removed from default prune whitelist:
-  # core/v1/Namespace -- not namespaced
-  # core/v1/PersistentVolume -- not namespaced
-  # core/v1/Endpoints -- managed by services
-  # core/v1/PersistentVolumeClaim -- would delete data
-  # core/v1/ReplicationController -- superseded by deployments/replicasets
-  # extensions/v1beta1/ReplicaSet -- managed by deployments
-  # core/v1/Secret -- should not committed / managed by shipit
-  PRUNE_WHITELIST = %w(
-    core/v1/ConfigMap
-    core/v1/Pod
-    core/v1/Service
-    batch/v1/Job
-    extensions/v1beta1/DaemonSet
-    extensions/v1beta1/Deployment
-    extensions/v1beta1/HorizontalPodAutoscaler
-    extensions/v1beta1/Ingress
-    apps/v1beta1/StatefulSet
-  ).freeze
-
-  PREDEPLOY_SEQUENCE = %w(
-    ConfigMap
-    PersistentVolumeClaim
-    Pod
-  )
-
   def self.logger=(value)
     @logger = value
   end

--- a/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
@@ -1,5 +1,5 @@
 module KubernetesDeploy
-  class Configmap < KubernetesResource
+  class ConfigMap < KubernetesResource
     TIMEOUT = 30.seconds
 
     def initialize(name, namespace, file)

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -6,6 +6,16 @@ require 'shellwords'
 require 'tempfile'
 
 require 'kubernetes-deploy/kubernetes_resource'
+%w(
+  config_map
+  deployment
+  ingress
+  persistent_volume_claim
+  pod
+  service
+).each do |subresource|
+  require "kubernetes-deploy/kubernetes_resource/#{subresource}"
+end
 
 module KubernetesDeploy
   class Runner

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -9,6 +9,32 @@ require 'kubernetes-deploy/kubernetes_resource'
 
 module KubernetesDeploy
   class Runner
+    PREDEPLOY_SEQUENCE = %w(
+      ConfigMap
+      PersistentVolumeClaim
+      Pod
+    )
+
+    # Things removed from default prune whitelist:
+    # core/v1/Namespace -- not namespaced
+    # core/v1/PersistentVolume -- not namespaced
+    # core/v1/Endpoints -- managed by services
+    # core/v1/PersistentVolumeClaim -- would delete data
+    # core/v1/ReplicationController -- superseded by deployments/replicasets
+    # extensions/v1beta1/ReplicaSet -- managed by deployments
+    # core/v1/Secret -- should not committed / managed by shipit
+    PRUNE_WHITELIST = %w(
+      core/v1/ConfigMap
+      core/v1/Pod
+      core/v1/Service
+      batch/v1/Job
+      extensions/v1beta1/DaemonSet
+      extensions/v1beta1/Deployment
+      extensions/v1beta1/HorizontalPodAutoscaler
+      extensions/v1beta1/Ingress
+      apps/v1beta1/StatefulSet
+    ).freeze
+
     def self.with_friendly_errors
       yield
     rescue FatalDeploymentError => error


### PR DESCRIPTION
@kirs @sirupsen  

This PR:
- Puts some constants I missed moving in https://github.com/Shopify/kubernetes-deploy/pull/3 where they belong.
- Addresses https://github.com/Shopify/kubernetes-deploy/pull/3#discussion_r96986742 (which I see I didn't answer--sorry about that!). The reason I put it at the bottom was that the superclass had to be loaded first, or else I'd get `uninitialized constant KubernetesDeploy::KubernetesResource (NameError)`.  Do you like this better?
- Fixes capitalization of the `ConfigMap` subclass to match the k8s norm.
- Replaces DescendantsTracker with a more straightforward solution, as previously requested. 
