### PR TITLE
Quick fix for deploy hangs when deployment includes evicted pods

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -37,8 +37,8 @@ module KubernetesDeploy
     def deploy_succeeded?
       return false unless @rollout_data.key?("availableReplicas")
       # TODO: this should look at the current replica set's pods too
-      @rollout_data["availableReplicas"].to_i == @pods.length &&
-      @rollout_data.values.uniq.length == 1 # num desired, current, up-to-date and available are equal
+      @rollout_data["updatedReplicas"].to_i == @rollout_data["replicas"].to_i &&
+      @rollout_data["updatedReplicas"].to_i == @rollout_data["availableReplicas"].to_i
     end
 
     def deploy_failed?


### PR DESCRIPTION
cc @Shopify/cloudplatform 

## This PR

This is a quick fix for the deploy problems we've been seeing when there are evicted pods managed by a deployment. The current behaviour is that the deploy hangs until timeout because the number of pods is _greater_ than the number of replicas available, whereas the script requires it to be exactly equal. IMO it would be better to keep this assertion but make it against the new replicaset's pods exclusively. However, this is affecting enough people to justify this patch in the meantime... it's so easy that I really should have proposed it a while ago, though by doing it now I was able to reproduce something similar in a test (see below).  

This change also fixes the fact that the set looked at by `@rollout_data.values.uniq.length == 1` can include `unavailableReplicas`.

## Testing

I made this change on top of the branch with integration test framework, and it passes all those tests. I also wrote the following regression test, which hangs forever without the patch and passes with it:

```ruby
  def test_dead_pods_in_old_replicaset_are_ignored
    fixture_set = load_fixture_data("basic", ["configmap-data", "web"])
    deployment = fixture_set["web"]["Deployment"].first
    container = deployment["spec"]["template"]["spec"]["activeDeadlineSeconds"] = 1
    deploy_loaded_fixture_set(fixture_set, wait: false)

    sleep 1 # make sure to hit DeadlineExceeded on at least one pod

    deploy_fixture_set("basic", ["web", "configmap-data"])
    pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=web,app=basic")
    running_pods, not_running_pods = pods.partition { |pod| pod.status.phase == "Running" }
    assert_equal 1, running_pods.size
    assert not_running_pods.size >= 1
  end
```

I'm using the unrealistic scenario of a deployment with a pod specifying `activeDeadlineSeconds` because I wasn't able to figure out how to manually evict a pod in a reasonable timeframe. This scenario also produces a dead pod that hangs around on redeploy, as you can see from the assertions.

## Alternatives

* Leave as is and wait for this to be fixed via replicaset awareness
* Assert that the number of pods must be >= number desired (not sure the assertion adds value, as it could theoretically pass midway through a rollout that allows surge)
* Teach deploys to manually delete evicted pods before they start. IMO this should be the job of something like a Pod GC controller, not deploys.