### PR TITLE
HPA removed from kube 1.6 so don't fail deploys

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -53,10 +53,11 @@ module KubernetesDeploy
       batch/v1/Job
       extensions/v1beta1/DaemonSet
       extensions/v1beta1/Deployment
-      extensions/v1beta1/HorizontalPodAutoscaler
       extensions/v1beta1/Ingress
       apps/v1beta1/StatefulSet
     ).freeze
+
+    PRUNE_WHITELIST_V_1_5 = %w(extensions/v1beta1/HorizontalPodAutoscaler).freeze
 
     def self.with_friendly_errors
       yield
@@ -292,6 +293,9 @@ MSG
       if prune
         command.push("--prune", "--all")
         PRUNE_WHITELIST.each { |type| command.push("--prune-whitelist=#{type}") }
+        if run_kubectl('version').first =~ /Server Version: version.Info{Major:"1", Minor:"5"/
+          PRUNE_WHITELIST_V_1_5.each { |type| command.push("--prune-whitelist=#{type}") }
+        end
       end
 
       _, err, st = run_kubectl(*command)

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -46,7 +46,7 @@ module KubernetesDeploy
     # core/v1/ReplicationController -- superseded by deployments/replicasets
     # extensions/v1beta1/ReplicaSet -- managed by deployments
     # core/v1/Secret -- should not committed / managed by shipit
-    PRUNE_WHITELIST = %w(
+    BASE_PRUNE_WHITELIST = %w(
       core/v1/ConfigMap
       core/v1/Pod
       core/v1/Service
@@ -127,6 +127,23 @@ MSG
     end
 
     private
+
+    def versioned_prune_whitelist
+      if server_major_version == "1.5"
+        BASE_PRUNE_WHITELIST + PRUNE_WHITELIST_V_1_5
+      else
+        BASE_PRUNE_WHITELIST + PRUNE_WHITELIST_V_1_6
+      end
+    end
+
+    def server_major_version
+      @server_major_version ||= begin
+        out, _, _ = run_kubectl('version', '--short')
+        matchdata = /Server Version: v(?<version>\d\.\d)/.match(out)
+        raise "Could not determine server version" unless matchdata[:version]
+        matchdata[:version]
+      end
+    end
 
     # Inspect the file referenced in the kubectl stderr
     # to make it easier for developer to understand what's going on
@@ -293,12 +310,7 @@ MSG
 
       if prune
         command.push("--prune", "--all")
-        PRUNE_WHITELIST.each { |type| command.push("--prune-whitelist=#{type}") }
-        if run_kubectl('version', '--short').first =~ /Server Version: v1.5./
-          PRUNE_WHITELIST_V_1_5.each { |type| command.push("--prune-whitelist=#{type}") }
-        else
-          PRUNE_WHITELIST_V_1_6.each { |type| command.push("--prune-whitelist=#{type}") }
-        end
+        versioned_prune_whitelist.each { |type| command.push("--prune-whitelist=#{type}") }
       end
 
       _, err, st = run_kubectl(*command)

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -58,6 +58,7 @@ module KubernetesDeploy
     ).freeze
 
     PRUNE_WHITELIST_V_1_5 = %w(extensions/v1beta1/HorizontalPodAutoscaler).freeze
+    PRUNE_WHITELIST_V_1_6 = %w(autoscaling/v1/HorizontalPodAutoscaler).freeze
 
     def self.with_friendly_errors
       yield
@@ -293,8 +294,10 @@ MSG
       if prune
         command.push("--prune", "--all")
         PRUNE_WHITELIST.each { |type| command.push("--prune-whitelist=#{type}") }
-        if run_kubectl('version').first =~ /Server Version: version.Info{Major:"1", Minor:"5"/
+        if run_kubectl('version', '--short').first =~ /Server Version: v1.5./
           PRUNE_WHITELIST_V_1_5.each { |type| command.push("--prune-whitelist=#{type}") }
+        else
+          PRUNE_WHITELIST_V_1_6.each { |type| command.push("--prune-whitelist=#{type}") }
         end
       end
 


### PR DESCRIPTION
HPA removed from kube 1.6 and trying to keep it in the prune white list causes an error. This pr checks for kube version and only uses it in v1.5.

This is my first PR in this repo, so any and all feedback would be appreciated. 

Resolves: https://github.com/Shopify/kubernetes-deploy/issues/75