### PR TITLE
Fail when kubectl apply returns non-zero status

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -269,7 +269,13 @@ MSG
         PRUNE_WHITELIST.each { |type| command.push("--prune-whitelist=#{type}") }
       end
 
-      run_kubectl(*command)
+      _, err, st = run_kubectl(*command)
+      unless st.success?
+        raise FatalDeploymentError, <<-MSG
+"The following command failed: #{Shellwords.join(command)}"
+#{err}
+MSG
+      end
     end
 
     def confirm_context_exists


### PR DESCRIPTION
Previously, when `kubectl apply` returned non-zero status we've been only printing the warning. This caused issues like https://github.com/Shopify/kubernetes-deploy/issues/20. We should raise an error and stop the deploy in this case.

review @KnVerey @sirupsen @wfarr 