### PR TITLE
Fix an edge case when the leading --- broke YAML stream

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -168,6 +168,8 @@ MSG
       file_content = File.read(File.join(@template_dir, filename))
       rendered_content = render_template(filename, file_content)
       YAML.load_stream(rendered_content) do |doc|
+        next if doc.blank?
+
         f = Tempfile.new(filename)
         f.write(YAML.dump(doc))
         f.close

--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -1,0 +1,23 @@
+<% %w(one two three).each do |name| %>
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: <%= "web-#{name}" %>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: <%= "web-#{name}" %>
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+        - name: GITHUB_REV
+          value: <%= current_sha %>
+---
+<% end %>

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -35,9 +35,14 @@ module FixtureDeployHelper
     FileUtils.remove_dir(target_dir) if target_dir
   end
 
+  def deploy_raw_fixtures(set, wait: true)
+    deploy_dir(fixture_path(set), wait: wait)
+  end
+
   def fixture_path(set_name)
     source_dir = File.expand_path("../../fixtures/#{set_name}", __FILE__)
-    raise "Fixture set #{set_name} does not exist as directory #{source_dir}" unless File.directory?(source_dir)
+    raise ArgumentError,
+      "Fixture set #{set_name} does not exist as directory #{source_dir}" unless File.directory?(source_dir)
     source_dir
   end
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -74,6 +74,14 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(/error validating data\: found invalid field myKey for v1.ObjectMeta/)
   end
 
+  def test_dynamic_erb_collection_works
+    deploy_raw_fixtures("collection-with-erb")
+
+    deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace)
+    assert_equal 3, deployments.size
+    assert_equal ["web-one", "web-three", "web-two"], deployments.map { |d| d.metadata.name }.sort
+  end
+
   # Reproduces k8s bug
   # https://github.com/kubernetes/kubernetes/issues/42057
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_on_apply


### PR DESCRIPTION
The following ERB breaks the tool:

```
<% %w(one two three).each do |worker| %>
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: <%= "worker-#{worker}" %>
spec:
  template:
    spec:
      containers:
      - name: <%= "worker-#{worker}" %>
        image: "...my registry"
---
<% end %>
```

`YAML.load_stream` will consider it as **four** chunks. The first three chunks with `Deployment` are valid, but when we try to apply the fourth chunk (which is technically blank) it will crash.

To rephrase the issue, the leading `---` at the end of the YAML makes us fail with an error.

review @KnVerey 