### PR TITLE
Refactor kubectl runner into KubectlWrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem 'pry'
 gem 'kubeclient'
 gem 'rubocop'
+gem 'mocha'

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'
 
 require 'logger'
+require 'kubernetes-deploy/kubectl_wrapper'
 require 'kubernetes-deploy/runner'
 
 module KubernetesDeploy

--- a/lib/kubernetes-deploy/kubectl_wrapper.rb
+++ b/lib/kubernetes-deploy/kubectl_wrapper.rb
@@ -1,0 +1,21 @@
+module KubernetesDeploy
+  module KubectlWrapper
+    extend self
+
+    def run_kubectl(*args, context: nil, namespace: nil)
+      args = args.unshift("kubectl")
+      args.push("--context=#{context}") if context
+      args.push("--namespace=#{namespace}") if namespace
+
+      KubernetesDeploy.logger.debug Shellwords.join(args)
+      out, err, st = Open3.capture3(*args)
+      KubernetesDeploy.logger.debug(out.shellescape)
+
+      unless st.success?
+        KubernetesDeploy.logger.warn("The following command returned non-zero status: #{Shellwords.join(args)}")
+        KubernetesDeploy.logger.warn(err.shellescape)
+      end
+      [out.chomp, err, st]
+    end
+  end
+end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -115,13 +115,9 @@ module KubernetesDeploy
     def run_kubectl(*args)
       raise FatalDeploymentError, "Namespace missing for namespaced command" if namespace.blank?
       raise FatalDeploymentError, "Explicit context is required to run this command" if context.blank?
-      args = args.unshift("kubectl").push("--namespace=#{namespace}").push("--context=#{context}")
 
-      KubernetesDeploy.logger.debug Shellwords.join(args)
-      out, err, st = Open3.capture3(*args)
-      KubernetesDeploy.logger.debug(out.shellescape)
-      KubernetesDeploy.logger.debug("[ERROR] #{err.shellescape}") unless st.success?
-      [out.chomp, st]
+      out, _, st = KubernetesDeploy::KubectlWrapper.run_kubectl(*args, namespace: namespace, context: context)
+      [out, st]
     end
 
     def log_status

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'kubernetes-deploy'
 require 'kubeclient'
 require 'pry'
 require 'minitest/autorun'
+require 'mocha/mini_test'
 
 require 'helpers/kubeclient_helper'
 require 'helpers/fixture_deploy_helper'

--- a/test/unit/kubernetes-deploy/kubectl_wrapper_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_wrapper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class KubectlWrapperTest < KubernetesDeploy::TestCase
+  def test_builds_with_namespace
+    Open3.expects(:capture3).with('kubectl', 'get', 'pods', '--namespace=trashbin').returns(successful_status)
+    out, err, st = KubernetesDeploy::KubectlWrapper.run_kubectl("get", "pods", namespace: "trashbin")
+    assert st.success?
+  end
+
+  def test_builds_with_context
+    Open3.expects(:capture3).with('kubectl', 'get', 'pods', '--context=trashbin').returns(successful_status)
+    out, err, st = KubernetesDeploy::KubectlWrapper.run_kubectl("get", "pods", context: "trashbin")
+    assert st.success?
+  end
+
+  def test_builds_without_context_and_namespace
+    Open3.expects(:capture3).with('kubectl', 'get', 'pods').returns(successful_status)
+    out, err, st = KubernetesDeploy::KubectlWrapper.run_kubectl("get", "pods")
+    assert st.success?
+  end
+
+  def test_logs_stderr
+    Open3.expects(:capture3).with('kubectl', 'get', 'pods').returns(failed_status_with_stderr)
+    out, err, st = KubernetesDeploy::KubectlWrapper.run_kubectl("get", "pods")
+    refute st.success?
+    assert_logs_match /The following command returned non-zero status/
+  end
+
+  private
+
+  FakeProcessStatus = Struct.new(:success?)
+  def successful_status
+    ["", "", FakeProcessStatus.new(true)]
+  end
+
+  def failed_status_with_stderr
+    ["", "error", FakeProcessStatus.new(false)]
+  end
+end


### PR DESCRIPTION
We have two places in the codebase that build and run `kubectl` command. I think this is redundant, and we already got troubles in the past updating one place and not updating the other (https://github.com/Shopify/kubernetes-deploy/pull/17).
It makes sense to move the duplicated code into a helper (`KubectlWrapper`). The PR is also introducing test coverage for the new class.

To be merged after https://github.com/Shopify/kubernetes-deploy/pull/32

review @KnVerey @wfarr @sirupsen 