### PR TITLE
bump ci minikube to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 
 Requirements:
 
- - kubectl 1.5.1+ binary must be available in your path
+ - kubectl 1.6.0+ binary must be available in your path
  - `ENV['KUBECONFIG']` must point to a valid kubeconfig file that includes the context you want to deploy to
  - The target namespace must already exist in the target context
  - `ENV['GOOGLE_APPLICATION_CREDENTIALS']` must point to the credentials for an authenticated service account if your user's auth provider is GCP
@@ -42,7 +42,7 @@ The following command will restart all pods in the `web` and `jobs` deployments:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. You currently need to [manually install kubectl version 1.5.1 or higher](https://kubernetes.io/docs/user-guide/prereqs/) as well if you don't already have it.
+After checking out the repo, run `bin/setup` to install dependencies. You currently need to [manually install kubectl version 1.6.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) as well if you don't already have it.
 
 To run the tests:
 

--- a/bin/ci
+++ b/bin/ci
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eox pipefail
 
-KUBERNETES_VER=1.5.2
+KUBERNETES_VER=1.6.0
 
 echo "--- Installing dependencies"
 bundle install --jobs 4

--- a/bin/setup
+++ b/bin/setup
@@ -9,8 +9,8 @@ if [ ! -x "$(which minikube)" ]; then
 fi
 
 if [ ! -x "$(which kubectl)" ]; then
-  echo -e "\n\033[0;33mPlease install kubectl version 1.5.1 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
+  echo -e "\n\033[0;33mPlease install kubectl version 1.6.0 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
 else
   KUBECTL_VERSION=$(kubectl version --short --client | grep -oe "v[[:digit:]\.]\+")
-  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.5.1 or greater.\033[0m"
+  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.6.0 or greater.\033[0m"
 fi

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -149,8 +149,8 @@ MSG
     # to make it easier for developer to understand what's going on
     def inspect_kubectl_out_for_files(stderr)
       # Output example:
-      # Error from server (BadRequest): error when creating \"/var/folders/n9/9x7qbcsd4tv2t3xkz3mwsb800000gp/T/configmap-data20170411-33615-gqq5oh.yml20170411-33615-t0t3m\":
-      match = stderr.match(/BadRequest.*"(?<path>\/\S+\.yml\S+)"/)
+      # Error from server (BadRequest): error when creating "/path/to/configmap-gqq5oh.yml20170411-33615-t0t3m":
+      match = stderr.match(%r{BadRequest.*"(?<path>\/\S+\.yml\S+)"})
       return unless match
 
       path = match[:path]

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -149,8 +149,8 @@ MSG
     # to make it easier for developer to understand what's going on
     def inspect_kubectl_out_for_files(stderr)
       # Output example:
-      # error: unable to decode "/tmp/path/to/file": [pos 96]: json: expect char '"' but got char '{'
-      match = stderr.match(/error: unable to decode "(?<path>\S+)":/)
+      # Error from server (BadRequest): error when creating \"/var/folders/n9/9x7qbcsd4tv2t3xkz3mwsb800000gp/T/configmap-data20170411-33615-gqq5oh.yml20170411-33615-t0t3m\":
+      match = stderr.match(/BadRequest.*"(?<path>\/\S+\.yml\S+)"/)
       return unless match
 
       path = match[:path]

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -134,7 +134,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       end
     end
     assert_match(/The following command failed/, err.to_s)
-    assert_match(/error: unable to decode/, err.to_s)
+    assert_match(/Error from server \(BadRequest\): error when creating/, err.to_s)
     assert_logs_match(/Inspecting the file mentioned in the error message/)
   end
 


### PR DESCRIPTION
We're running into errors disabling `automountServiceAccountToken` in the new 1.6.0 PodSpec.

```config/deploy/production/elasticsearch.yml": error validating data: found invalid field automountServiceAccountToken for v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false```

All the clusters are at 1.6 ref https://github.com/Shopify/kubernetes-deploy/pull/76