### PR TITLE
Refactor Runner to be reusable

### DIFF
--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class ResourceWatcher
+    def initialize(resources)
+      unless resources.is_a?(Enumerable)
+        raise ArgumentError, <<-MSG.strip
+ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead
+MSG
+      end
+      @resources = resources
+    end
+
+    def run(delay_sync: 3.seconds, logger: KubernetesDeploy.logger)
+      delay_sync_until = Time.now.utc
+      started_at = delay_sync_until
+      human_resources = @resources.map(&:id).join(", ")
+      max_wait_time = @resources.map(&:timeout).max
+      logger.info("Waiting for #{human_resources} with #{max_wait_time}s timeout")
+
+      while @resources.present?
+        if Time.now.utc < delay_sync_until
+          sleep(delay_sync_until - Time.now.utc)
+        end
+        delay_sync_until = Time.now.utc + delay_sync # don't pummel the API if the sync is fast
+        @resources.each(&:sync)
+        newly_finished_resources, @resources = @resources.partition(&:deploy_finished?)
+        newly_finished_resources.each do |resource|
+          next unless resource.deploy_failed? || resource.deploy_timed_out?
+          logger.error("#{resource.id} failed to deploy with status '#{resource.status}'.")
+        end
+      end
+
+      watch_time = Time.now.utc - started_at
+      logger.info("Spent #{watch_time.round(2)}s waiting for #{human_resources}")
+    end
+  end
+end

--- a/lib/kubernetes-deploy/ui_helpers.rb
+++ b/lib/kubernetes-deploy/ui_helpers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  module UIHelpers
+    private
+
+    def phase_heading(phase_name)
+      @current_phase ||= 0
+      @current_phase += 1
+      heading = "Phase #{@current_phase}: #{phase_name}"
+      padding = (100.0 - heading.length) / 2
+      KubernetesDeploy.logger.info("")
+      KubernetesDeploy.logger.info("#{'-' * padding.floor}#{heading}#{'-' * padding.ceil}")
+    end
+
+    def log_green(msg)
+      KubernetesDeploy.logger.info("\033[0;32m#{msg}\x1b[0m")
+    end
+  end
+end

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ResourceWatcherTest < KubernetesDeploy::TestCase
+  def test_requires_enumerable
+    err = assert_raises(ArgumentError) do
+      KubernetesDeploy::ResourceWatcher.new(Object.new)
+    end
+    assert_equal "ResourceWatcher expects Enumerable collection, got `Object` instead", err.to_s
+
+    KubernetesDeploy::ResourceWatcher.new([])
+  end
+
+  def test_success_with_mock_resource
+    resource = build_mock_resource
+
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher.run(delay_sync: 0.1)
+
+    assert_logs_match(/Waiting for web-pod with 1s timeout/)
+    assert_logs_match(/Spent (\S+)s waiting for web-pod/)
+  end
+
+  def test_failure_with_mock_resource
+    resource = build_mock_resource("failed")
+
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher.run(delay_sync: 0.1)
+
+    assert_logs_match(/Waiting for web-pod with 1s timeout/)
+    assert_logs_match(/web-pod failed to deploy with status 'failed'/)
+    assert_logs_match(/Spent (\S+)s waiting for web-pod/)
+  end
+
+  def test_timeout_from_resource
+    resource = build_mock_resource("timeout")
+
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher.run(delay_sync: 0.1)
+
+    assert_logs_match(/Waiting for web-pod with 1s timeout/)
+    assert_logs_match(/web-pod failed to deploy with status 'timeout'/)
+    assert_logs_match(/Spent (\S+)s waiting for web-pod/)
+  end
+
+  private
+
+  MockResource = Struct.new(:id, :timeout, :status) do
+    def sync
+      @hits ||= 0
+      @hits += 1
+    end
+
+    def deploy_finished?
+      @hits > 3
+    end
+
+    def deploy_failed?
+      status == "failed"
+    end
+
+    def deploy_timed_out?
+      status == "timeout"
+    end
+  end
+
+  def build_mock_resource(status = nil)
+    MockResource.new("web-pod", 1, status)
+  end
+end


### PR DESCRIPTION
Moving `phase_heading` and `wait_for_completion` out of `Runner` to make them reusable for the Restart task.

This is a blocker to ship https://github.com/Shopify/kubernetes-deploy/pull/61.

