### PR TITLE
Allow to skip waiting for completion

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -12,13 +12,22 @@
 
 require 'kubernetes-deploy'
 
+require 'optparse'
+
+skip_wait = false
+ARGV.options do |opts|
+  opts.on("-w", "--skip-wait") { skip_wait = true }
+  opts.parse!
+end
+
 KubernetesDeploy::Runner.with_friendly_errors do
   runner = KubernetesDeploy::Runner.new(
     namespace: ARGV[0],
     context: ARGV[1],
     environment: ENV['ENVIRONMENT'],
     current_sha: ENV['REVISION'],
-    template_folder: ENV['K8S_TEMPLATE_FOLDER']
+    template_folder: ENV['K8S_TEMPLATE_FOLDER'],
+    wait_for_completion: !skip_wait,
   )
   runner.run
 end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -55,13 +55,18 @@ MSG
       exit 1
     end
 
-    def initialize(namespace:, environment:, current_sha:, template_folder: nil, context:)
+    def initialize(namespace:, environment:, current_sha:, context:, wait_for_completion:, template_folder: nil)
       @namespace = namespace
       @context = context
       @current_sha = current_sha
       @template_path = File.expand_path('./' + (template_folder || "config/deploy/#{environment}"))
       # Max length of podname is only 63chars so try to save some room by truncating sha to 8 chars
       @id = current_sha[0...8] + "-#{SecureRandom.hex(4)}" if current_sha
+      @wait_for_completion = wait_for_completion
+    end
+
+    def wait_for_completion?
+      @wait_for_completion
     end
 
     def run
@@ -84,8 +89,9 @@ MSG
 
       phase_heading("Deploying all resources")
       deploy_resources(resources, prune: true)
-      wait_for_completion(resources)
 
+      return unless wait_for_completion?
+      wait_for_completion(resources)
       report_final_status(resources)
     end
 


### PR DESCRIPTION
Roughly, the current workflow of the script is:

1) kubectl apply
2) watch for changes to be propagated

I'm going to start deploying Shopify core with the script and at the same time I don't want to block the current deploys with the watch & wait part if something breaks. To allow that, I'm adding the `--skip-wait` flag. I'm open to rename it to `--skip-watch` if you think it's a better name.

I'd like to ship this ASAP to start deploying today.

review @sirupsen @KnVerey 