### PR TITLE
add arbritary binding options

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -11,17 +11,16 @@ allow_protected_ns = false
 prune = true
 bindings = {}
 
-def parse_bindings(binds)
-  binds.each_with_object({}) do |bind, bindings|
-    k,v = bind.split('=')
-    raise "key for value #{v} is blank!" if k.blank?
-    raise "value for key #{k} is blank!" if v.blank?
-    bindings[k] = v
-  end
-end
-
 ARGV.options do |opts|
-  opts.on("--bindings=BINDINGS", Array, "k1=v1,k2=v2") { |binds| bindings = parse_bindings(binds) }
+  opts.on("--bindings=BINDINGS", Array, "k1=v1,k2=v2") do |binds|
+    bindings = binds.each_with_object({}) do |bind, acc|
+      k,v = bind.split('=')
+      raise "key for value #{v} is blank!" if k.blank?
+      raise "value for key #{k} is blank!" if v.blank?
+      acc[k] = v
+    end
+  end
+
   opts.on("--skip-wait") { skip_wait = true }
   opts.on("--allow-protected-ns") { allow_protected_ns = true }
   opts.on("--no-prune") { prune = false }

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -9,7 +9,23 @@ skip_wait = false
 template_dir = nil
 allow_protected_ns = false
 prune = true
+bindings = {}
+
+def blank?(v)
+  !v || v == ""
+end
+
+def parse_bindings(binds)
+  binds.each_with_object({}) do |bind, bindings|
+    k,v = bind.split('=')
+    raise "key for value #{v} is blank!" if blank?(k)
+    raise "value for key #{k} is blank!" if blank?(v)
+    bindings[k] = v
+  end
+end
+
 ARGV.options do |opts|
+  opts.on("--bindings=BINDINGS", Array, "k1=v1,k2=v2") { |binds| bindings = parse_bindings(binds) }
   opts.on("--skip-wait") { skip_wait = true }
   opts.on("--allow-protected-ns") { allow_protected_ns = true }
   opts.on("--no-prune") { prune = false }
@@ -41,6 +57,7 @@ KubernetesDeploy::Runner.with_friendly_errors do
     wait_for_completion: !skip_wait,
     allow_protected_ns: allow_protected_ns,
     prune: prune,
+    bindings: bindings
   )
   runner.run
 end

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -11,15 +11,11 @@ allow_protected_ns = false
 prune = true
 bindings = {}
 
-def blank?(v)
-  !v || v == ""
-end
-
 def parse_bindings(binds)
   binds.each_with_object({}) do |bind, bindings|
     k,v = bind.split('=')
-    raise "key for value #{v} is blank!" if blank?(k)
-    raise "value for key #{k} is blank!" if blank?(v)
+    raise "key for value #{v} is blank!" if k.blank?
+    raise "value for key #{k} is blank!" if v.blank?
     bindings[k] = v
   end
 end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -71,7 +71,7 @@ MSG
     end
 
     def initialize(namespace:, current_sha:, context:, template_dir:,
-      wait_for_completion:, allow_protected_ns: false, prune: true)
+      wait_for_completion:, allow_protected_ns: false, prune: true, bindings: {})
       @namespace = namespace
       @context = context
       @current_sha = current_sha
@@ -81,6 +81,7 @@ MSG
       @wait_for_completion = wait_for_completion
       @allow_protected_ns = allow_protected_ns
       @prune = prune
+      @bindings = bindings
     end
 
     def wait_for_completion?
@@ -123,7 +124,7 @@ MSG
       {
         'current_sha' => @current_sha,
         'deployment_id' => @id,
-      }
+      }.merge(@bindings)
     end
 
     private

--- a/test/fixtures/collection-with-erb/conf_map.yml.erb
+++ b/test/fixtures/collection-with-erb/conf_map.yml.erb
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extra-binding
+  labels:
+    name: extra-binding
+data:
+  BINDING_TEST_A: <%= binding_test_a %>
+  BINDING_TEST_B: <%= binding_test_b %>

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -23,7 +23,7 @@ module FixtureDeployHelper
   #     pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
-  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false, prune: true)
+  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false, prune: true, bindings: {})
     fixtures = load_fixtures(set, subset)
     raise "Cannot deploy empty template set" if fixtures.empty?
 
@@ -31,13 +31,13 @@ module FixtureDeployHelper
 
     target_dir = Dir.mktmpdir
     write_fixtures_to_dir(fixtures, target_dir)
-    deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns, prune: prune)
+    deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns, prune: prune, bindings: bindings)
   ensure
     FileUtils.remove_dir(target_dir) if target_dir
   end
 
-  def deploy_raw_fixtures(set, wait: true)
-    deploy_dir(fixture_path(set), wait: wait)
+  def deploy_raw_fixtures(set, wait: true, bindings: {})
+    deploy_dir(fixture_path(set), wait: wait, bindings: bindings)
   end
 
   def fixture_path(set_name)
@@ -50,7 +50,7 @@ module FixtureDeployHelper
   # Deploys all fixtures in the given directory via KubernetesDeploy::Runner
   # Exposed for direct use only when deploy_fixtures cannot be used because the template cannot be loaded pre-deploy,
   # for example because it contains an intentional syntax error
-  def deploy_dir(dir, sha: 'abcabcabc', wait: true, allow_protected_ns: false, prune: true)
+  def deploy_dir(dir, sha: 'abcabcabc', wait: true, allow_protected_ns: false, prune: true, bindings: {})
     runner = KubernetesDeploy::Runner.new(
       namespace: @namespace,
       current_sha: sha,
@@ -59,6 +59,7 @@ module FixtureDeployHelper
       wait_for_completion: wait,
       allow_protected_ns: allow_protected_ns,
       prune: prune,
+      bindings: bindings
     )
     runner.run
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -204,4 +204,10 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_equal 'binding_test_a', map['BINDING_TEST_A']
     assert_equal 'binding_test_b', map['BINDING_TEST_B']
   end
+
+  def test_should_raise_if_required_binding_not_present
+    assert_raises NameError do
+      deploy_fixtures('collection-with-erb', subset: ["conf_map.yml.erb"])
+    end
+  end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -115,7 +115,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_dynamic_erb_collection_works
-    deploy_raw_fixtures("collection-with-erb")
+    deploy_raw_fixtures("collection-with-erb", bindings: { binding_test_a: 'foo', binding_test_b: 'bar' })
 
     deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace)
     assert_equal 3, deployments.size
@@ -194,5 +194,14 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=hello-cloud')
     assert_equal 1, pods.size, "Unable to find web pod"
     assert_equal "Pending", pods.first.status.phase
+  end
+
+  def test_extra_bindings_should_be_rendered
+    deploy_fixtures('collection-with-erb', subset: ["conf_map.yml.erb"],
+      bindings: { binding_test_a: 'binding_test_a', binding_test_b: 'binding_test_b' })
+
+    map = kubeclient.get_config_map('extra-binding', @namespace).data
+    assert_equal 'binding_test_a', map['BINDING_TEST_A']
+    assert_equal 'binding_test_b', map['BINDING_TEST_B']
   end
 end


### PR DESCRIPTION
## What
I want to allow for two different registry's in core, parameterized by the datacenter.  IE use the the local registry in every case

## How
Expose a way to inject bindings into the script

## Why
So images are fast in both places, and allow for future customization.

## Why not a proper option
I think this is more flexible.