### PR TITLE
Tighten timeout on deployment resource

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -1,6 +1,6 @@
 module KubernetesDeploy
   class Deployment < KubernetesResource
-    TIMEOUT = 15.minutes
+    TIMEOUT = 5.minutes
 
     def initialize(name, namespace, context, file)
       @name, @namespace, @context, @file = name, namespace, context, file

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -1,6 +1,6 @@
 module KubernetesDeploy
   class Pod < KubernetesResource
-    TIMEOUT = 15.minutes
+    TIMEOUT = 10.minutes
     SUSPICIOUS_CONTAINER_STATES = %w(ImagePullBackOff RunContainerError).freeze
 
     def initialize(name, namespace, context, file, parent: nil)

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -1,6 +1,6 @@
 module KubernetesDeploy
   class Service < KubernetesResource
-    TIMEOUT = 15.minutes
+    TIMEOUT = 5.minutes
 
     def initialize(name, namespace, context, file)
       @name, @namespace, @context, @file = name, namespace, context, file

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class KubernetesResourceTest < KubernetesDeploy::TestCase
+  def test_service_and_deployment_timeouts_are_equal
+    message = "Service and Deployment timeouts have to match since services are waiting to get endpoints from their backing deployments"
+    assert_equal KubernetesDeploy::Service.timeout, KubernetesDeploy::Deployment.timeout, message
+  end
+end


### PR DESCRIPTION
With the right rollout strategy, we should be ready to tighten the `Deployment` rollout. Right now it leads to deploys hanging up for 15 minutes and I'm sure that such timeout isn't necessary to find that something is not going as expected.

The new timeout is debatable and I wouldn't be surprised if at some point in future we get apps that are very slow to boot and take more than 5 minutes to roll out. However the `Shopify/shopify` monolith is a very large codebase to boot, and the rollout to hundreds of replicas manages to complete within 3 minutes.

Alternatively we can introduce a  configurable global waiting timeout as a CLI flag. This would unblock us to set it to `5.minutes` in Shipit because there we'd prefer to fail early rather than wait for 15 minutes and grow the deploy backlog.

thoughts? @KnVerey @sirupsen @wfarr 