### PR TITLE
Status may not have conditions

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -40,7 +40,7 @@ module KubernetesDeploy
       elsif @phase == "Terminating"
         @status = @phase
       else
-        ready_condition = pod_data["status"]["conditions"].find { |condition| condition["type"] == "Ready" }
+        ready_condition = pod_data["status"].fetch("conditions", []).find { |condition| condition["type"] == "Ready" }
         @ready = ready_condition.present? && (ready_condition["status"] == "True")
         @status = "#{@phase} (Ready: #{@ready})"
       end


### PR DESCRIPTION
@sirupsen Fixes the error below, which someone saw in Shipit this morning. TBH I'm not sure what state leads to pods not having status conditions, but it's easy to avoid 💥 .

```
/usr/lib/ruby-shopify/ruby-shopify-2.3.1/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.2.1/lib/kubernetes-deploy/kubernetes_resource/pod.rb:43:in `interpret_json_data': undefined method `find' for nil:NilClass (NoMethodError)
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.1/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.2.1/lib/kubernetes-deploy/kubernetes_resource/deployment.rb:27:in `block in sync'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.1/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.2.1/lib/kubernetes-deploy/kubernetes_resource/deployment.rb:23:in `each'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.1/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.2.1/lib/kubernetes-deploy/kubernetes_resource/deployment.rb:23:in `sync'
```

I did a 🎩  with a template set that includes pods and deployments.