### PR TITLE
Accept --template-dir as an argument

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -15,18 +15,28 @@ require 'kubernetes-deploy'
 require 'optparse'
 
 skip_wait = false
+template_dir = nil
 ARGV.options do |opts|
-  opts.on("-w", "--skip-wait") { skip_wait = true }
+  opts.on("--skip-wait") { skip_wait = true }
+  opts.on("--template-dir=DIR") { |v| template_dir = v }
   opts.parse!
+end
+
+if !template_dir && ENV.key?("ENVIRONMENT")
+  template_dir = "config/deploy/#{ENV["ENVIRONMENT"]}"
+end
+
+if !template_dir || template_dir.empty?
+  puts "Template directory is unknown. Either specify --template-dir argument or set $ENVIRONMENT to use config/deploy/$ENVIRONMENT as a default path."
+  exit 1
 end
 
 KubernetesDeploy::Runner.with_friendly_errors do
   runner = KubernetesDeploy::Runner.new(
     namespace: ARGV[0],
     context: ARGV[1],
-    environment: ENV['ENVIRONMENT'],
     current_sha: ENV['REVISION'],
-    template_folder: ENV['K8S_TEMPLATE_FOLDER'],
+    template_dir: template_dir,
     wait_for_completion: !skip_wait,
   )
   runner.run

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -55,11 +55,12 @@ MSG
       exit 1
     end
 
-    def initialize(namespace:, environment:, current_sha:, context:, wait_for_completion:, template_folder: nil)
+    def initialize(namespace:, current_sha:, context:, wait_for_completion:, template_dir:)
       @namespace = namespace
       @context = context
       @current_sha = current_sha
-      @template_path = File.expand_path('./' + (template_folder || "config/deploy/#{environment}"))
+
+      @template_dir = File.expand_path(template_dir)
       # Max length of podname is only 63chars so try to save some room by truncating sha to 8 chars
       @id = current_sha[0...8] + "-#{SecureRandom.hex(4)}" if current_sha
       @wait_for_completion = wait_for_completion
@@ -119,7 +120,7 @@ MSG
 
     def discover_resources
       resources = []
-      Dir.foreach(@template_path) do |filename|
+      Dir.foreach(@template_dir) do |filename|
         next unless filename.end_with?(".yml.erb", ".yml")
 
         split_templates(filename) do |tempfile|
@@ -139,7 +140,7 @@ MSG
     end
 
     def split_templates(filename)
-      file_content = File.read(File.join(@template_path, filename))
+      file_content = File.read(File.join(@template_dir, filename))
       rendered_content = render_template(filename, file_content)
       YAML.load_stream(rendered_content) do |doc|
         f = Tempfile.new(filename)
@@ -201,10 +202,10 @@ MSG
         errors << "Current SHA must be specified"
       end
 
-      if !File.directory?(@template_path)
-        errors << "Template path #{@template_path} doesn't exist"
-      elsif Dir.entries(@template_path).none? { |file| file =~ /\.yml(\.erb)?$/ }
-        errors << "#{@template_path} doesn't contain valid templates (postfix .yml or .yml.erb)"
+      if !File.directory?(@template_dir)
+        errors << "Template directory `#{@template_dir}` doesn't exist"
+      elsif Dir.entries(@template_dir).none? { |file| file =~ /\.yml(\.erb)?$/ }
+        errors << "`#{@template_dir}` doesn't contain valid templates (postfix .yml or .yml.erb)"
       end
 
       if @namespace.blank?


### PR DESCRIPTION
This is required to specify custom directory with k8s templates. It's `config/deploy/$ENVIRONMENT` by default, but for Shopify core it has to be another path. Right now the deploy fails because it can't find any k8s configs in `config/deploy/$ENVIRONMENT`.

closes https://github.com/Shopify/kubernetes-deploy/pull/6

review @sirupsen @KnVerey 