### PR TITLE
Logging improvements

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -17,12 +17,13 @@ module KubernetesDeploy
       @logger ||= begin
         l = Logger.new($stderr)
         l.level = level_from_env
-        l.formatter = proc do |severity, _datetime, _progname, msg|
+        l.formatter = proc do |severity, datetime, _progname, msg|
+          log_text = "[#{severity}][#{datetime}]\t#{msg}"
           case severity
-          when "FATAL", "ERROR" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n" # red
-          when "WARN" then "\033[0;33m[#{severity}]\t#{msg}\x1b[0m\n" # yellow
-          when "INFO" then "\033[0;36m#{msg}\x1b[0m\n" # blue
-          else "[#{severity}]\t#{msg}\n"
+          when "FATAL" then "\033[0;31m#{log_text}\x1b[0m\n" # red
+          when "ERROR", "WARN" then "\033[0;33m#{log_text}\x1b[0m\n" # yellow
+          when "INFO" then "\033[0;36m#{log_text}\x1b[0m\n" # blue
+          else "#{log_text}\n"
           end
         end
         l

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -11,8 +11,8 @@ module KubernetesDeploy
     def self.logger
       @logger ||= begin
         l = Logger.new($stderr)
-        l.formatter = proc do |_severity, _datetime, _progname, msg|
-          "#{msg}\n"
+        l.formatter = proc do |_severity, datetime, _progname, msg|
+          "[KUBESTATUS][#{datetime}]\t#{msg}\n"
         end
         l
       end
@@ -125,7 +125,7 @@ module KubernetesDeploy
     end
 
     def log_status
-      KubernetesResource.logger.info("[KUBESTATUS][#{@context}][#{@namespace}] #{JSON.dump(status_data)}")
+      KubernetesResource.logger.info("[#{@context}][#{@namespace}] #{JSON.dump(status_data)}")
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -23,8 +23,8 @@ module KubernetesDeploy
         @ready = false
         @containers = []
       end
-      display_logs if @bare && deploy_finished?
       log_status
+      display_logs if @bare && deploy_finished?
     end
 
     def interpret_json_data(pod_data)
@@ -80,8 +80,7 @@ module KubernetesDeploy
         out, st = run_kubectl("logs", @name, "--timestamps=true", "--since-time=#{@deploy_started.to_datetime.rfc3339}")
         next unless st.success? && out.present?
 
-        KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
-        KubernetesResource.logger.info(out)
+        KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:\x1b[0m \n#{out}\n"
         @already_displayed = true
       end
     end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -206,7 +206,7 @@ MSG
         newly_finished_resources, watched_resources = watched_resources.partition(&:deploy_finished?)
         newly_finished_resources.each do |resource|
           next unless resource.deploy_failed? || resource.deploy_timed_out?
-          KubernetesDeploy.logger.warn("#{resource.id} failed to deploy with status '#{resource.status}'.")
+          KubernetesDeploy.logger.error("#{resource.id} failed to deploy with status '#{resource.status}'.")
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/kubernetes-deploy/issues/49 by introducing timestamps on both loggers. Screenshots of a full successful deploy At the bottom of this description... wdyt? Are the "user-friendly" blue logs still adequately so?

Also reduces the noise we generate on deploy failures. There's a lot of repeated information in here:
![screenshot](https://screenshot.click/2017-03-17--154213_meget-i0yti.png)

The idea was that those messages could theoretically appear spaced out. But in practice I've always seen them clumped uselessly like that. I've also changed error logs to be yellow so that red is exclusive to fatal. Here's the new version:

![screenshot](https://screenshot.click/2017-03-17--161020_v6wcw-hrnu8.png)

## Success screenshots

<details>

Success:

![screenshot](https://screenshot.click/2017-03-17--154947_w0kb6-3ktll.png)
![screenshot](https://screenshot.click/2017-03-17--155056_k37qf-h5zgj.png)

</details>