### PR TITLE
Add resource for Bugsnag TPR

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -31,6 +31,7 @@ module KubernetesDeploy
       when 'deployment' then Deployment.new(name, namespace, context, file)
       when 'pod' then Pod.new(name, namespace, context, file)
       when 'redis' then Redis.new(name, namespace, context, file)
+      when 'bugsnag' then Bugsnag.new(name, namespace, context, file)
       when 'ingress' then Ingress.new(name, namespace, context, file)
       when 'persistentvolumeclaim' then PersistentVolumeClaim.new(name, namespace, context, file)
       when 'service' then Service.new(name, namespace, context, file)

--- a/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class Bugsnag < KubernetesResource
+    TIMEOUT = 1.minute
+
+    def initialize(name, namespace, context, file)
+      @name = name
+      @namespace = namespace
+      @context = context
+      @file = file
+      @secret_found = false
+    end
+
+    def sync
+      _, _err, st = run_kubectl("get", type, @name)
+      @found = st.success?
+      if @found
+        secrets, _err, _st = run_kubectl("get", "secrets", "--output=name")
+        @secret_found = secrets.split.any? { |s| s.end_with?("-bugsnag") }
+      end
+      @status = @secret_found ? "Available" : "Unknown"
+      log_status
+    end
+
+    def deploy_succeeded?
+      @secret_found
+    end
+
+    def deploy_failed?
+      false
+    end
+
+    def exists?
+      @found
+    end
+
+    def tpr?
+      true
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -16,6 +16,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   pod
   redis
   service
+  bugsnag
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
 end
@@ -30,6 +31,7 @@ module KubernetesDeploy
     PREDEPLOY_SEQUENCE = %w(
       Cloudsql
       Redis
+      Bugsnag
       ConfigMap
       PersistentVolumeClaim
       Pod


### PR DESCRIPTION
Apps using the Bugsnag TPR are failing to deploy because of a chicken/egg situation with this resource. This PR makes it deploy early and also checks that the corresponding secret is created.

/cc @Shopify/cloudplatform @lyninx 