### PR TITLE
Integration tests and helpers

### DIFF
--- a/test/fixtures/basic/redis.yml
+++ b/test/fixtures/basic/redis.yml
@@ -16,6 +16,9 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: basic-redis
+  labels:
+    name: redis
+    app: basic
 spec:
   accessModes:
     - ReadWriteOnce

--- a/test/fixtures/invalid/yaml-error.yml
+++ b/test/fixtures/invalid/yaml-error.yml
@@ -6,5 +6,5 @@ metadata:
     name: basic-configmap-data
     app: basic
 data:
-  datapoint1: value1
+  datapoint1: value1:
   datapoint2: value2

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -1,0 +1,90 @@
+module FixtureDeployHelper
+  # use deploy_fixture_set if you are not adding to or otherwise modifying the template set
+  def deploy_fixture_set(set, subset=nil, wait: true)
+    source_dir = fixture_path(set)
+    return deploy_dir(source_dir) unless subset
+
+    target_dir = Dir.mktmpdir
+    files = []
+    each_k8s_yaml(source_dir, subset) do |basename, ext, content|
+      Tempfile.open([basename, ext], target_dir) do |f|
+        files << f
+        f.write(content)
+      end
+    end
+
+    deploy_dir(target_dir, wait: wait)
+  ensure
+    files.each { |f| File.delete(f) } if files
+  end
+
+  # use load_fixture_data + deploy_loaded_fixture_set to have the chance to add to / modify the template set before deploy
+  def deploy_loaded_fixture_set(template_map, wait: true)
+    dir = Dir.mktmpdir
+    files = []
+    template_map.each do |file_basename, file_data|
+      data = YAML.dump_stream(*file_data.values.flatten)
+      # assume they're all erb now in case erb was added
+      Tempfile.open([file_basename, ".yml.erb"], dir) do |f|
+        files << f
+        f.write(data)
+      end
+    end
+    deploy_dir(dir, wait: wait)
+  ensure
+    files.each { |f| File.delete(f) }
+  end
+
+  # load_fixture_data return format
+  # {
+  #   file_basename: {
+  #     type_name: [
+  #       loaded_yaml_of_type,
+  #       loaded_yaml_of_type,
+  #     ]
+  #   }
+  # }
+  def load_fixture_data(set, subset=nil)
+    source_dir = fixture_path(set)
+    templates = {}
+
+    each_k8s_yaml(source_dir, subset) do |basename, ext, content|
+      templates[basename] = {}
+      YAML.load_stream(content) do |doc|
+        templates[basename][doc["kind"]] ||= []
+        templates[basename][doc["kind"]] << doc
+      end
+    end
+    templates
+  end
+
+  def deploy_dir(dir, sha: 'abcabcabc', wait: true)
+    runner = KubernetesDeploy::Runner.new(
+      namespace: @namespace,
+      current_sha: sha,
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      template_dir: dir,
+      wait_for_completion: wait,
+    )
+    runner.run
+  end
+
+  # HELPER METHODS BELOW NOT INTENDED FOR INCLUDING CLASS USE
+
+  def fixture_path(set_name)
+    source_dir = File.expand_path("../../fixtures/#{set_name}", __FILE__)
+    raise "Fixture set pat #{source_dir} is invalid" unless File.directory?(source_dir)
+    source_dir
+  end
+
+  def each_k8s_yaml(source_dir, subset)
+    Dir["#{source_dir}/*.yml*"].each do |filename|
+      match_data = File.basename(filename).match(/(?<basename>.*)(?<ext>\.yml(?:\.erb)?)\z/)
+      basename = match_data[:basename]
+      ext = match_data[:ext]
+      next unless !subset || subset.include?(basename)
+
+      yield basename, ext, File.read(filename)
+    end
+  end
+end

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -1,6 +1,6 @@
 module FixtureDeployHelper
   # use deploy_fixture_set if you are not adding to or otherwise modifying the template set
