### PR TITLE
Add a task runner to trigger one-off jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ The following command will restart all pods in the `web` and `jobs` deployments:
 
 `kubernetes-restart <kube namespace> <kube context> --deployments=web,jobs`
 
+### Running one off tasks
+
+To trigger a one-off job such as a rake task _outside_ of a deploy, use the following command:
+
+`kubernetes-run <kube namespace> <kube context> <arguments> --entrypoint=/bin/bash`
+
+This command assumes that you've already deployed a `PodTemplate` named `task-runner-template`, which contains a full pod specification in its `data`. The pod specification in turn must have a container named `task-runner`. Based on this specification `kubernetes-run` will create a new pod with the entrypoint of the task-runner container overriden with the supplied arguments.
+
+#### Creating a PodTemplate
+
+The [`PodTemplate`](https://kubernetes.io/docs/api-reference/v1.6/#podtemplate-v1-core) object should have a field `template` containing a `Pod` specification which does not include the `apiVersion` or `kind` parameters. An example is provided in this repo in `test/fixtures/hello-cloud/template-runner.yml`. 
+
+#### Providing multiple different task-runner configurations
+
+If your application requires task runner templates you can specify which template to use by using the `--template` option. All templates are expected to provide a container called `task-runner`.
+
+#### Specifying environment variables for the container
+
+If you also need to specify environment variables on top of the arguments, you can specify the `--env-vars` flag which accepts a comma separated list of environment variables like so: `--env-vars="ENV=VAL,ENV2=VAL"`
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You currently need to [manually install kubectl version 1.6.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) as well if you don't already have it.

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kubernetes-deploy'
+require 'kubernetes-deploy/runner_task'
+require 'optparse'
+
+template = "task-runner-template"
+entrypoint = nil
+env_vars = []
+
+ARGV.options do |opts|
+  opts.on("--template=TEMPLATE") { |n| template = n }
+  opts.on("--env-vars=ENV_VARS") { |vars| env_vars = n.split(",")}
+  opts.on("--entrypoint=ENTRYPOINT") { |c| entrypoint = [c] }
+  opts.parse!
+end
+
+runner = KubernetesDeploy::RunnerTask.new(
+  namespace: ARGV[0],
+  context: ARGV[1],
+)
+
+ KubernetesDeploy::Runner.with_friendly_errors do
+  runner.run(
+    task_template: template,
+    entrypoint: entrypoint,
+    args: ARGV[2..-1],
+    env_vars: env_vars
+  )
+end

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -10,5 +10,12 @@ require 'kubernetes-deploy/runner'
 
 module KubernetesDeploy
   class FatalDeploymentError < StandardError; end
+
+  class NamespaceNotFoundError < FatalDeploymentError
+    def initialize(name, context)
+      super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
+    end
+  end
+
   include Logger
 end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -35,6 +35,7 @@ module KubernetesDeploy
       when 'ingress' then Ingress.new(name, namespace, context, file)
       when 'persistentvolumeclaim' then PersistentVolumeClaim.new(name, namespace, context, file)
       when 'service' then Service.new(name, namespace, context, file)
+      when 'podtemplate' then PodTemplate.new(name, namespace, context, file)
       else self.new(name, namespace, context, file).tap { |r| r.type = type }
       end
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class PodTemplate < KubernetesResource
+    def initialize(name, namespace, context, file)
+      @name = name
+      @namespace = namespace
+      @context = context
+      @file = file
+    end
+
+    def sync
+      _, _err, st = run_kubectl("get", type, @name)
+      @status = st.success? ? "Available" : "Unknown"
+      @found = st.success?
+      log_status
+    end
+
+    def deploy_succeeded?
+      exists?
+    end
+
+    def deploy_failed?
+      false
+    end
+
+    def exists?
+      @found
+    end
+  end
+end

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -14,12 +14,6 @@ module KubernetesDeploy
       end
     end
 
-    class NamespaceNotFoundError < FatalDeploymentError
-      def initialize(name, context)
-        super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
-      end
-    end
-
     class RestartError < FatalDeploymentError
       def initialize(deployment_name, response)
         super("Failed to restart #{deployment_name}. " \

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -5,7 +5,6 @@ require 'erb'
 require 'yaml'
 require 'shellwords'
 require 'tempfile'
-
 require 'kubernetes-deploy/kubernetes_resource'
 %w(
   cloudsql
@@ -16,6 +15,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   pod
   redis
   service
+  pod_template
   bugsnag
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
@@ -116,6 +116,7 @@ MSG
       if PROTECTED_NAMESPACES.include?(@namespace) && @prune
         raise FatalDeploymentError, "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
       end
+
       deploy_resources(resources, prune: @prune)
 
       return unless wait_for_completion?

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+require 'tempfile'
+
+require 'kubernetes-deploy/kubeclient_builder'
+require 'kubernetes-deploy/ui_helpers'
+require 'kubernetes-deploy/kubectl'
+
+module KubernetesDeploy
+  class RunnerTask
+    include KubeclientBuilder
+    include Kubectl
+    include UIHelpers
+
+    class FatalTaskRunError < FatalDeploymentError; end
+    class TaskTemplateMissingError < FatalDeploymentError
+      def initialize(task_template, namespace, context)
+        super("Pod template `#{task_template}` cannot be found in namespace: `#{namespace}`, context: `#{context}`")
+      end
+    end
+
+    def initialize(namespace:, context:, logger: KubernetesDeploy.logger)
+      @logger = logger
+      @namespace = namespace
+      @kubeclient = build_v1_kubeclient(context)
+      @context = context
+    end
+
+    def run(task_template:, entrypoint:, args:, env_vars: [])
+      phase_heading("Validating configuration")
+      validate_configuration(task_template, args)
+
+      phase_heading("Fetching task template")
+      raw_template = get_template(task_template)
+
+      phase_heading("Constructing final pod specification")
+      rendered_template = build_pod_template(raw_template, entrypoint, args, env_vars)
+
+      validate_pod_spec(rendered_template)
+
+      phase_heading("Creating pod")
+      KubernetesDeploy.logger.info("Starting task runner pod: '#{rendered_template.metadata.name}'")
+      @kubeclient.create_pod(rendered_template)
+    end
+
+    private
+
+    def validate_configuration(task_template, args)
+      errors = []
+
+      if task_template.blank?
+        errors << "Task template name can't be nil"
+      end
+
+      if @namespace.blank?
+        errors << "Namespace can't be empty"
+      end
+
+      if args.blank?
+        errors << "Args can't be nil"
+      end
+
+      begin
+        @kubeclient.get_namespace(@namespace)
+      rescue KubeException => e
+        errors << if e.error_code == 404
+          "Namespace was not found"
+        else
+          "Could not connect to kubernetes cluster"
+        end
+      end
+
+      raise FatalTaskRunError, "Configuration invalid: #{errors.join(', ')}" unless errors.empty?
+    end
+
+    def get_template(template_name)
+      KubernetesDeploy.logger.info(
+        "Fetching task runner pod template: '#{template_name}' in namespace: '#{@namespace}'"
+      )
+
+      pod_template = @kubeclient.get_pod_template(template_name, @namespace)
+
+      pod_template.template
+    rescue KubeException => error
+      if error.error_code == 404
+        raise TaskTemplateMissingError.new(template_name, @namespace, @context)
+      else
+        raise
+      end
+    end
+
+    def build_pod_template(base_template, entrypoint, args, env_vars)
+      KubernetesDeploy.logger.info("Rendering template for task runner pod")
+
+      rendered_template = base_template.dup
+      rendered_template.kind = 'Pod'
+      rendered_template.apiVersion = 'v1'
+
+      container = rendered_template.spec.containers.find { |cont| cont.name == 'task-runner' }
+
+      raise FatalTaskRunError, "Pod spec does not contain a template container called 'task-runner'" if container.nil?
+
+      container.command = entrypoint
+      container.args = args
+      container.env ||= []
+
+      env_args = env_vars.map do |key, value|
+        key, value = env.split('=', 2)
+        { name: key, value: value }
+      end
+
+      container.env = container.env.map(&:to_h) + env_args
+
+      unique_name = rendered_template.metadata.name + "-" + SecureRandom.hex(8)
+
+      KubernetesDeploy.logger.warn("Name is too long, using '#{unique_name[0..62]}'") if unique_name.length > 63
+      rendered_template.metadata.name = unique_name[0..62]
+      rendered_template.metadata.namespace = @namespace
+
+      rendered_template
+    end
+
+    def validate_pod_spec(pod)
+      f = Tempfile.new(pod.metadata.name)
+      f.write recursive_to_h(pod).to_json
+      f.close
+
+      _out, err, status = Kubectl.run_kubectl(
+        "apply", "--dry-run", "-f", f.path,
+        namespace: @namespace,
+        context: @context
+      )
+
+      unless status.success?
+        raise FatalTaskRunError, "Invalid pod spec: #{err}"
+      end
+    end
+
+    def recursive_to_h(struct)
+      if struct.is_a?(Array)
+        return struct.map { |v| v.is_a?(OpenStruct) || v.is_a?(Array) || v.is_a?(Hash) ? recursive_to_h(v) : v }
+      end
+
+      hash = {}
+
+      struct.each_pair do |k, v|
+        recursive_val = v.is_a?(OpenStruct) || v.is_a?(Array) || v.is_a?(Hash)
+        hash[k] = recursive_val ? recursive_to_h(v) : v
+      end
+      hash
+    end
+  end
+end

--- a/test/fixtures/hello-cloud/template-runner.yml
+++ b/test/fixtures/hello-cloud/template-runner.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: hello-cloud-template-runner
+  labels:
+    name: hello-cloud-template-runner
+    app: hello-cloud
+template:
+  metadata:
+    name: task-runner
+    labels:
+      name: runner
+      app: hello-cloud
+  spec:
+    containers:
+    - name: task-runner
+      image: hello-world:latest
+      env:
+      - name: CONFIG
+        valueFrom:
+          configMapKeyRef:
+            name: hello-cloud-configmap-data
+            key: datapoint1

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -83,5 +83,13 @@ module FixtureSetAssertions
       assert_equal 1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}"
       assert_equal expected_data, configmaps.first["data"].to_h
     end
+
+    def assert_pod_templates_present(cm_name)
+      pod_templates = kubeclient.get_pod_templates(
+        namespace: namespace,
+        label_selector: "name=#{cm_name},app=#{app_name}"
+      )
+      assert_equal 1, pod_templates.size, "Expected 1 podtemplate, got #{pod_templates.size}"
+    end
   end
 end

--- a/test/helpers/fixture_sets/hello-cloud.rb
+++ b/test/helpers/fixture_sets/hello-cloud.rb
@@ -11,6 +11,7 @@ module FixtureSetAssertions
       assert_all_web_resources_up
       assert_all_redis_resources_up
       assert_configmap_data_present
+      assert_podtemplate_runner_present
     end
 
     def assert_unmanaged_pod_statuses(status, count = 1)
@@ -60,6 +61,10 @@ module FixtureSetAssertions
       else
         refute_resource_exists("pvc", "redis")
       end
+    end
+
+    def assert_podtemplate_runner_present
+      assert_pod_templates_present("hello-cloud-template-runner")
     end
   end
 end

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -110,7 +110,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: "walrus"
     )
-    error = assert_raises(KubernetesDeploy::RestartTask::NamespaceNotFoundError) do
+    error = assert_raises(KubernetesDeploy::NamespaceNotFoundError) do
       restart.perform(["web"])
     end
     assert_equal "Namespace `walrus` not found in context `minikube`. Aborting the task.", error.to_s

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+require 'kubernetes-deploy/runner_task'
+class RunnerTaskTest < KubernetesDeploy::IntegrationTest
+  def test_works
+    deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
+
+    task_runner = KubernetesDeploy::RunnerTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+
+    task_runner.run(
+      task_template: 'hello-cloud-template-runner',
+      entrypoint: ['/bin/bash'],
+      args: %w(echo "KUBERNETES-DEPLOY")
+    )
+
+    assert_logs_match(/Starting task runner/)
+  end
+
+  def test_substitutes_arguments
+    deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
+
+    task_runner = KubernetesDeploy::RunnerTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: @namespace,
+    )
+
+    pod = task_runner.run(
+      task_template: 'hello-cloud-template-runner',
+      entrypoint: nil,
+      args: %w(rake some_task)
+    )
+
+    assert_equal %w(rake some_task), pod.spec.containers.first.args
+  end
+end

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RunnerTaskUnitTest < KubernetesDeploy::TestCase
+  def test_missing_namespace
+    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError,
+      message: "Configuration invalid: Namespace was not found") do
+      task_runner = KubernetesDeploy::RunnerTask.new(
+        context: KubeclientHelper::MINIKUBE_CONTEXT,
+        namespace: "missing",
+      )
+
+      task_runner.run(
+        task_template: 'hello-cloud-template-runner',
+        entrypoint: nil,
+        args: 'a'
+      )
+    end
+  end
+
+  def test_missing_arguments
+    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
+      task_runner = KubernetesDeploy::RunnerTask.new(
+        context: KubeclientHelper::MINIKUBE_CONTEXT,
+        namespace: @namespace,
+      )
+
+      task_runner.run(
+        task_template: 'hello-cloud-template-runner',
+        entrypoint: nil,
+        args: nil
+      )
+    end
+  end
+
+  def test_missing_template
+    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
+      task_runner = KubernetesDeploy::RunnerTask.new(
+        namespace: @namespace,
+        context: KubeclientHelper::MINIKUBE_CONTEXT
+      )
+
+      task_runner.run(
+        task_template: nil,
+        entrypoint: nil,
+        args: ['a']
+      )
+    end
+  end
+end


### PR DESCRIPTION
There is a need to run one off tasks within a kubernetes infrastructure. This system allows application developers to provide a `ConfigMap` embedding a pod spec which is used as a template. The provided `kubernetes-run` executable will be able to look up the template and fill in the `args` and `command` parameters with user supplied values.

cc @Shopify/pods 