### PR TITLE
ResourceWatcher may hang forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### Unreleased
+*Features*
+- Added `--max-watch-seconds=seconds` to kubernetes-restart and kubernetes-deploy. When set
+a timeout error is raised if it takes longer than _seconds_ for any resource to deploy.
+
 *Enhancements*
 - Prune resource quotas ([#264](https://github.com/Shopify/kubernetes-deploy/pull/264/files))
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ Refer to `kubernetes-deploy --help` for the authoritative set of options.
 - `--template-dir=DIR`: Used to set the deploy directory. Set `$ENVIRONMENT` instead to use `config/deploy/$ENVIRONMENT`.
 - `--bindings=BINDINGS`: Makes additional variables available to your ERB templates. For example, `kubernetes-deploy my-app cluster1 --bindings=color=blue,size=large` will expose `color` and `size`.
 - `--no-prune`: Skips pruning of resources that are no longer in your Kubernetes template set. Not recommended, as it allows your namespace to accumulate cruft that is not reflected in your deploy directory.
-
-
-
+- `--max-watch-seconds=seconds`: Raise a timeout error if it takes longer than _seconds_ for any
+resource to deploy.
 
 
 ### Using templates and variables

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -10,6 +10,7 @@ allow_protected_ns = false
 prune = true
 bindings = {}
 verbose_log_prefix = false
+max_watch_seconds = nil
 
 ARGV.options do |opts|
   opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
@@ -23,6 +24,10 @@ ARGV.options do |opts|
   opts.on("--no-prune", "Disable deletion of resources that do not appear in the template dir") { prune = false }
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
   opts.on("--verbose-log-prefix", "Add [context][namespace] to the log prefix") { verbose_log_prefix = true }
+  opts.on("--max-watch-seconds=seconds",
+    "Timeout error is raised if it takes longer than the specified number of seconds") do |t|
+    max_watch_seconds = t.to_i
+  end
 
   opts.on_tail("-h", "--help", "Print this help") do
     puts opts
@@ -60,7 +65,8 @@ runner = KubernetesDeploy::DeployTask.new(
   current_sha: revision,
   template_dir: template_dir,
   bindings: bindings,
-  logger: logger
+  logger: logger,
+  max_watch_seconds: max_watch_seconds
 )
 
 begin

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -7,8 +7,10 @@ require 'kubernetes-deploy'
 require 'kubernetes-deploy/restart_task'
 
 raw_deployments = nil
+max_watch_seconds = nil
 ARGV.options do |opts|
   opts.on("--deployments=LIST") { |v| raw_deployments = v.split(",") }
+  opts.on("--max-watch-seconds=seconds") { |t| max_watch_seconds = t.to_i }
   opts.parse!
 end
 
@@ -16,7 +18,8 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
-restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
+restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger,
+   max_watch_seconds: max_watch_seconds)
 begin
   restart.perform!(raw_deployments)
 rescue KubernetesDeploy::DeploymentTimeoutError

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -89,13 +89,15 @@ module KubernetesDeploy
 
     NOT_FOUND_ERROR = 'NotFound'
 
-    def initialize(namespace:, context:, current_sha:, template_dir:, logger:, kubectl_instance: nil, bindings: {})
+    def initialize(namespace:, context:, current_sha:, template_dir:, logger:, kubectl_instance: nil, bindings: {},
+      max_watch_seconds: nil)
       @namespace = namespace
       @context = context
       @current_sha = current_sha
       @template_dir = File.expand_path(template_dir)
       @logger = logger
       @kubectl = kubectl_instance
+      @max_watch_seconds = max_watch_seconds
       @renderer = KubernetesDeploy::Renderer.new(
         current_sha: @current_sha,
         template_dir: @template_dir,
@@ -377,7 +379,7 @@ module KubernetesDeploy
 
       if verify
         watcher = ResourceWatcher.new(resources: resources, sync_mediator: @sync_mediator,
-          logger: @logger, deploy_started_at: deploy_started_at)
+          logger: @logger, deploy_started_at: deploy_started_at, timeout: @max_watch_seconds)
         watcher.run(record_summary: record_summary)
       end
     end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -158,9 +158,15 @@ module KubernetesDeploy
       @debug_info_synced = true
     end
 
-    def debug_message
+    def debug_message(cause = nil, info_hash = {})
+      sync_debug_info unless @debug_info_synced
+
       helpful_info = []
-      if deploy_failed?
+      if cause == :gave_up
+        helpful_info << ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
+        helpful_info << "If you expected it to take longer than #{info_hash[:timeout]} seconds for your deploy"\
+        " to roll out, increase --max-watch-seconds."
+      elsif deploy_failed?
         helpful_info << ColorizedString.new("#{id}: FAILED").red
         helpful_info << failure_message if failure_message.present?
       elsif deploy_timed_out?

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -159,8 +159,6 @@ module KubernetesDeploy
     end
 
     def debug_message(cause = nil, info_hash = {})
-      sync_debug_info unless @debug_info_synced
-
       helpful_info = []
       if cause == :gave_up
         helpful_info << ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class ResourceWatcher
-    def initialize(resources:, sync_mediator:, logger:, deploy_started_at: Time.now.utc, operation_name: "deploy", timeout: nil)
+    def initialize(resources:, sync_mediator:, logger:, deploy_started_at: Time.now.utc,
+      operation_name: "deploy", timeout: nil)
       unless resources.is_a?(Enumerable)
         raise ArgumentError, <<~MSG
           ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -78,7 +78,11 @@ module KubernetesDeploy
       record_success_statuses(successful_resources)
       record_failed_statuses(failed_resources, remaining_resources)
 
-      raise DeploymentTimeoutError
+      if failed_resources.present? && !failed_resources.all?(&:deploy_timed_out?)
+        raise FatalDeploymentError
+      else
+        raise DeploymentTimeoutError
+      end
     end
 
     def record_statuses_for_summary(resources)

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class ResourceWatcher
-    def initialize(resources:, sync_mediator:, logger:, deploy_started_at: Time.now.utc, operation_name: "deploy")
+    def initialize(resources:, sync_mediator:, logger:, deploy_started_at: Time.now.utc, operation_name: "deploy", timeout: nil)
       unless resources.is_a?(Enumerable)
         raise ArgumentError, <<~MSG
           ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead
@@ -12,13 +12,17 @@ module KubernetesDeploy
       @sync_mediator = sync_mediator
       @deploy_started_at = deploy_started_at
       @operation_name = operation_name
+      @timeout = timeout
     end
 
     def run(delay_sync: 3.seconds, reminder_interval: 30.seconds, record_summary: true)
-      delay_sync_until = last_message_logged_at = Time.now.utc
+      delay_sync_until = last_message_logged_at = monitoring_started = Time.now.utc
       remainder = @resources.dup
 
       while remainder.present?
+        if @timeout && (Time.now.utc - monitoring_started > @timeout)
+          report_and_give_up(remainder)
+        end
         if Time.now.utc < delay_sync_until
           sleep(delay_sync_until - Time.now.utc)
         end
@@ -69,20 +73,26 @@ module KubernetesDeploy
       @logger.info(msg)
     end
 
+    def report_and_give_up(remaining_resources)
+      successful_resources, failed_resources = (@resources - remaining_resources).partition(&:deploy_succeeded?)
+      record_success_statuses(successful_resources)
+      record_failed_statuses(failed_resources, remaining_resources)
+
+      raise DeploymentTimeoutError
+    end
+
     def record_statuses_for_summary(resources)
       successful_resources, failed_resources = resources.partition(&:deploy_succeeded?)
-      fail_count = failed_resources.length
-      success_count = successful_resources.length
+      record_success_statuses(successful_resources)
+      record_failed_statuses(failed_resources)
+    end
 
-      if success_count > 0
-        @logger.summary.add_action("successfully #{@operation_name}ed #{success_count} "\
-          "#{'resource'.pluralize(success_count)}")
-        final_statuses = successful_resources.map(&:pretty_status).join("\n")
-        @logger.summary.add_paragraph("#{ColorizedString.new('Successful resources').green}\n#{final_statuses}")
-      end
+    def record_failed_statuses(failed_resources, global_timeouts = [])
+      fail_count = failed_resources.length + global_timeouts.length
 
       if fail_count > 0
         timeouts, failures = failed_resources.partition(&:deploy_timed_out?)
+        timeouts += global_timeouts
         if timeouts.present?
           @logger.summary.add_action(
             "timed out waiting for #{timeouts.length} #{'resource'.pluralize(timeouts.length)} to #{@operation_name}"
@@ -94,10 +104,21 @@ module KubernetesDeploy
             "failed to #{@operation_name} #{failures.length} #{'resource'.pluralize(failures.length)}"
           )
         end
-        KubernetesDeploy::Concurrency.split_across_threads(failed_resources) do |r|
+        KubernetesDeploy::Concurrency.split_across_threads(failed_resources + global_timeouts) do |r|
           r.sync_debug_info(@sync_mediator.kubectl)
         end
         failed_resources.each { |r| @logger.summary.add_paragraph(r.debug_message) }
+        global_timeouts.each { |r| @logger.summary.add_paragraph(r.debug_message(:gave_up, timeout: @timeout)) }
+      end
+    end
+
+    def record_success_statuses(successful_resources)
+      success_count = successful_resources.length
+      if success_count > 0
+        @logger.summary.add_action("successfully #{@operation_name}ed #{success_count} "\
+          "#{'resource'.pluralize(success_count)}")
+        final_statuses = successful_resources.map(&:pretty_status).join("\n")
+        @logger.summary.add_paragraph("#{ColorizedString.new('Successful resources').green}\n#{final_statuses}")
       end
     end
 

--- a/test/fixtures/invalid/config_map.yml
+++ b/test/fixtures/invalid/config_map.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  datapoint: value1

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -45,7 +45,7 @@ module FixtureDeployHelper
   end
 
   def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {},
-    sha: nil, kubectl_instance: nil)
+    sha: nil, kubectl_instance: nil, max_watch_seconds: nil)
     current_sha = sha || "k#{SecureRandom.hex(6)}"
     kubectl_instance ||= build_kubectl
 
