### PR TITLE
Create kubernetes secrets from ejson

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
+gem 'pry-byebug'
 gem 'rubocop'
 gem 'timecop'
 gem 'byebug'

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -23,10 +23,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "kubeclient", "~> 2.3"
   spec.add_dependency "googleauth", ">= 0.5"
+  spec.add_dependency "ejson", "1.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.add_development_dependency "webmock", "~> 3.0"
+  spec.add_development_dependency "mocha", "~> 1.1"
 end

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -4,18 +4,12 @@ require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/hash/keys'
 
+require 'kubernetes-deploy/errors'
 require 'kubernetes-deploy/logger'
 require 'kubernetes-deploy/runner'
 
 module KubernetesDeploy
-  class FatalDeploymentError < StandardError; end
-
-  class NamespaceNotFoundError < FatalDeploymentError
-    def initialize(name, context)
-      super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
-    end
-  end
-
   include Logger
 end

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+require 'json'
+require 'base64'
+require 'open3'
+require 'kubernetes-deploy/logger'
+
+module KubernetesDeploy
+  class EjsonSecretError < FatalDeploymentError
+    def initialize(msg)
+      super("Creation of Kubernetes secrets from ejson failed: #{msg}")
+    end
+  end
+
+  class EjsonSecretProvisioner
+    MANAGEMENT_ANNOTATION = "kubernetes-deploy.shopify.io/ejson-secret"
+    MANAGED_SECRET_EJSON_KEY = "kubernetes_secrets"
+    EJSON_SECRETS_FILE = "secrets.ejson"
+    EJSON_KEYS_SECRET = "ejson-keys"
+
+    def initialize(namespace:, template_dir:, client:)
+      @namespace = namespace
+      @ejson_file = "#{template_dir}/#{EJSON_SECRETS_FILE}"
+      @kubeclient = client
+    end
+
+    def secret_changes_required?
+      File.exist?(@ejson_file) || managed_secrets_exist?
+    end
+
+    def run
+      create_secrets
+      prune_managed_secrets
+    end
+
+    private
+
+    def create_secrets
+      with_decrypted_ejson do |decrypted|
+        secrets = decrypted[MANAGED_SECRET_EJSON_KEY]
+        unless secrets.present?
+          KubernetesDeploy.logger.warn("#{EJSON_SECRETS_FILE} does not have key #{MANAGED_SECRET_EJSON_KEY}."\
+            "No secrets will be created.")
+          return
+        end
+
+        secrets.each do |secret_name, secret_spec|
+          validate_secret_spec(secret_name, secret_spec)
+          create_or_update_secret(secret_name, secret_spec["_type"], secret_spec["data"])
+        end
+      end
+    end
+
+    def prune_managed_secrets
+      ejson_secret_names = encrypted_ejson.fetch(MANAGED_SECRET_EJSON_KEY, {}).keys
+      live_secrets = @kubeclient.get_secrets(namespace: @namespace)
+
+      live_secrets.each do |secret|
+        secret_name = secret.metadata.name
+        next unless secret_managed?(secret)
+        next if ejson_secret_names.include?(secret_name)
+
+        KubernetesDeploy.logger.info("Pruning secret #{secret_name}")
+        @kubeclient.delete_secret(secret_name, @namespace)
+      end
+    end
+
+    def managed_secrets_exist?
+      all_secrets = @kubeclient.get_secrets(namespace: @namespace)
+      all_secrets.any? { |secret| secret_managed?(secret) }
+    end
+
+    def secret_managed?(secret)
+      secret.metadata.annotations.to_h.stringify_keys.key?(MANAGEMENT_ANNOTATION)
+    end
+
+    def encrypted_ejson
+      @encrypted_ejson ||= load_ejson_from_file
+    end
+
+    def public_key
+      encrypted_ejson["_public_key"]
+    end
+
+    def private_key
+      @private_key ||= fetch_private_key_from_secret
+    end
+
+    def validate_secret_spec(secret_name, spec)
+      errors = []
+      errors << "secret type unspecified" if spec["_type"].blank?
+      errors << "no data provided" if spec["data"].blank?
+
+      unless errors.empty?
+        raise EjsonSecretError, "Ejson incomplete for secret #{secret_name}: #{errors.join(', ')}"
+      end
+    end
+
+    def create_or_update_secret(secret_name, secret_type, data)
+      metadata = {
+        name: secret_name,
+        labels: { "name" => secret_name },
+        namespace: @namespace,
+        annotations: { MANAGEMENT_ANNOTATION => "true" }
+      }
+      secret = Kubeclient::Secret.new(type: secret_type, stringData: data, metadata: metadata)
+      if secret_exists?(secret)
+        KubernetesDeploy.logger.info("Updating secret #{secret_name}")
+        @kubeclient.update_secret(secret)
+      else
+        KubernetesDeploy.logger.info("Creating secret #{secret_name}")
+        @kubeclient.create_secret(secret)
+      end
+    rescue KubeException => e
+      raise unless e.error_code == 400
+      raise EjsonSecretError, "Data for secret #{secret_name} was invalid: #{e}"
+    end
+
+    def secret_exists?(secret)
+      @kubeclient.get_secret(secret.metadata.name, @namespace)
+      true
+    rescue KubeException => error
+      raise unless error.error_code == 404
+      false
+    end
+
+    def load_ejson_from_file
+      return {} unless File.exist?(@ejson_file)
+      JSON.parse(File.read(@ejson_file))
+    rescue JSON::ParserError => e
+      raise EjsonSecretError, "Failed to parse encrypted ejson:\n  #{e}"
+    end
+
+    def with_decrypted_ejson
+      return unless File.exist?(@ejson_file)
+
+      Dir.mktmpdir("ejson_keydir") do |key_dir|
+        File.write(File.join(key_dir, public_key), private_key)
+        decrypted = decrypt_ejson(key_dir)
+        yield decrypted
+      end
+    end
+
+    def decrypt_ejson(key_dir)
+      KubernetesDeploy.logger.info("Decrypting #{EJSON_SECRETS_FILE}")
+      # ejson seems to dump both errors and output to STDOUT
+      out_err, st = Open3.capture2e("EJSON_KEYDIR=#{key_dir} ejson decrypt #{@ejson_file}")
+      raise EjsonSecretError, out_err unless st.success?
+      JSON.parse(out_err)
+    rescue JSON::ParserError => e
+      raise EjsonSecretError, "Failed to parse decrypted ejson:\n  #{e}"
+    end
+
+    def fetch_private_key_from_secret
+      KubernetesDeploy.logger.info("Fetching ejson private key from secret #{EJSON_KEYS_SECRET}")
+      secret = @kubeclient.get_secret(EJSON_KEYS_SECRET, @namespace)
+      encoded_private_key = secret["data"][public_key]
+      unless encoded_private_key
+        raise EjsonSecretError, "Private key for #{public_key} not found in #{EJSON_KEYS_SECRET} secret"
+      end
+
+      Base64.decode64(encoded_private_key)
+    rescue KubeException => error
+      raise unless error.error_code == 404
+      secret_missing_err = "Failed to decrypt ejson: secret #{EJSON_KEYS_SECRET} not found in namespace #{@namespace}."
+      raise EjsonSecretError, secret_missing_err
+    end
+  end
+end

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class FatalDeploymentError < StandardError; end
+
+  class NamespaceNotFoundError < FatalDeploymentError
+    def initialize(name, context)
+      super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -39,6 +39,7 @@ module KubernetesDeploy
     PROTECTED_NAMESPACES = %w(
       default
       kube-system
+      kube-public
     )
 
     # Things removed from default prune whitelist:

--- a/test/fixtures/ejson-cloud/secrets.ejson
+++ b/test/fixtures/ejson-cloud/secrets.ejson
@@ -1,0 +1,21 @@
+{
+  "_public_key": "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a",
+  "kubernetes_secrets": {
+    "catphotoscom": {
+      "_type": "kubernetes.io/tls",
+      "data": {
+        "tls.crt": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:Z3AW84E4MTa3ntO9jHqVAFy3cpDVF3tC:BpMYh76OGkBIi0BKlFG1gZnkSGGCmwLUX5Fk+BkUCn0mN/X5Nrvs]",
+        "tls.key": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:W9F16TEKrtF1rdXaBaRv6bX7uIOB0SJi:O6kgaj5mly05JXjFt10eo6sj6ZBNzvNxQrPBBQ1i0g==]"}
+    },
+    "unused-secret": {
+      "_type": "Opaque",
+      "data": {
+        "this-is-for-testing-deletion": "EJ[1:a5fxfJdMJhKrMOLenuSdEZSbNbc2AiyZsnZq4lZZXDU=:TVP663l51tRU2aT4nrsQgUAINTdnV+e0:WjPz3MhugxaNmt5biQgetCOcwMk=]"}
+    },
+    "monitoring-token": {
+      "_type": "Opaque",
+      "data": {
+        "api-token": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:yiXxO6D4W5/wtYNoOoxzllkTrw+XZ8Bx:gXL/hMM2JNlTJ1stmrHCGXQqWsELg5j9i5Mfmlz7ww21p2mUfQ==]"}
+    }
+  }
+}