-  def deploy_fixture_set(set, subset=nil, wait: true)
+  def deploy_fixture_set(set, subset: nil, wait: true)
     source_dir = fixture_path(set)
     return deploy_dir(source_dir) unless subset
 
@@ -15,7 +15,7 @@ module FixtureDeployHelper
 
     deploy_dir(target_dir, wait: wait)
   ensure
-    files.each { |f| File.delete(f) } if files
+    FileUtils.remove_dir(target_dir) if target_dir
   end
 
   # use load_fixture_data + deploy_loaded_fixture_set to have the chance to add to / modify the template set before deploy
@@ -69,7 +69,7 @@ module FixtureDeployHelper
     runner.run
   end
 
-  # HELPER METHODS BELOW NOT INTENDED FOR INCLUDING CLASS USE
+  private
 
   def fixture_path(set_name)
     source_dir = File.expand_path("../../fixtures/#{set_name}", __FILE__)

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -1,0 +1,78 @@
+require 'helpers/kubeclient_helper'
+
+module FixtureSetAssertions
+  class FixtureSet
+    class FixtureSetError < StandardError; end
+    include KubeclientHelper
+    include Minitest::Assertions
+    attr_writer :assertions
+
+    def initialize
+      raise NotImplementedError
+    end
+
+    def assertions
+      @assertions ||= 0
+    end
+
+    def namespace
+      raise FixtureSetError.new("@namespace must be set in initializer") if @namespace.blank?
+      @namespace
+    end
+
+    def app_name
+      raise FixtureSetError.new("@app_name must be set in initializer") if @app_name.blank?
+      @app_name
+    end
+
+    private
+
+    def refute_resource_exists(type, name, beta: false)
+      client = beta ? v1beta1_kubeclient : kubeclient
+      resources = client.public_send("get_#{type}", name, namespace) # 404s
+      flunk "#{type} #{name} unexpectedly existed"
+    rescue KubeException => e
+      raise unless e.to_s.include?("not found")
+    end
+
+    def assert_pod_status(pod_name, status)
+      pods = kubeclient.get_pods(namespace: namespace, label_selector: "name=#{pod_name},app=#{app_name}")
+      assert_equal 1, pods.size, "Unable to find #{pod_name} pod"
+      assert_equal status, pods.first.status.phase
+    end
+
+    def assert_service_up(svc_name)
+      services = kubeclient.get_services(namespace: namespace, label_selector: "name=#{svc_name},app=#{app_name}")
+      assert_equal 1, services.size, "Expected 1 #{svc_name} service, got #{services.size}"
+      refute services.first["spec"]["clusterIP"].empty?, "Cluster IP was not assigned"
+
+      endpoints_obj = kubeclient.get_endpoint(svc_name, namespace)
+      num_endpoints = endpoints_obj["subsets"].first["addresses"].length
+      assert_equal 1, num_endpoints
+    end
+
+    def assert_deployment_up(dep_name, replicas)
+      deployments = v1beta1_kubeclient.get_deployments(namespace: namespace, label_selector: "name=#{dep_name},app=#{app_name}")
+      assert_equal 1, deployments.size, "Expected 1 #{dep_name} deployment, got #{deployments.size}"
+      available = deployments.first["status"]["availableReplicas"]
+      assert_equal replicas, available, "Expected #{dep_name} deployment to have #{replicas} available replicas, saw #{available}"
+    end
+
+    def assert_pvc_status(pvc_name, status)
+      pvc = kubeclient.get_persistent_volume_claims(namespace: namespace, label_selector: "name=#{pvc_name},app=#{app_name}")
+      assert_equal 1, pvc.size, "Expected 1 #{pvc_name} pvc, saw #{pvc.size}"
+      assert_equal status, pvc.first.status.phase
+    end
+
+    def assert_ingress_up(ing_name)
+      ing = v1beta1_kubeclient.get_ingresses(namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}")
+      assert_equal 1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}"
+    end
+
+    def assert_configmap_up(cm_name, expected_data)
+      configmaps = kubeclient.get_config_maps(namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}")
+      assert_equal 1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}"
+      assert_equal expected_data, configmaps.first["data"].to_h
+    end
+  end
+end

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -67,7 +67,7 @@ module FixtureSetAssertions
       assert_equal 1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}"
     end
 