@@ -56,7 +56,8 @@ module FixtureDeployHelper
       template_dir: dir,
       logger: logger,
       kubectl_instance: kubectl_instance,
-      bindings: bindings
+      bindings: bindings,
+      max_watch_seconds: max_watch_seconds
     )
     deploy.run(
       verify_result: wait,

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -501,14 +501,9 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_deploy_result_logging_for_mixed_result_deploy
-    result = deploy_fixtures("invalid", subset: ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml"]) do |f|
-      f["bad_probe.yml"]["ConfigMap"] = {
-        "apiVersion" => "v1",
-        "kind" => "ConfigMap",
-        "metadata" => { "name" => "test" },
-        "data" => { "datapoint1" => "value1" }
-      }
-    end
+    subset = ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml", "config_map.yml"]
+    result = deploy_fixtures("invalid", subset: subset)
+
     assert_deploy_failure(result)
     assert_logs_match_all([
       "Successfully deployed 1 resource, timed out waiting for 2 resources to deploy, and failed to deploy 1 resource",
@@ -895,18 +890,12 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   def test_resource_watcher_reports_failed_after_timeout
     result = deploy_fixtures(
       "invalid",
-      subset: ["bad_probe.yml", "cannot_run.yml", "missing_volumes.yml"],
+      subset: ["bad_probe.yml", "cannot_run.yml", "missing_volumes.yml", "config_map.yml"],
       max_watch_seconds: 15
     ) do |f|
       deployment = f["bad_probe.yml"]["Deployment"].first
       deployment["metadata"]["annotations"]["kubernetes-deploy.shopify.io/timeout-override"] = '5s'
       f["cannot_run.yml"]["Deployment"].first["spec"]["replicas"] = 1
-      f["bad_probe.yml"]["ConfigMap"] = {
-        "apiVersion" => "v1",
-        "kind" => "ConfigMap",
-        "metadata" => { "name" => "test" },
-        "data" => { "datapoint1" => "value1" }
-      }
     end
     assert_deploy_failure(result)
 

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -99,7 +99,9 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
 
   def test_timeout_allows_success
     resource = build_mock_resource(hits_to_complete: 1)
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger, timeout: 2)
+    sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new(resources: [resource], logger: logger,
+      timeout: 2, sync_mediator: sync_mediator)
 
     watcher.run(delay_sync: 0.1)
     assert_logs_match(/Successfully deployed in \d.\ds: web-pod/)
@@ -107,7 +109,9 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
 
   def test_timeout_raises_after_timeout_seconds
     resource = build_mock_resource(hits_to_complete: 10**100)
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger, timeout: 2)
+    sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new(resources: [resource], logger: logger,
+      timeout: 2, sync_mediator: sync_mediator)
 
     assert_raises(KubernetesDeploy::DeploymentTimeoutError) { watcher.run(delay_sync: 0.1) }
   end


### PR DESCRIPTION
I've noticed that the `ResourceWatcher` that has earlier been extracted from `wait_for_completion` (https://github.com/Shopify/kubernetes-deploy/pull/72) may hang forever if the `KubernetesResource#deploy_finished?` doesn't return `true` at some point.

That makes sense in the context of `KubernetesResource` but I think that the `ResourceWatcher` should have a global timeout and do not hang forever.

what do you think @KnVerey ?