--- a/test/fixtures/ejson-cloud/web.yml
+++ b/test/fixtures/ejson-cloud/web.yml
@@ -1,0 +1,37 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: web
+        app: ejson-cloud
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+          name: http
+        volumeMounts:
+        - mountPath: /keys
+          name: ejson-keys
+        - mountPath: /server-cert
+          name: server-cert
+        env:
+        - name: MONITORING_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: monitoring-token
+              key: api-token
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: catphotoscom
+      - name: ejson-keys
+        secret:
+          secretName: ejson-keys

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module FixtureSetAssertions
+  class EjsonCloud < FixtureSet
+    def initialize(namespace)
+      @namespace = namespace
+      @app_name = "ejson-cloud"
+    end
+
+    def assert_all_up
+      assert_all_secrets_present
+      assert_web_resources_up
+    end
+
+    def create_ejson_keys_secret
+      metadata = {
+        name: 'ejson-keys',
+        namespace: namespace,
+        labels: { name: 'ejson-keys' }
+      }
+      encoded_data = {
+        "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a" =>
+          "ZmVkY2M5NTEzMmU5YjM5OWVlMWY0MDQzNjRmZGJjODFiZGJlNGZlYjViODI5MmIwNjFmMTAyMjQ4MTE1N2Q1YQ=="
+      }
+      secret = Kubeclient::Secret.new(type: 'Opaque', metadata: metadata, data: encoded_data)
+      kubeclient.create_secret(secret)
+    end
+
+    def assert_all_secrets_present
+      assert_secret_present("ejson-keys")
+      cert_data = { "tls.crt" => "this-is-the-certificate", "tls.key" => "this-is-the-key" }
+      assert_secret_present("catphotoscom", cert_data, type: "kubernetes.io/tls", managed: true)
+      assert_secret_present("monitoring-token", { "api-token" => "this-is-the-api-token" }, managed: true)
+      assert_secret_present("unused-secret", { "this-is-for-testing-deletion" => "true" }, managed: true)
+    end
+
+    def assert_web_resources_up
+      assert_pod_status("web", "Running")
+      assert_deployment_up("web", replicas: 1)
+    end
+  end
+end

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
+  def test_secret_changes_required_based_on_ejson_file_existence
+    mock_kubeclient.expects(:get_secrets).with(namespace: 'test').returns([])
+    refute build_provisioner(fixture_path('hello-cloud')).secret_changes_required?
+    assert build_provisioner(fixture_path('ejson-cloud')).secret_changes_required?
+  end
+
+  def test_secret_changes_required_based_on_managed_secret_existence
+    metadata = {
+      annotations: { KubernetesDeploy::EjsonSecretProvisioner::MANAGEMENT_ANNOTATION => "true" },
+      name: 'foo'
+    }
+    managed_secret = Kubeclient::Secret.new(type: 'Opaque', metadata: metadata)
+    mock_kubeclient.expects(:get_secrets).with(namespace: 'test').returns([managed_secret])
+    assert build_provisioner(fixture_path('hello-cloud')).secret_changes_required?
+  end
+
+  def test_run_with_no_secrets_file_or_managed_secrets_no_ops
+    # nothing raised, no unexpected kubeclient calls
+    mock_kubeclient.expects(:get_secrets).with(namespace: 'test').returns([])
+    build_provisioner(fixture_path('hello-cloud')).run
+  end
+
+  def test_run_with_secrets_file_invalid_json
+    assert_raises_message(KubernetesDeploy::EjsonSecretError, /Failed to parse encrypted ejson/) do
+      with_ejson_file("}") do |target_dir|
+        build_provisioner(target_dir).run
+      end
+    end
+  end
+
+  def test_run_with_ejson_keypair_mismatch
+    wrong_data = {
+      "2200e55f22dd0c93fac3832ba14842cc75fa5a99a2e01696daa30e188d465036" =>
+        "MTM5ZDVjMmEzMDkwMWRkOGFlMTg2YmU1ODJjY2MwYTg4MmMxNmY4ZTBiYjU0Mjk4ODRkYmM3Mjk2ZTgwNjY5ZQo="
+    }
+    mock_kubeclient.expects(:get_secret).with('ejson-keys', 'test').returns("data" => wrong_data)
+
+    msg = "Private key for 65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a not found"
+    assert_raises_message(KubernetesDeploy::EjsonSecretError, msg) do
+      build_provisioner.run
+    end
+  end
+
+  def test_run_with_bad_private_key_in_cloud_keys
+    wrong_private = {
+      "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a" =>
+        "MTM5ZDVjMmEzMDkwMWRkOGFlMTg2YmU1ODJjY2MwYTg4MmMxNmY4ZTBiYjU0Mjk4ODRkYmM3Mjk2ZTgwNjY5ZQo="
+    }
+    mock_kubeclient.expects(:get_secret).with('ejson-keys', 'test').returns("data" => wrong_private)
+    assert_raises_message(KubernetesDeploy::EjsonSecretError, /Decryption failed/) do
+      build_provisioner.run
+    end
+  end
+
+  def test_run_with_cloud_keys_secret_missing
+    mock_kubeclient.expects(:get_secret).with('ejson-keys', 'test').raises(KubeException.new(404, "not found", nil))
+    assert_raises_message(KubernetesDeploy::EjsonSecretError, /secret ejson-keys not found in namespace test/) do
+      build_provisioner.run
+    end
+  end
+
+  def test_run_with_file_missing_section_for_managed_secrets_logs_warning
+    mock_kubeclient.expects(:get_secret).with('ejson-keys', 'test').returns("data" => correct_ejson_key_secret_data)
+    mock_kubeclient.expects(:get_secrets).with(namespace: 'test').returns([])
+    new_content = { "_public_key" => fixture_public_key, "not_the_right_key" => [] }
+
+    with_ejson_file(new_content.to_json) do |target_dir|
+      build_provisioner(target_dir).run
+    end
+    assert_logs_match("No secrets will be created.")
+  end
+
+  def test_run_with_incomplete_secret_spec
+    mock_kubeclient.expects(:get_secret).with('ejson-keys', 'test').returns("data" => correct_ejson_key_secret_data)
+    new_content = {
+      "_public_key" => fixture_public_key,
+      "kubernetes_secrets" => { "foobar" => {} }
+    }
+
+    msg = "Ejson incomplete for secret foobar: secret type unspecified, no data provided"
+    assert_raises_message(KubernetesDeploy::EjsonSecretError, msg) do
+      with_ejson_file(new_content.to_json) do |target_dir|
+        build_provisioner(target_dir).run
+      end
+    end
+  end
+
+  private
+
+  def correct_ejson_key_secret_data
+    {
+      fixture_public_key => "ZmVkY2M5NTEzMmU5YjM5OWVlMWY0MDQzNjRmZGJjODFiZGJlNGZlYjViODI5MmIwNjFmMTAyMjQ4MTE1N2Q1YQ=="
+    }
+  end
+
+  def fixture_public_key
+    "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a"
+  end
+
+  def with_ejson_file(content)
+    Dir.mktmpdir do |target_dir|
+      File.write(File.join(target_dir, KubernetesDeploy::EjsonSecretProvisioner::EJSON_SECRETS_FILE), content)
+      yield target_dir
+    end
+  end
+
+  def mock_kubeclient
+    @mock_kubeclient ||= mock('kubeclient')
+  end
+
+  def build_provisioner(dir = nil)
+    dir ||= fixture_path('ejson-cloud')
+    KubernetesDeploy::EjsonSecretProvisioner.new(
+      namespace: 'test',
+      template_dir: dir,
+      client: mock_kubeclient
+    )
+  end
+end


