### PR TITLE
Require ENV['REVISION'] on startup

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -21,11 +21,16 @@ if !template_dir || template_dir.empty?
   exit 1
 end
 
+revision = ENV.fetch('REVISION') do
+  puts "ENV['REVISION'] is missing. Please specify the commit SHA"
+  exit 1
+end
+
 KubernetesDeploy::Runner.with_friendly_errors do
   runner = KubernetesDeploy::Runner.new(
     namespace: ARGV[0],
     context: ARGV[1],
-    current_sha: ENV['REVISION'],
+    current_sha: revision,
     template_dir: template_dir,
     wait_for_completion: !skip_wait,
   )


### PR DESCRIPTION
Right now having `ENV['REVISION']` missing will lead to `Current SHA must be specified` as the error message. However the message doesn't tell you what exactly is wrong and how to fix it.

This check is only the case when running the script locally. Shipit always has the `REVISION` set.

Since `Runner` has no context of `ENV['REVISION']`, I think the right place for the check would be in the bin script.

review @KnVerey @sirupsen @wfarr 