### PR TITLE
Allow overriding timeout on command line

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -10,6 +10,7 @@ template_dir = nil
 ARGV.options do |opts|
   opts.on("--skip-wait") { skip_wait = true }
   opts.on("--template-dir=DIR") { |v| template_dir = v }
+  opts.on("--timeout=TIMEOUT") { |v| KubernetesDeploy::KubernetesResource::timeout_override = v.to_i }
   opts.parse!
 end
 

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/class/attribute'
 
 require 'logger'
 require 'kubernetes-deploy/runner'

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -20,6 +20,7 @@ module KubernetesDeploy
 
     attr_reader :name, :namespace, :file, :context
     attr_writer :type, :deploy_started
+    class_attribute :timeout_override
 
     TIMEOUT = 5.minutes
 
@@ -38,7 +39,7 @@ module KubernetesDeploy
     end
 
     def self.timeout
-      self::TIMEOUT
+      self.timeout_override || self::TIMEOUT
     end
 
     def timeout


### PR DESCRIPTION
We are using kubernetes-deploy to roll out buildkite agents for CI, and would like a higher timeout value than the defaults to allow enough time for jobs to complete (matching scrooges behaviour for now). I didn't find much unit testing around this code so as it's pretty simple I've just tested locally:

```
$ kubernetes-deploy --template-dir config/deploy/testing/ buildkite-testing ci
...
Waiting for Deployment/buildkite-runner with 300s timeout
...
$ kubernetes-deploy --timeout 800 --template-dir config/deploy/testing/ buildkite-testing ci
...
Waiting for Deployment/buildkite-runner with 800s timeout
```

/cc @Shopify/pipeline 