### PR TITLE
Allow deploys to protected namespaces, without pruning

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -7,8 +7,10 @@ require 'optparse'
 
 skip_wait = false
 template_dir = nil
+allow_protected_ns = false
 ARGV.options do |opts|
   opts.on("--skip-wait") { skip_wait = true }
+  opts.on("--allow-protected-ns") { allow_protected_ns = true }
   opts.on("--template-dir=DIR") { |v| template_dir = v }
   opts.parse!
 end
@@ -35,6 +37,7 @@ KubernetesDeploy::Runner.with_friendly_errors do
     current_sha: revision,
     template_dir: template_dir,
     wait_for_completion: !skip_wait,
+    allow_protected_ns: allow_protected_ns,
   )
   runner.run
 end

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -8,9 +8,11 @@ require 'optparse'
 skip_wait = false
 template_dir = nil
 allow_protected_ns = false
+prune = true
 ARGV.options do |opts|
   opts.on("--skip-wait") { skip_wait = true }
   opts.on("--allow-protected-ns") { allow_protected_ns = true }
+  opts.on("--no-prune") { prune = false }
   opts.on("--template-dir=DIR") { |v| template_dir = v }
   opts.parse!
 end
@@ -38,6 +40,7 @@ KubernetesDeploy::Runner.with_friendly_errors do
     template_dir: template_dir,
     wait_for_completion: !skip_wait,
     allow_protected_ns: allow_protected_ns,
+    prune: prune,
   )
   runner.run
 end

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-stub-const", "~> 0.6"
 end

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/string/strip'
 
 require 'logger'
 require 'kubernetes-deploy/runner'

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -107,14 +107,10 @@ MSG
       predeploy_priority_resources(resources)
 
       phase_heading("Deploying all resources")
-      if PROTECTED_NAMESPACES.include?(@namespace)
-        KubernetesDeploy.logger.warn("Deploying to protected namespace #{@namespace} without resource pruning.")
-        # Ignoring @prune here is a redundant safeguard given the danger of pruning protected namespaces:
-        # validate_configuration should already raise an error if it is true with a protected ns
-        deploy_resources(resources, prune: false)
-      else
-        deploy_resources(resources, prune: @prune)
+      if PROTECTED_NAMESPACES.include?(@namespace) && @prune
+        raise FatalDeploymentError, "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
       end
+      deploy_resources(resources, prune: @prune)
 
       return unless wait_for_completion?
       wait_for_completion(resources)

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -23,7 +23,7 @@ module FixtureDeployHelper
   #     pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
-  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false)
+  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false, prune: true)
     fixtures = load_fixtures(set, subset)
     raise "Cannot deploy empty template set" if fixtures.empty?
 
@@ -31,7 +31,7 @@ module FixtureDeployHelper
 
     target_dir = Dir.mktmpdir
     write_fixtures_to_dir(fixtures, target_dir)
-    deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns)
+    deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns, prune: prune)
   ensure
     FileUtils.remove_dir(target_dir) if target_dir
   end
@@ -50,7 +50,7 @@ module FixtureDeployHelper
   # Deploys all fixtures in the given directory via KubernetesDeploy::Runner
   # Exposed for direct use only when deploy_fixtures cannot be used because the template cannot be loaded pre-deploy,
   # for example because it contains an intentional syntax error
-  def deploy_dir(dir, sha: 'abcabcabc', wait: true, allow_protected_ns: false)
+  def deploy_dir(dir, sha: 'abcabcabc', wait: true, allow_protected_ns: false, prune: true)
     runner = KubernetesDeploy::Runner.new(
       namespace: @namespace,
       current_sha: sha,
@@ -58,6 +58,7 @@ module FixtureDeployHelper
       template_dir: dir,
       wait_for_completion: wait,
       allow_protected_ns: allow_protected_ns,
+      prune: prune,
     )
     runner.run
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -47,8 +47,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: false)
       hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
       hello_cloud.assert_all_up
+      assert_logs_match(/cannot be pruned/)
       assert_logs_match(/Please do not deploy to #{@namespace} unless you really know what you are doing/)
-      assert_logs_match(/Deploying to protected namespace #{@namespace} without resource pruning/)
 
       deploy_fixtures("hello-cloud", subset: ["redis.yml"], allow_protected_ns: true, prune: false)
       hello_cloud.assert_all_up

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -32,6 +32,19 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.refute_web_resources_exist
   end
 
+  def test_deploying_to_protected_namespace_does_not_prune
+    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+      deploy_fixtures("hello-cloud")
+      hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+      hello_cloud.assert_all_up
+      assert_logs_match(/deploying to protected namespace/)
+      assert_logs_match(/without resource pruning/)
+
+      deploy_fixtures("hello-cloud", subset: ["redis.yml"])
+      hello_cloud.assert_all_up
+    end
+  end
+
   def test_pvcs_are_not_pruned
     deploy_fixtures("hello-cloud", subset: ["redis.yml"])
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'kubeclient'
 require 'pry'
 require 'timecop'
 require 'minitest/autorun'
+require 'minitest/stub/const'
 
 require 'helpers/kubeclient_helper'
 require 'helpers/fixture_deploy_helper'


### PR DESCRIPTION
### What?

Re-enables deploying to `default`/`kube-system` but with pruning disabled and some large warnings (output is from the test, hence the odd namespace name):
![image](https://cloud.githubusercontent.com/assets/4789493/24125875/46fe2bca-0da1-11e7-8c8b-d2f87f4392af.png)
![image](https://cloud.githubusercontent.com/assets/4789493/24125883/54d6d152-0da1-11e7-9764-33e19c6521e0.png)

EDIT: It will still refuse to deploy to protected namespaces unless you use `--allow-protected-ns --no-prune`, which enables the above behaviour.

### Why?

With https://github.com/Shopify/cloudplatform/issues/264, we're switching to deploying all our cluster services with Shipit/kuberentes-deploy. In most cases, we're able to move them to their own namespace. However, there's one thing we need unfortunately need to leave in default at least during a transition period. WDYT, reviewers? Is this a terrible thing to allow temporarily/permanently?

cc @Shopify/cloudplatform 