### PR TITLE
Capture all logging

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -4,6 +4,19 @@ require 'shellwords'
 
 module KubernetesDeploy
   class KubernetesResource
+    def self.logger=(value)
+      @logger = value
+    end
+
+    def self.logger
+      @logger ||= begin
+        l = Logger.new($stderr)
+        l.formatter = proc do |_severity, _datetime, _progname, msg|
+          "#{msg}\n"
+        end
+        l
+      end
+    end
 
     attr_reader :name, :namespace, :file, :context
     attr_writer :type, :deploy_started
@@ -112,7 +125,7 @@ module KubernetesDeploy
     end
 
     def log_status
-      STDOUT.puts "[KUBESTATUS] #{JSON.dump(status_data)}"
+      KubernetesResource.logger.info("[KUBESTATUS] #{JSON.dump(status_data)}")
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -76,7 +76,7 @@ module KubernetesDeploy
         next unless st.success? && out.present?
 
         KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
-        STDOUT.puts "#{out}"
+        KubernetesResource.logger.info(out)
         @already_displayed = true
       end
     end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -319,7 +319,7 @@ MSG
     end
 
     def log_green(msg)
-      STDOUT.puts "\033[0;32m#{msg}\x1b[0m\n" # green
+      KubernetesDeploy.logger.info("\033[0;32m#{msg}\x1b[0m")
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ module KubernetesDeploy
       @logger_stream = StringIO.new
       @logger = Logger.new(@logger_stream)
       KubernetesDeploy.logger = @logger
+      KubernetesResource.logger = @logger
     end
 
     def teardown


### PR DESCRIPTION
This makes it possible to redirect all logging during tests by making kubestatus logging (and an errant "Deploy succeeded!" puts) use a settable logger.