### PR TITLE
Measure waiting for the resource

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -165,6 +165,9 @@ MSG
 
     def wait_for_completion(watched_resources)
       delay_sync_until = Time.now.utc
+      started_at = delay_sync_until
+      human_resources = watched_resources.map(&:id).join(", ")
+      KubernetesDeploy.logger.info("Waiting for #{human_resources}")
       while watched_resources.present?
         if Time.now.utc < delay_sync_until
           sleep (delay_sync_until - Time.now.utc)
@@ -179,6 +182,9 @@ MSG
           KubernetesDeploy.logger.error(resource.status_data)
         end
       end
+
+      watch_time = Time.now.utc - started_at
+      KubernetesDeploy.logger.info("Spent #{watch_time.round(2)}s waiting for #{human_resources}")
     end
 
     def render_template(filename, raw_template)


### PR DESCRIPTION
Report how much time we spent waiting for a resource to be ready:

<img width="660" alt="screen shot 2017-01-31 at 21 33 11" src="https://cloud.githubusercontent.com/assets/522155/22481306/6d092488-e7fd-11e6-8cfd-cf1bdb7d7ed4.png">

review @KnVerey @sirupsen 