-    def assert_configmap_up(cm_name, expected_data)
+    def assert_configmap_present(cm_name, expected_data)
       configmaps = kubeclient.get_config_maps(namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}")
       assert_equal 1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}"
       assert_equal expected_data, configmaps.first["data"].to_h

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -49,7 +49,7 @@ module FixtureSetAssertions
       assert_equal 1, num_endpoints
     end
 
-    def assert_deployment_up(dep_name, replicas)
+    def assert_deployment_up(dep_name, replicas:)
       deployments = v1beta1_kubeclient.get_deployments(namespace: namespace, label_selector: "name=#{dep_name},app=#{app_name}")
       assert_equal 1, deployments.size, "Expected 1 #{dep_name} deployment, got #{deployments.size}"
       available = deployments.first["status"]["availableReplicas"]

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -25,8 +25,6 @@ module FixtureSetAssertions
       @app_name
     end
 
-    private
-
     def refute_resource_exists(type, name, beta: false)
       client = beta ? v1beta1_kubeclient : kubeclient
       resources = client.public_send("get_#{type}", name, namespace) # 404s
@@ -35,10 +33,10 @@ module FixtureSetAssertions
       raise unless e.to_s.include?("not found")
     end
 
-    def assert_pod_status(pod_name, status)
+    def assert_pod_status(pod_name, status, count=1)
       pods = kubeclient.get_pods(namespace: namespace, label_selector: "name=#{pod_name},app=#{app_name}")
-      assert_equal 1, pods.size, "Unable to find #{pod_name} pod"
-      assert_equal status, pods.first.status.phase
+      num_with_status = pods.count { |pod| pod.status.phase == status }
+      assert_equal count, num_with_status, "Expected to find #{count} #{pod_name} pods with status #{status}, found #{num_with_status}"
     end
 
     def assert_service_up(svc_name)

--- a/test/helpers/fixture_sets/basic.rb
+++ b/test/helpers/fixture_sets/basic.rb
@@ -1,0 +1,63 @@
+module FixtureSetAssertions
+  class Basic < FixtureSet
+    def initialize(namespace)
+      @namespace = namespace
+      @app_name = "basic"
+    end
+
+    def assert_all_up
+      assert_unmanaged_pod_statuses("Succeeded")
+      assert_all_web_resources_up
+      assert_all_redis_resources_up
+      assert_configmap_data_up
+    end
+
+    def assert_unmanaged_pod_statuses(status, count=1)
+      pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
+      assert_equal count, pods.size, "Expected to find #{count} unmanaged pod(s), found #{pods.size}"
+      assert pods.all? { |pod| pod.status.phase == status }
+    end
+
+    def refute_managed_pod_exists
+      assert_unmanaged_pod_statuses("", 0)
+    end
+
+    def assert_configmap_data_up
+      assert_configmap_up("basic-configmap-data", { datapoint1: "value1", datapoint2: "value2" })
+    end
+
+    def refute_configmap_data_exists
+      refute_resource_exists("config_map", "basic-configmap-data")
+    end
+
+    def assert_all_web_resources_up
+      assert_pod_status("web", "Running")
+      assert_ingress_up("web")
+      assert_service_up("web")
+      assert_deployment_up("web", 1)
+    end
+
+    def refute_web_resources_exist
+      refute_resource_exists("deployment", "web", beta: true)
+      refute_resource_exists("ingress", "web", beta: true)
+      refute_resource_exists("service", "web")
+    end
+
+    def assert_all_redis_resources_up
+      assert_pod_status("redis", "Running")
+      assert_service_up("redis")
+      assert_deployment_up("redis", 1)
+      assert_pvc_status("redis", "Bound")
+    end
+
+    def refute_redis_resources_exist(expect_pvc: false)
+      refute_resource_exists("deployment", "redis", beta: true)
+      refute_resource_exists("service", "redis")
+      if expect_pvc
+        assert_pvc_status("redis", "Bound")
+      else
+        refute_resource_exists("pvc", "redis")
+      end
+    end
+  end
+end

