### PR TITLE
Do not log each pod status

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -25,7 +25,6 @@ module KubernetesDeploy
             pod = Pod.new(pod_name, namespace, context, nil, parent: "#{@name.capitalize} deployment")
             pod.deploy_started = @deploy_started
             pod.interpret_json_data(pod_json)
-            pod.log_status
             @pods << pod
           end
         end


### PR DESCRIPTION
There may be hundreds of pods in a deployment. We log status of every one of them and that makes the deploy log hardly readable:

![screen shot 2017-02-22 at 13 21 26](https://cloud.githubusercontent.com/assets/522155/23232150/3b386000-f918-11e6-8f3f-842a5fa75c27.png)

(you have to scroll it to skip those hundreds of pods)

**Why I think we don't need to log each pod status:**

1. Because `{"group":"Web deployment","name":"web-295249071-zrrvz","status_string":"Running (Ready: true)","exists":true,"succeeded":true,"failed":false,"timed_out":false}` doesn't give you much info in the context of a bunch of pods. You don't even need the pod name (`web-295249071-zrrvz`) which is auto generated.

2. What you want to watch is the proportion of rolled out pods:

`
{"group":"deployments","name":"web","status_string":"Waiting for rollout to finish: 132 of 150 updated replicas are available...","exists":true,"succeeded":false,"failed":false,"timed_out":false,"replicas":{"updatedReplicas":150,"replicas":150,"availableReplicas":132,"unavailableReplicas":18},"num_pods":157}
`

From this line you see that `132 of 150 pods` have been rolled out. This is logged by the `KubernetesDeploy::Deployment#log_status` and the PR is not touching it.

review @sirupsen @KnVerey @wfarr @ibawt 