### PR TITLE
Fix logger

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -11,7 +11,7 @@ module KubernetesDeploy
 
     def self.logger
       @logger ||= begin
-        l = Logger.new($stderr)
+        l = ::Logger.new($stderr)
         l.formatter = proc do |_severity, datetime, _progname, msg|
           "[KUBESTATUS][#{datetime}]\t#{msg}\n"
         end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -121,7 +121,7 @@ module KubernetesDeploy
       raise FatalDeploymentError, "Namespace missing for namespaced command" if @namespace.blank?
       raise KubectlError, "Explicit context is required to run this command" if @context.blank?
 
-      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context)
+      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context, log_failure: false)
     end
   end
 end

--- a/lib/kubernetes-deploy/logger.rb
+++ b/lib/kubernetes-deploy/logger.rb
@@ -32,12 +32,12 @@ module KubernetesDeploy
       private
 
       def level_from_env
-        return Logger::DEBUG if ENV["DEBUG"]
+        return ::Logger::DEBUG if ENV["DEBUG"]
 
         if ENV["LEVEL"]
-          Logger.const_get(ENV["LEVEL"].upcase)
+          ::Logger.const_get(ENV["LEVEL"].upcase)
         else
-          Logger::INFO
+          ::Logger::INFO
         end
       end
     end

--- a/test/unit/kubernetes-deploy/logger_test.rb
+++ b/test/unit/kubernetes-deploy/logger_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class LoggerTest < KubernetesDeploy::TestCase
+  def setup
+    # don't use the test logger
+    KubernetesDeploy.logger = nil
+  end
+
+  def teardown
+    # reset to the test logger
+    KubernetesDeploy.logger = @logger
+  end
+
+  def test_real_logger
+    prod_logger = KubernetesDeploy.logger
+    assert prod_logger.is_a?(::Logger)
+    assert prod_logger.instance_variable_get(:@logdev).dev == ::STDERR, "This was not the actual production logger"
+    assert_equal ::Logger::INFO, prod_logger.level
+    refute_nil prod_logger.formatter
+  end
+
+  def test_debug_log_level_from_env
+    original_env = ENV["DEBUG"]
+    ENV["DEBUG"] = "lol"
+    prod_logger = KubernetesDeploy.logger
+    assert_equal ::Logger::DEBUG, prod_logger.level
+  ensure
+    ENV["DEBUG"] = original_env
+  end
+
+  def test_warn_log_level_from_env
+    original_env = ENV["LEVEL"]
+    ENV["LEVEL"] = "warn"
+    prod_logger = KubernetesDeploy.logger
+    assert_equal ::Logger::WARN, prod_logger.level
+  ensure
+    ENV["LEVEL"] = original_env
+  end
+end


### PR DESCRIPTION
Master is silently broken because of problems with the logger changes that were not caught by the test suite because it swaps the real logger for one that does not log to stderr. Example error as reproduced in my regression tests: 
```
NameError: uninitialized constant KubernetesDeploy::Logger::INFO
Did you mean?  TZInfo
    /Users/KnVerey/Github/kubernetes-deploy/lib/kubernetes-deploy/logger.rb:40:in `level_from_env'
    /Users/KnVerey/Github/kubernetes-deploy/lib/kubernetes-deploy/logger.rb:18:in `logger'
    test/unit/kubernetes-deploy/logger_test.rb:16:in `test_real_logger'
```

Also adds `log_failure: false` to the KubernetesResource version of `run_kubectl`. That option exists for the purposes of that class, but it wasn't actually used! As a result, confusing errors would get logged during the initial deploy of any resource.