--- a/test/helpers/fixture_sets/basic.rb
+++ b/test/helpers/fixture_sets/basic.rb
@@ -9,7 +9,7 @@ module FixtureSetAssertions
       assert_unmanaged_pod_statuses("Succeeded")
       assert_all_web_resources_up
       assert_all_redis_resources_up
-      assert_configmap_data_up
+      assert_configmap_data_present
     end
 
     def assert_unmanaged_pod_statuses(status, count=1)
@@ -19,11 +19,12 @@ module FixtureSetAssertions
     end
 
     def refute_managed_pod_exists
-      assert_unmanaged_pod_statuses("", 0)
+      pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
+      assert_equal 0, pods.size, "Expected to find 0 managed pods, found #{pods.size}"
     end
 
-    def assert_configmap_data_up
-      assert_configmap_up("basic-configmap-data", { datapoint1: "value1", datapoint2: "value2" })
+    def assert_configmap_data_present
+      assert_configmap_present("basic-configmap-data", { datapoint1: "value1", datapoint2: "value2" })
     end
 
     def refute_configmap_data_exists

--- a/test/helpers/fixture_sets/basic.rb
+++ b/test/helpers/fixture_sets/basic.rb
@@ -35,7 +35,7 @@ module FixtureSetAssertions
       assert_pod_status("web", "Running")
       assert_ingress_up("web")
       assert_service_up("web")
-      assert_deployment_up("web", 1)
+      assert_deployment_up("web", replicas: 1)
     end
 
     def refute_web_resources_exist
@@ -47,7 +47,7 @@ module FixtureSetAssertions
     def assert_all_redis_resources_up
       assert_pod_status("redis", "Running")
       assert_service_up("redis")
-      assert_deployment_up("redis", 1)
+      assert_deployment_up("redis", replicas: 1)
       assert_pvc_status("redis", "Bound")
     end
 

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -2,23 +2,29 @@ module KubeclientHelper
   MINIKUBE_CONTEXT = "minikube".freeze
 
   def kubeclient
-    @kubeclient ||= begin
-      config = Kubeclient::Config.read(ENV["KUBECONFIG"])
-      unless config.contexts.include?(MINIKUBE_CONTEXT)
-        raise "`#{MINIKUBE_CONTEXT}` context must be configured in your KUBECONFIG (#{ENV["KUBECONFIG"]}). Please see the README."
-      end
-      minikube = config.context(MINIKUBE_CONTEXT)
+    @kubeclient ||= build_kube_client("v1")
+  end
 
-      client = Kubeclient::Client.new(
-        minikube.api_endpoint,
-        minikube.api_version,
-        {
-          ssl_options: minikube.ssl_options,
-          auth_options: minikube.auth_options
-        }
-      )
-      client.discover
-      client
+  def v1beta1_kubeclient
+    @v1beta1_kubeclient ||= build_kube_client("v1beta1", "/apis/extensions/")
+  end
+
+  def build_kube_client(api_version, endpoint_path="")
+    config = Kubeclient::Config.read(ENV["KUBECONFIG"])
+    unless config.contexts.include?(MINIKUBE_CONTEXT)
+      raise "`#{MINIKUBE_CONTEXT}` context must be configured in your KUBECONFIG (#{ENV["KUBECONFIG"]}). Please see the README."
     end
+    minikube = config.context(MINIKUBE_CONTEXT)
+
+    client = Kubeclient::Client.new(
+      "#{minikube.api_endpoint}#{endpoint_path}",
+      api_version,
+      {
+        ssl_options: minikube.ssl_options,
+        auth_options: minikube.auth_options
+      }
+    )
+    client.discover
+    client
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -2,29 +2,29 @@ require 'test_helper'
 
 class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_full_basic_set_deploy_succeeds