### PR DESCRIPTION
@Shopify/cloudplatform @kirs @sirupsen 

This PR makes it possible to create kubernetes secrets during deploys by committing a conventionally named (`secrets.kubernetes-deploy.ejson`) ejson file with a `kubernetes_secrets` key to your deploy directory, alongside your k8s yamls. There is [an example in the fixtures](https://github.com/Shopify/kubernetes-deploy/blob/970cff87e0f9b1ec5bcb6a8e92aada6dff565498/test/fixtures/ejson-cloud/secrets.kubernetes-deploy.ejson). In case this isn't obvious, you can't commit k8s secret yamls to your repo because the data is merely base64-encoded.

The secrets created in this manner are annotated so that they can be pruned by future deploys if they are removed from the ejson.

**This is not meant to replace app ejson**. If it is practical for an app to consume ejson itself, it should do that directly rather than adding k8s secrets into the mix. The primary Shopify uses cases for this feature are:
- App-specific TLS secrets that _must_ be k8s secrets to be consumed by an ingress
- Secrets an app needs to mount as a volume 
- Secrets that a third-party container (e.g. things in our cluster services repo) needs in its environment
- Secrets that app maintainers are providing to an admin-maintained container (e.g. our oauth proxy)

With this feature in place, all k8s secrets can live on the repo of the app they belong to, and there will be no reason (that I've thought of... lmk if I'm missing something) to deploy any by hand / with Klusterify.

Todo:
- [x] Appease Policial
- [x] Fix the tests
- [x] Add this feature to the readme
- [x] Add this feature to the cloud docs
- [x] Run CI on latest commit (buildkite.com/shopify/kubernetes-deploy-gem)