### PR TITLE
Print waiting timeout

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -24,6 +24,14 @@ module KubernetesDeploy
       end
     end
 
+    def self.timeout
+      self::TIMEOUT
+    end
+
+    def timeout
+      self.class.timeout
+    end
+
     def initialize(name, namespace, context, file)
       # subclasses must also set these
       @name, @namespace, @context, @file = name, namespace, context, file
@@ -68,7 +76,7 @@ module KubernetesDeploy
 
     def deploy_timed_out?
       return false unless @deploy_started
-      !deploy_succeeded? && !deploy_failed? && (Time.now.utc - @deploy_started > self.class::TIMEOUT)
+      !deploy_succeeded? && !deploy_failed? && (Time.now.utc - @deploy_started > timeout)
     end
 
     def tpr?

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -174,7 +174,8 @@ MSG
       delay_sync_until = Time.now.utc
       started_at = delay_sync_until
       human_resources = watched_resources.map(&:id).join(", ")
-      KubernetesDeploy.logger.info("Waiting for #{human_resources}")
+      max_wait_time = watched_resources.map(&:timeout).max
+      KubernetesDeploy.logger.info("Waiting for #{human_resources} with #{max_wait_time}s timeout")
       while watched_resources.present?
         if Time.now.utc < delay_sync_until
           sleep (delay_sync_until - Time.now.utc)


### PR DESCRIPTION
Before waiting for the resource rollout, I'd like to also print the timeout that we'll use.
This PR also adds basic accessors for `timeout`.

preview:

![screen shot 2017-02-21 at 14 58 59](https://cloud.githubusercontent.com/assets/522155/23182402/69f8cc5e-f846-11e6-8adf-b812f447ab27.png)


review @KnVerey @sirupsen @wfarr 