### PR TITLE
Context flag for KubernetesResource#run_kubectl

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class Cloudsql < KubernetesResource
     TIMEOUT = 5.minutes
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync

--- a/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class ConfigMap < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class Deployment < KubernetesResource
     TIMEOUT = 15.minutes
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync
@@ -22,7 +22,7 @@ module KubernetesDeploy
           pods_json = JSON.parse(pod_list)["items"]
           pods_json.each do |pod_json|
             pod_name = pod_json["metadata"]["name"]
-            pod = Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment")
+            pod = Pod.new(pod_name, namespace, context, nil, parent: "#{@name.capitalize} deployment")
             pod.deploy_started = @deploy_started
             pod.interpret_json_data(pod_json)
             pod.log_status

--- a/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class Ingress < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync

--- a/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class PersistentVolumeClaim < KubernetesResource
     TIMEOUT = 5.minutes
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -3,8 +3,8 @@ module KubernetesDeploy
     TIMEOUT = 15.minutes
     SUSPICIOUS_CONTAINER_STATES = %w(ImagePullBackOff RunContainerError).freeze
 
-    def initialize(name, namespace, file, parent: nil)
-      @name, @namespace, @file, @parent = name, namespace, file, parent
+    def initialize(name, namespace, context, file, parent: nil)
+      @name, @namespace, @context, @file, @parent = name, namespace, context, file, parent
       @bare = !@parent
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -2,8 +2,8 @@ module KubernetesDeploy
   class Service < KubernetesResource
     TIMEOUT = 15.minutes
 
-    def initialize(name, namespace, file)
-      @name, @namespace, @file = name, namespace, file
+    def initialize(name, namespace, context, file)
+      @name, @namespace, @context, @file = name, namespace, context, file
     end
 
     def sync

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -76,9 +76,9 @@ MSG
       phase_heading("Validating configuration")
       validate_configuration
 
-      phase_heading("Configuring kubectl")
-      validate_context
-      validate_namespace
+      phase_heading("Identifying deployment target")
+      confirm_context_exists
+      confirm_namespace_exists
 
       phase_heading("Parsing deploy content")
       resources = discover_resources
@@ -263,7 +263,7 @@ MSG
       run_kubectl(*command)
     end
 
-    def validate_context
+    def confirm_context_exists
       out, err, st = run_kubectl("config", "get-contexts", "-o", "name", namespaced: false, with_context: false)
       available_contexts = out.split("\n")
       if !st.success?
@@ -271,13 +271,13 @@ MSG
       elsif !available_contexts.include?(@context)
         raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
       end
-      KubernetesDeploy.logger.info("Context #{@context} validated")
+      KubernetesDeploy.logger.info("Context #{@context} found")
     end
 
-    def validate_namespace
+    def confirm_namespace_exists
       _, _, st = run_kubectl("get", "namespace", @namespace, namespaced: false)
-      raise FatalDeploymentError, "Failed to validate namespace #{@namespace}" unless st.success?
-      KubernetesDeploy.logger.info("Namespace #{@namespace} validated")
+      raise FatalDeploymentError, "Namespace #{@namespace} not found" unless st.success?
+      KubernetesDeploy.logger.info("Namespace #{@namespace} found")
     end
 
     def run_kubectl(*args, namespaced: true, with_context: true)


### PR DESCRIPTION
@kirs @sirupsen @mkobetic this is the minimum change need to fix the problem described in https://github.com/Shopify/shipit/pull/141. Another option is to make the runner's version a utility method available to both the runner instance and the resource instances, although that wouldn't get around passing the namespace/context everywhere (suggestions on that welcome). Some background:
- The original reason for having two different versions is a difference in error handling and logging. The runner version handles critical deploy commands that could fail, and both its callers and the end user should be interested in error output as a result. The resources on the other hand are doing polling, in which context typical `!st.success?` causes are transient or even expected, e.g. 404s on a GETs for resources that aren't up yet.
- As Kir suggested in another issue, the resource instances' version should likely be replaced with using the API via a gem rather than shelling out to kubectl.

I've done a quick 🎩  already, but will also do the following on the final version after review:
- [x] context missing
- [x] context provided does not match current-context in kubeconfig
- [x] at least one success and one error deploy with the `trashbin` set of files