### PR TITLE
Log context

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -125,7 +125,7 @@ module KubernetesDeploy
     end
 
     def log_status
-      KubernetesResource.logger.info("[KUBESTATUS] #{JSON.dump(status_data)}")
+      KubernetesResource.logger.info("[KUBESTATUS][#{@context}][#{@namespace}] #{JSON.dump(status_data)}")
     end
   end
 end


### PR DESCRIPTION
Since now we may run the script in parallel to deploy to multiple clusters concurrently, it's important to see which context produced the log line.

I'd also unblock me to integrate the script with the Shipit rollout UI, since the way how it works is parsing the the log line. Right now the line like `[KUBESTATUS] {"group":"deployments","name":"web","status_string":"Waiting for rollout to finish: 132 of 150 updated replicas are available..."}` doesn't tell us which cluster/context is progressing.

review @wfarr @sirupsen @KnVerey 