### PR TITLE
Restart task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
-gem 'kubeclient'
 gem 'rubocop'
+gem 'timecop'

--- a/README.md
+++ b/README.md
@@ -29,9 +29,16 @@ Requirements:
  - kubectl 1.5.1+ binary must be available in your path
  - `ENV['KUBECONFIG']` must point to a valid kubeconfig file that includes the context you want to deploy to
  - The target namespace must already exist in the target context
- - `ENV['GOOGLE_APPLICATION_CREDENTIALS']` must point to the credentials for an authenticated service account if your user's auth provider is gcp
+ - `ENV['GOOGLE_APPLICATION_CREDENTIALS']` must point to the credentials for an authenticated service account if your user's auth provider is GCP
  - `ENV['ENVIRONMENT']` must be set to use the default template path (`config/deploy/$ENVIRONMENT`) in the absence of the `--template-dir=DIR` option
 
+The tool also provides a task for restarting all of the pods in one or more deployments.
+It triggers the restart by touching the `RESTARTED_AT` environment variable in the deployment's podSpec.
+The rollout strategy defined for each deployment will be respected by the restart.
+
+The following command will restart all pods in the `web` and `jobs` deployments:
+
+`kubernetes-restart <kube namespace> <kube context> --deployments=web,jobs`
 
 ## Development
 

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+require 'kubernetes-deploy'
+require 'kubernetes-deploy/restart_task'
+
+raw_deployments = nil
+ARGV.options do |opts|
+  opts.on("--deployments=LIST") { |v| raw_deployments = v }
+  opts.parse!
+end
+
+if raw_deployments.nil?
+  puts "Failed: specify at least one deployment to restart with --deployments flag"
+  exit 1
+end
+
+KubernetesDeploy::Runner.with_friendly_errors do
+  restart = KubernetesDeploy::RestartTask.new(namespace: ARGV[0], context: ARGV[1])
+  restart.perform(raw_deployments.split(","))
+end

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "kubeclient", "~> 2.3"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'kubeclient'
+
+module KubernetesDeploy
+  module KubeclientBuilder
+    class ContextMissingError < FatalDeploymentError
+      def initialize(context_name)
+        super("`#{context_name}` context must be configured in your KUBECONFIG (#{ENV['KUBECONFIG']}). " \
+          "Please see the README.")
+      end
+    end
+
+    private
+
+    def build_v1_kubeclient(context)
+      _build_kubeclient(
+        api_version: "v1",
+        context: context
+      )
+    end
+
+    def build_v1beta1_kubeclient(context)
+      _build_kubeclient(
+        api_version: "v1beta1",
+        context: context,
+        endpoint_path: "/apis/extensions/"
+      )
+    end
+
+    def _build_kubeclient(api_version:, context:, endpoint_path: nil)
+      config = Kubeclient::Config.read(ENV.fetch("KUBECONFIG"))
+      unless config.contexts.include?(context)
+        raise ContextMissingError, context
+      end
+      kube_context = config.context(context)
+
+      client = Kubeclient::Client.new(
+        "#{kube_context.api_endpoint}#{endpoint_path}",
+        api_version,
+        ssl_options: kube_context.ssl_options,
+        auth_options: kube_context.auth_options
+      )
+      client.discover
+      client
+    end
+  end
+end

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+require 'kubernetes-deploy/kubeclient_builder'
+require 'kubernetes-deploy/ui_helpers'
+require 'kubernetes-deploy/resource_watcher'
+
+module KubernetesDeploy
+  class RestartTask
+    include UIHelpers
+    include KubernetesDeploy::KubeclientBuilder
+
+    class DeploymentNotFoundError < FatalDeploymentError
+      def initialize(name, namespace)
+        super("Deployment `#{name}` not found in namespace `#{namespace}`. Aborting the task.")
+      end
+    end
+
+    class NamespaceNotFoundError < FatalDeploymentError
+      def initialize(name, context)
+        super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
+      end
+    end
+
+    class RestartError < FatalDeploymentError
+      def initialize(deployment_name, response)
+        super("Failed to restart #{deployment_name}. " \
+            "API returned non-200 response code (#{response.code})\n" \
+            "Response:\n#{response.body}")
+      end
+    end
+
+    HTTP_OK_RANGE = 200..299
+
+    def initialize(context:, namespace:, logger: KubernetesDeploy.logger)
+      @context = context
+      @namespace = namespace
+      @logger = logger
+      @kubeclient = build_v1_kubeclient(context)
+      @v1beta1_kubeclient = build_v1beta1_kubeclient(context)
+    end
+
+    def perform(deployments_names)
+      verify_namespace
+
+      if deployments_names.empty?
+        raise ArgumentError, "#perform takes at least one deployment to restart"
+      end
+
+      phase_heading("Triggering restart by touching ENV[RESTARTED_AT]")
+      deployments = fetch_deployments(deployments_names.uniq)
+      patch_kubeclient_deployments(deployments)
+
+      phase_heading("Waiting for rollout")
+      wait_for_rollout(deployments)
+
+      names = deployments.map { |d| "`#{d.metadata.name}`" }
+      @logger.info "Restart of #{names.join(', ')} deployments succeeded"
+    end
+
+    private
+
+    def wait_for_rollout(kubeclient_resources)
+      resources = kubeclient_resources.map { |d| Deployment.new(d.metadata.name, @namespace, @context, nil) }
+      watcher = ResourceWatcher.new(resources)
+      watcher.run
+    end
+
+    def verify_namespace
+      @kubeclient.get_namespace(@namespace)
+    rescue KubeException => error
+      if error.error_code == 404
+        raise NamespaceNotFoundError.new(@namespace, @context)
+      else
+        raise
+      end
+    end
+
+    def patch_deployment_with_restart(record)
+      @v1beta1_kubeclient.patch_deployment(
+        record.metadata.name,
+        build_patch_payload(record),
+        @namespace
+      )
+    end
+
+    def patch_kubeclient_deployments(deployments)
+      deployments.each do |record|
+        response = patch_deployment_with_restart(record)
+        if HTTP_OK_RANGE.cover?(response.code)
+          @logger.info "Triggered `#{record.metadata.name}` restart"
+        else
+          raise RestartError.new(record.metadata.name, response)
+        end
+      end
+    end
+
+    def fetch_deployments(list)
+      list.map do |name|
+        record = nil
+        begin
+          record = @v1beta1_kubeclient.get_deployment(name, @namespace)
+        rescue KubeException => error
+          if error.error_code == 404
+            raise DeploymentNotFoundError.new(name, @namespace)
+          else
+            raise
+          end
+        end
+        record
+      end
+    end
+
+    def build_patch_payload(deployment)
+      containers = deployment.spec.template.spec.containers
+      {
+        spec: {
+          template: {
+            spec: {
+              containers: containers.map do |container|
+                {
+                  name: container.name,
+                  env: [{ name: "RESTARTED_AT", value: Time.now.to_i.to_s }]
+                }
+              end
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -1,31 +1,16 @@
 # frozen_string_literal: true
+require 'kubernetes-deploy/kubeclient_builder'
+
 module KubeclientHelper
   MINIKUBE_CONTEXT = "minikube"
 
+  include KubernetesDeploy::KubeclientBuilder
+
   def kubeclient
-    @kubeclient ||= build_kube_client("v1")
+    @kubeclient ||= build_v1_kubeclient(MINIKUBE_CONTEXT)
   end
 
   def v1beta1_kubeclient
-    @v1beta1_kubeclient ||= build_kube_client("v1beta1", "/apis/extensions/")
-  end
-
-  def build_kube_client(api_version, endpoint_path="")
-    config = Kubeclient::Config.read(ENV["KUBECONFIG"])
-    unless config.contexts.include?(MINIKUBE_CONTEXT)
-      raise "`#{MINIKUBE_CONTEXT}` context must be configured in your KUBECONFIG (#{ENV["KUBECONFIG"]}). Please see the README."
-    end
-    minikube = config.context(MINIKUBE_CONTEXT)
-
-    client = Kubeclient::Client.new(
-      "#{minikube.api_endpoint}#{endpoint_path}",
-      api_version,
-      {
-        ssl_options: minikube.ssl_options,
-        auth_options: minikube.auth_options
-      }
-    )
-    client.discover
-    client
+    @v1beta1_kubeclient ||= build_v1beta1_kubeclient(MINIKUBE_CONTEXT)
   end
 end

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'kubernetes-deploy/restart_task'
+
+class RestartTaskTest < KubernetesDeploy::IntegrationTest
+  def test_restart
+    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
+
+    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    restart.perform(["web"])
+
+    assert_logs_match(/Triggered `web` restart/, 1)
+    assert_logs_match(/Restart of `web` deployments succeeded/, 1)
+
+    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
+  end
+
+  def test_restart_twice
+    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
+
+    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    restart.perform(["web"])
+
+    assert_logs_match(/Triggered `web` restart/, 1)
+    assert_logs_match(/Restart of `web` deployments succeeded/, 1)
+
+    first_restarted_at = fetch_restarted_at("web")
+    assert first_restarted_at, "RESTARTED_AT is present after first restart"
+
+    Timecop.freeze(1.second.from_now) do
+      restart.perform(["web"])
+    end
+
+    second_restarted_at = fetch_restarted_at("web")
+    assert second_restarted_at, "RESTARTED_AT is present after second restart"
+    refute_equal first_restarted_at.value, second_restarted_at.value
+  end
+
+  def test_restart_with_same_resource_twice
+    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
+
+    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    restart.perform(%w(web web))
+
+    assert_logs_match(/Triggered `web` restart/, 1)
+    assert_logs_match(/Restart of `web` deployments succeeded/, 1)
+
+    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
+  end
+
+  def test_restart_not_existing_deployment
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    assert_raises(KubernetesDeploy::RestartTask::DeploymentNotFoundError) do
+      restart.perform(["web"])
+    end
+  end
+
+  def test_restart_one_not_existing_deployment
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    assert_raises(KubernetesDeploy::RestartTask::DeploymentNotFoundError) do
+      restart.perform(%w(walrus web))
+    end
+
+    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
+    refute fetch_restarted_at("web"), "no RESTARTED_AT env after failed restart task"
+  end
+
+  def test_restart_none
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+    assert_raises(ArgumentError) do
+      restart.perform([])
+    end
+  end
+
+  def test_restart_not_existing_context
+    assert_raises(KubernetesDeploy::KubeclientBuilder::ContextMissingError) do
+      KubernetesDeploy::RestartTask.new(
+        context: "walrus",
+        namespace: @namespace,
+      )
+    end
+  end
+
+  def test_restart_not_existing_namespace
+    restart = KubernetesDeploy::RestartTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: "walrus"
+    )
+    error = assert_raises(KubernetesDeploy::RestartTask::NamespaceNotFoundError) do
+      restart.perform(["web"])
+    end
+    assert_equal "Namespace `walrus` not found in context `minikube`. Aborting the task.", error.to_s
+  end
+
+  private
+
+  def fetch_restarted_at(deployment_name)
+    deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
+    containers = deployment.spec.template.spec.containers
+    assert_equal 1, containers.size
+    containers.first.env.find { |n| n.name == "RESTARTED_AT" }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'kubernetes-deploy'
 require 'kubeclient'
 require 'pry'
+require 'timecop'
 require 'minitest/autorun'
 
 require 'helpers/kubeclient_helper'
@@ -25,9 +26,14 @@ module KubernetesDeploy
       @logger_stream.close
     end
 
-    def assert_logs_match(regexp)
+    def assert_logs_match(regexp, times = nil)
       @logger_stream.rewind
-      assert_match regexp, @logger_stream.read
+      if times
+        count = @logger_stream.read.scan(regexp).count
+        assert_equal 1, count, "Expected #{regexp} to appear #{times} time(s) in the log, but appeared #{count} times"
+      else
+        assert_match regexp, @logger_stream.read
+      end
     end
   end
 


### PR DESCRIPTION
This is an implementation of the restart task according to what we discussed in the original issue (https://github.com/Shopify/kubernetes-deploy/issues/43)

TL;DR there's no way to tell Kubernetes to restart the pods and that's something that we need to have control over processed in case of an incident.

The hackish way to get the pods restarted is to update the deployment with a noop ENV variable, like `RESTARTED_AT` containing a timestamp. This can be done with a kubectl command:

```
RESTART_DATE=$(date -u '+%Y-%m-%dT%H:%M:%S%z')
kubectl patch deployment web -n trashbin \
  -p '{"spec":{"template":{"spec":{"containers":[{"name":"app","env":[{"name":"RESTARTED_AT","value":"'$RESTART_DATE'"}]}]}}}}'
```

This PR implements the restart task as a CLI tool. The usage:

```
# restarts the "web" deployment
kubernetes-deploy-restart <kube namespace> <kube context> --deployments=web
```

Under the hood it crafts the `PATCH` request to update the deployment, similar to what the kubectl command does.

fixes https://github.com/Shopify/kubernetes-deploy/issues/43

review @sirupsen @KnVerey 