### PR TITLE
Create namespace if it does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Requirements:
 
  - kubectl 1.5.1+ binary must be available in your path
  - `ENV['KUBECONFIG']` must point to a valid kubeconfig file that includes the context you want to deploy to
- - The target namespace must already exist in the target context
  - `ENV['GOOGLE_APPLICATION_CREDENTIALS']` must point to the credentials for an authenticated service account if your user's auth provider is gcp
  - `ENV['ENVIRONMENT']` must be set to use the default template path (`config/deploy/$ENVIRONMENT`) in the absence of the `--template-dir=DIR` option
 

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -84,7 +84,7 @@ MSG
 
       phase_heading("Identifying deployment target")
       confirm_context_exists
-      confirm_namespace_exists
+      ensure_namespace_exists
 
       phase_heading("Parsing deploy content")
       resources = discover_resources
@@ -289,10 +289,18 @@ MSG
       KubernetesDeploy.logger.info("Context #{@context} found")
     end
 
-    def confirm_namespace_exists
+    def ensure_namespace_exists
       _, _, st = run_kubectl("get", "namespace", @namespace, namespaced: false)
-      raise FatalDeploymentError, "Namespace #{@namespace} not found" unless st.success?
-      KubernetesDeploy.logger.info("Namespace #{@namespace} found")
+      unless st.success?
+        _, _, st = run_kubectl("create", "namespace", @namespace, namespaced: false)
+        if st.success?
+          KubernetesDeploy.logger.info("Created namespace #{@namespace}")
+        else
+          raise FatalDeploymentError, "Failed to create #{@namespace}" 
+        end
+      else
+        KubernetesDeploy.logger.info("Namespace #{@namespace} found")
+      end
     end
 
     def run_kubectl(*args, namespaced: true, with_context: true)


### PR DESCRIPTION
I thought about this when I was adding a new stack for an existing
service and found myself debating between using chat to initialize
a repository for a 5th time (it's deployed to as many clusters)
just for namespace creation, or to do it manually and out-of-band.
Neither seemed like great options to me, so I figured, why couldn't
we just create the namespace on the fly if it doesn't exist?

I don't think the tradeoff of requiring a namespace to already
exist necessarily makes sense any longer, even though in the
majority of cases at Shopify it will.

The initializer already enforces that a namespace is given,
so we can guarantee this receives a non-empty value.

This makes kubernetes-deploy a little more plug-and-play with,
IMO, minimal drawbacks.