### PR TITLE
Enable CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubernetes::Deploy
 
+[![Build status](https://badge.buildkite.com/0f2d4956d49fbc795f9c17b0a741a6aa9ea532738e5f872ac8.svg)](https://buildkite.com/shopify/kubernetes-deploy-gem)
+
 Deploy script used to manage a Kubernetes application's namespace with [Shipit](https://github.com/Shopify/shipit-engine).
 
 ## Installation
@@ -44,6 +46,14 @@ To run the tests:
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## CI
+
+Buildkite will build branches as you're working on them, but as soon as you create a PR it will stop building new commits from that branch because we disabled PR builds for security reasons.
+As a Shopify employee, you can manually trigger the PR build from the Buildkite UI (just specify the branch, SHA is not required):
+
+<img width="464" alt="screen shot 2017-02-21 at 10 55 33" src="https://cloud.githubusercontent.com/assets/522155/23172610/52771a3a-f824-11e6-8c8e-3d59c45e7ff8.png">
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/kubernetes-deploy.
@@ -52,4 +62,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eox pipefail
+
+MINIKUBE_VER=0.16.0
+KUBERNETES_VER=1.5.2
+DOCKER_MACHINE_KVM_VER=0.7.0
+
+echo "--- Installing dependencies"
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v$MINIKUBE_VER/minikube-linux-amd64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+
+# minikube requires kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBERNETES_VER/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+
+# KVM support for minikube
+curl -Lo docker-machine-driver-kvm https://github.com/dhiltgen/docker-machine-kvm/releases/download/v$DOCKER_MACHINE_KVM_VER/docker-machine-driver-kvm
+chmod +x docker-machine-driver-kvm
+sudo mv docker-machine-driver-kvm /usr/local/bin/
+
+minikube config set vm-driver kvm
+
+gem install bundler --no-ri --no-rdoc
+bundle install --jobs 4
+
+echo "--- Starting minikube"
+minikube start --cpus 2 --memory 2048 --disk-size=2gb --kubernetes-version=$KUBERNETES_VER
+
+echo "--- Running tests"
+bundle exec rake test


### PR DESCRIPTION
This is the scrappy version of the CI running for master and branches. Surprisingly, it took me less than an hour to set it up (big thanks to @sander-m for help with BK and VMs) 🎉 

Important things:

* Only Shopify employees can access the CI page, however the CI status is reported back to GH and visible for everyone
* I didn't enable it for the PRs on purpose because it's a source of vulnerabilities. This is a public project and anyone could submit a PR with malicious code in `bin/ci` that would be executed on Shopify VMs. Technically the VMs are isolated but still I wouldn't like to give this opportunity to people outside of the company.

**How it works:**
Mobile CI at Shopify provides disposable Ubuntu VMs with enabled KVM. We have them integrated with BuildKite, and these computing resources are available to run CI for this project. In `bin/ci` script we install kubectl, minikube, docker kvm driver, and ruby dependencies. Them we simply run `rake test`.

It takes 2m40s to start minikube, and the complete test suite runs in 20 seconds. This sounds good enough for me, but in future we can speed it up by pre-building the VM template with minikube and all dependencies installed.

Preview:

<img width="880" alt="screen shot 2017-02-17 at 20 16 56" src="https://cloud.githubusercontent.com/assets/522155/23088829/8de21d82-f54e-11e6-819c-7693633241cc.png">

review @sirupsen @KnVerey @ibawt @wfarr 