-    deploy_fixture_set("basic")
+    deploy_fixtures("basic")
     basic = FixtureSetAssertions::Basic.new(@namespace)
     basic.assert_all_up
   end
 
   def test_partial_deploy_followed_by_full_deploy
-    deploy_fixture_set("basic", subset: ["configmap-data", "redis"])
+    deploy_fixtures("basic", subset: ["configmap-data.yml", "redis.yml"])
     basic = FixtureSetAssertions::Basic.new(@namespace)
     basic.assert_all_redis_resources_up
     basic.assert_configmap_data_present
     basic.refute_managed_pod_exists
     basic.refute_web_resources_exist
 
-    deploy_fixture_set("basic")
+    deploy_fixtures("basic")
     basic.assert_all_up
   end
 
   def test_pruning
-    deploy_fixture_set("basic")
+    deploy_fixtures("basic")
     basic = FixtureSetAssertions::Basic.new(@namespace)
     basic.assert_all_up
 
-    deploy_fixture_set("basic", subset: ["redis"])
+    deploy_fixtures("basic", subset: ["redis.yml"])
     basic.assert_all_redis_resources_up
     basic.refute_configmap_data_exists
     basic.refute_managed_pod_exists
@@ -32,57 +32,58 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_pvcs_are_not_pruned
-    deploy_fixture_set("basic", subset: ["redis"])
+    deploy_fixtures("basic", subset: ["redis.yml"])
     basic = FixtureSetAssertions::Basic.new(@namespace)
     basic.assert_all_redis_resources_up
 
-    deploy_fixture_set("basic", subset: ["configmap-data"])
+    deploy_fixtures("basic", subset: ["configmap-data.yml"])
     basic.assert_configmap_data_present
     basic.refute_redis_resources_exist(expect_pvc: true)
   end
 
   def test_success_with_unrecognized_resource_type
     # Secrets are intentionally unsupported because they should not be committed to your repo
-    fixture_set = load_fixture_data("basic", ["configmap-data"])
     secret = {
       "apiVersion" => "v1",
       "kind" => "Secret",
       "metadata" => { "name" => "test" },
       "data" => { "foo" => "YmFy" }
     }
-    fixture_set["secret"] = { "Secret" => secret }
-    deploy_loaded_fixture_set(fixture_set)
+
+    deploy_fixtures("basic", subset: ["configmap-data.yml"]) do |fixtures|
+      fixtures["secret.yml"] = { "Secret" => secret }
+    end
 
     live_secret = kubeclient.get_secret("test", @namespace)
     assert_equal({ foo: "YmFy" }, live_secret["data"].to_h)
   end
 
   def test_invalid_yaml_fails_fast
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /Template \S+ cannot be parsed/) do
-      deploy_fixture_set("invalid", subset: ["yaml-error"])
+    assert_raises(KubernetesDeploy::FatalDeploymentError, /Template \S+yaml-error\S+ cannot be parsed/) do
+      deploy_dir(fixture_path("invalid"))
     end
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast
-    fixture_set = load_fixture_data("basic", ["configmap-data"])
-    configmap = fixture_set["configmap-data"]["ConfigMap"].first
-    configmap["metadata"]["myKey"] = "uhOh"
-
     assert_raises(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
-      deploy_loaded_fixture_set(fixture_set)
+      deploy_fixtures("basic", subset: ["configmap-data.yml"]) do |fixtures|
+        configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
+        configmap["metadata"]["myKey"] = "uhOh"
+      end
     end
     assert_logs_match(/error validating data\: found invalid field myKey for v1.ObjectMeta/)
   end
 
   def test_dead_pods_in_old_replicaset_are_ignored
-    fixture_set = load_fixture_data("basic", ["configmap-data", "web"])
-    deployment = fixture_set["web"]["Deployment"].first
-    container = deployment["spec"]["template"]["spec"]["activeDeadlineSeconds"] = 1
-    deploy_loaded_fixture_set(fixture_set, wait: false) # this will never succeed as pods are killed after 1s
+    deploy_fixtures("basic", subset: ["configmap-data.yml", "web.yml.erb"], wait: false) do |fixtures|
+      deployment = fixtures["web.yml.erb"]["Deployment"].first
+      # web pods will get killed after one second and will not be cleaned up
+      container = deployment["spec"]["template"]["spec"]["activeDeadlineSeconds"] = 1
+    end
 
     sleep 1 # make sure to hit DeadlineExceeded on at least one pod
 
-    deploy_fixture_set("basic", subset: ["web", "configmap-data"])
+    deploy_fixtures("basic", subset: ["web.yml.erb", "configmap-data.yml"])
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=web,app=basic")
     running_pods, not_running_pods = pods.partition { |pod| pod.status.phase == "Running" }
     assert_equal 1, running_pods.size
@@ -90,13 +91,12 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_bad_container_image_on_run_once_halts_and_fails_deploy
-    fixture_set = load_fixture_data("basic")
-    pod = fixture_set["unmanaged-pod"]["Pod"].first
-    pod["spec"]["activeDeadlineSeconds"] = 3
-    pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
-
     assert_raises(KubernetesDeploy::FatalDeploymentError, /1 priority resources failed to deploy/) do
-      deploy_loaded_fixture_set(fixture_set)
+      deploy_fixtures("basic") do |fixtures|
+        pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+        pod["spec"]["activeDeadlineSeconds"] = 1
+        pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
+      end
     end
 
     basic = FixtureSetAssertions::Basic.new(@namespace)
@@ -107,20 +107,19 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_wait_false_still_waits_for_priority_resources
-    fixture_set = load_fixture_data("basic")
-    pod = fixture_set["unmanaged-pod"]["Pod"].first
-    pod["spec"]["activeDeadlineSeconds"] = 1
-    pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
-
     assert_raises(KubernetesDeploy::FatalDeploymentError, /1 priority resources failed to deploy/) do
-      deploy_loaded_fixture_set(fixture_set)
+      deploy_fixtures("basic") do |fixtures|
+        pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+        pod["spec"]["activeDeadlineSeconds"] = 1
+        pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
+      end
     end
     assert_logs_match(/DeadlineExceeded/)
   end
 
   def test_wait_false_ignores_non_priority_resource_failures
     # web depends on configmap so will not succeed deployed alone
-    deploy_fixture_set("basic", subset: ["web"], wait: false)
+    deploy_fixtures("basic", subset: ["web.yml.erb"], wait: false)
 
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=basic')
     assert_equal 1, pods.size, "Unable to find web pod"

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1,27 +1,118 @@
 require 'test_helper'
 
 class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
-  def test_basic
-    runner = KubernetesDeploy::Runner.new(
-      namespace: @namespace,
-      current_sha: "abcabcabc",
-      context: MINIKUBE_CONTEXT,
-      template_dir: File.expand_path("./test/fixtures/basic"),
-      wait_for_completion: true,
-    )
-    runner.run
+  def test_full_basic_set_deploy_succeeds
+    deploy_fixture_set("basic")
+    basic = FixtureSetAssertions::Basic.new(@namespace)
+    basic.assert_all_up
+  end
 
-    pods = kubeclient.get_pods(namespace: @namespace)
-    managed_pods, unmanaged_pods = pods.partition do |pod|
-      pod.metadata.ownerReferences && pod.metadata.ownerReferences.first.kind == "ReplicaSet"
+  def test_partial_deploy_followed_by_full_deploy
+    deploy_fixture_set("basic", ["configmap-data", "redis"])
+    basic = FixtureSetAssertions::Basic.new(@namespace)
+    basic.assert_all_redis_resources_up
+    basic.assert_configmap_data_up
+    basic.refute_managed_pod_exists
+    basic.refute_web_resources_exist
+
+    deploy_fixture_set("basic")
+    basic.assert_all_up
+  end
+
+  def test_pruning
+    deploy_fixture_set("basic")
+    basic = FixtureSetAssertions::Basic.new(@namespace)
+    basic.assert_all_up
+
+    deploy_fixture_set("basic", ["redis"])
+    basic.assert_all_redis_resources_up
+    basic.refute_configmap_data_exists
+    basic.refute_managed_pod_exists
+    basic.refute_web_resources_exist
+  end
+
+  def test_pvcs_are_not_pruned
+    deploy_fixture_set("basic", ["redis"])
+    basic = FixtureSetAssertions::Basic.new(@namespace)
+    basic.assert_all_redis_resources_up
+
+    deploy_fixture_set("basic", ["configmap-data"])
+    basic.assert_configmap_data_up
+    basic.refute_redis_resources_exist(expect_pvc: true)
+  end
+
+  def test_success_with_unrecognized_resource_type
+    fixture_set = load_fixture_data("basic", ["configmap-data"])
+    secret = {
+      "apiVersion" => "v1",
+      "kind" => "Secret",
+      "metadata" => { "name" => "test" },
+      "data" => { "foo" => "YmFy" }
+    }
+    fixture_set["secret"] = { "Secret" => secret }
+    deploy_loaded_fixture_set(fixture_set)
+
+    live_secret = kubeclient.get_secret("test", @namespace)
+    assert_equal({ foo: "YmFy" }, live_secret["data"].to_h)
+  end
+
+  def test_invalid_yaml_fails_fast
+    error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
+      deploy_fixture_set("invalid", ["yaml-error"])
     end
+    assert_match /Template \S+ cannot be parsed/, error.to_s
+  end
 
-    assert_equal 2, managed_pods.size
-    managed_pods.each do |pod|
-      assert_equal "Running", pod.status.phase
+  def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast
+    fixture_set = load_fixture_data("basic", ["configmap-data"])
+    configmap = fixture_set["configmap-data"]["ConfigMap"].first
+    configmap["metadata"]["myKey"] = "uhOh"
+
+    error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
+      deploy_loaded_fixture_set(fixture_set)
     end
+    assert_match /Dry run failed for template configmap-data/, error.to_s
 
-    assert_equal 1, unmanaged_pods.size
-    assert_equal "Succeeded", unmanaged_pods.first.status.phase
+    @logger_stream.rewind
+    assert_match /error validating data\: found invalid field myKey for v1.ObjectMeta/, @logger_stream.read
+  end
+
+  def test_bad_container_image_on_run_once_halts_and_fails_deploy
+    fixture_set = load_fixture_data("basic")
+    pod = fixture_set["unmanaged-pod"]["Pod"].first
+    pod["spec"]["activeDeadlineSeconds"] = 3
+    pod["spec"]["containers"].first["image"] = "hello-world:elephants"
+
+    error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
+      deploy_loaded_fixture_set(fixture_set)
+    end
+    assert_match /1 priority resources failed to deploy/, error.to_s
+
+    basic = FixtureSetAssertions::Basic.new(@namespace)
+    basic.assert_unmanaged_pod_statuses("Failed")
+    basic.assert_configmap_data_up # priority resource
+    basic.refute_redis_resources_exist(expect_pvc: true) # pvc is priority resource
+    basic.refute_web_resources_exist
+  end
+
+  def test_wait_false_still_waits_for_priority_resources
+    fixture_set = load_fixture_data("basic")
+    pod = fixture_set["unmanaged-pod"]["Pod"].first
+    pod["spec"]["activeDeadlineSeconds"] = 1
+    pod["spec"]["containers"].first["image"] = "hello-world:elephants"
+
+    error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
+      deploy_loaded_fixture_set(fixture_set)
+    end
+    assert_match /1 priority resources failed to deploy/, error.to_s
+  end
+
+  def test_wait_false_ignores_non_priority_resource_failures
+    # web depends on configmap so will not succeed deployed alone
+    deploy_fixture_set("basic", ["web"], wait: false)
+
+    pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=basic')
+    assert_equal 1, pods.size, "Unable to find web pod"
+    assert_equal "Pending", pods.first.status.phase
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -97,7 +97,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     fixture_set = load_fixture_data("basic")
     pod = fixture_set["unmanaged-pod"]["Pod"].first
     pod["spec"]["activeDeadlineSeconds"] = 3
-    pod["spec"]["containers"].first["image"] = "hello-world:elephants"
+    pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
 
     error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
       deploy_loaded_fixture_set(fixture_set)
@@ -115,7 +115,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     fixture_set = load_fixture_data("basic")
     pod = fixture_set["unmanaged-pod"]["Pod"].first
     pod["spec"]["activeDeadlineSeconds"] = 1
-    pod["spec"]["containers"].first["image"] = "hello-world:elephants"
+    pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
 
     error = assert_raises(KubernetesDeploy::FatalDeploymentError) do
       deploy_loaded_fixture_set(fixture_set)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,11 @@ require 'kubernetes-deploy'
 require 'kubeclient'
 require 'pry'
 require 'minitest/autorun'
+
 require 'helpers/kubeclient_helper'
+require 'helpers/fixture_deploy_helper'
+require 'helpers/fixture_set'
+require 'helpers/fixture_sets/basic'
 
 ENV["KUBECONFIG"] ||= "#{Dir.home}/.kube/config"
 
@@ -23,6 +27,7 @@ module KubernetesDeploy
 
   class IntegrationTest < KubernetesDeploy::TestCase
     include KubeclientHelper
+    include FixtureDeployHelper
 
     def run
       @namespace = TestProvisioner.claim_namespace(self.name)
@@ -77,4 +82,5 @@ module KubernetesDeploy
   end
 
   TestProvisioner.prepare_pv("pv0001")
+  TestProvisioner.prepare_pv("pv0002")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,11 @@ module KubernetesDeploy
     def teardown
       @logger_stream.close
     end
+
+    def assert_logs_match(regexp)
+      @logger_stream.rewind
+      assert_match regexp, @logger_stream.read
+    end
   end
 
   class IntegrationTest < KubernetesDeploy::TestCase


### PR DESCRIPTION
This PR adds coverage for most of what I was looking for in the manual tophat flow with the "trashbin" repo, plus a couple bonus scenarios. Not covered:
- Error logging related to deploys that eventually time out. The current behaviour would be hard to integration test (could be covered by unit tests on the polling) and switching these to be fast failures is near the top of my todo list.
- The actual CLI invocation itself (tests trigger deploys via the Runner)

The most interesting part here was trying to devise a helper structure would make these tests easy to read, simple to write and clean to customize. My idea of what this would look like definitely changed as I wrote more tests! What I landed on here is perhaps a bit unusual, but I quite like the API it gives the tests themselves, and the encapsulation of concerns in the helpers. **I recommend checking out the integration test file first, since it is the whole point of the rest of the code.**

### Details

Here's an overview of how the helpers are set up:
- `FixtureDeployHelper` contains methods for loading and manipulating the yaml fixtures. It provides two options:
  - `deploy_fixture_set(set, subset=nil, wait: true)` to immediately deploy a full or partial set of fixtures
  - `load_fixture_data(set, subset=nil)` + `deploy_loaded_fixture_set(template_map, wait: true)` allows you to make changes/additions to the set before deploying it. The alternative to providing this option is to duplicate the fixtures for each scenario that needs a change. I find this much better because it not only reduces duplication, but also makes it super clear within the test what is special (aka broken in most cases) about the set being deployed.
- `FixtureSetAssertions::Basic` is used to encapsulate knowledge about the contents of the fixture set named "basic" (I'm kinda regretting that name... too adjectival). You instantiate it with the namespace you deployed to, then use it to assert things like "the whole set is up", "all the redis-related components are up", or "no web-related components exist".
- `FixtureSetAssertions::FixtureSet` is the superclass of `FixtureSetAssertions::Basic` and provides generic resource assertions that can be leveraged by any fixture set class (e.g. `assert_service_up(svc_name)`). I made these methods private, but it might make sense for tests to be able to use them directly as well, i.e. when they've added something to the set deployed.
