### PR TITLE
Fix assertions on exception messages

### DIFF
--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -56,7 +56,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace .* pruning enabled/) do
+    expected_msg = /Refusing to deploy to protected namespace .* pruning enabled/
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
         deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true)
       end
@@ -161,7 +162,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_bad_container_image_on_run_once_halts_and_fails_deploy
-    expected_msg = /The following priority resources failed to deploy: Pod\/unmanaged-pod/
+    expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
     assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
@@ -178,7 +179,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_wait_false_still_waits_for_priority_resources
-    expected_msg = /The following priority resources failed to deploy: Pod\/unmanaged-pod/
+    expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
     assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -56,7 +56,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace with pruning/) do
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace .* pruning enabled/) do
       KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
         deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true)
       end
@@ -64,7 +64,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_refuses_deploy_to_protected_namespace_without_override
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace/) do
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace/) do
       KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
         deploy_fixtures("hello-cloud", prune: false)
       end
@@ -99,13 +99,13 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_invalid_yaml_fails_fast
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /Template \S+yaml-error\S+ cannot be parsed/) do
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Template yaml-error.yml cannot be parsed/) do
       deploy_dir(fixture_path("invalid"))
     end
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
       deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
         configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
         configmap["metadata"]["myKey"] = "uhOh"
@@ -133,7 +133,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
         }
       end
     end
-    assert_match(/The following command failed/, err.to_s)
+    assert_match(/The following command failed: apply/, err.to_s)
     assert_match(/Error from server \(BadRequest\): error when creating/, err.to_s)
     assert_logs_match(/Inspecting the file mentioned in the error message/)
   end
@@ -161,7 +161,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_bad_container_image_on_run_once_halts_and_fails_deploy
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /1 priority resources failed to deploy/) do
+    expected_msg = /The following priority resources failed to deploy: Pod\/unmanaged-pod/
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
         pod["spec"]["activeDeadlineSeconds"] = 1
@@ -177,7 +178,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_wait_false_still_waits_for_priority_resources
-    assert_raises(KubernetesDeploy::FatalDeploymentError, /1 priority resources failed to deploy/) do
+    expected_msg = /The following priority resources failed to deploy: Pod\/unmanaged-pod/
+    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
         pod["spec"]["activeDeadlineSeconds"] = 1

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -57,7 +57,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
     expected_msg = /Refusing to deploy to protected namespace .* pruning enabled/
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
         deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true)
       end
@@ -65,7 +65,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_refuses_deploy_to_protected_namespace_without_override
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace/) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace/) do
       KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
         deploy_fixtures("hello-cloud", prune: false)
       end
@@ -100,13 +100,13 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_invalid_yaml_fails_fast
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Template yaml-error.yml cannot be parsed/) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Template yaml-error.yml cannot be parsed/) do
       deploy_dir(fixture_path("invalid"))
     end
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
       deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
         configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
         configmap["metadata"]["myKey"] = "uhOh"
@@ -163,7 +163,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
   def test_bad_container_image_on_run_once_halts_and_fails_deploy
     expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
         pod["spec"]["activeDeadlineSeconds"] = 1
@@ -180,7 +180,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
   def test_wait_false_still_waits_for_priority_resources
     expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
-    assert_raises_msg(KubernetesDeploy::FatalDeploymentError, expected_msg) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
       deploy_fixtures("hello-cloud") do |fixtures|
         pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
         pod["spec"]["activeDeadlineSeconds"] = 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,8 @@ module KubernetesDeploy
     def assert_raises(*args)
       case args.last
       when Regexp, String
-        flunk("Please use assert_raises_msg to check the exception message. That is not what the last argument of assert_raises does.")
+        flunk("Please use assert_raises_msg to check the exception message.\n"\
+          "That is not what the last argument of assert_raises does.")
       else
         orig_assert_raises(*args) { yield }
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,22 @@ module KubernetesDeploy
         assert_match regexp, @logger_stream.read
       end
     end
+
+    alias_method :orig_assert_raises, :assert_raises
+    def assert_raises(*args)
+      case args.last
+      when Regexp, String
+        flunk("Please use assert_raises_msg to check the exception message. That is not what the last argument of assert_raises does.")
+      else
+        orig_assert_raises(*args) { yield }
+      end
+    end
+
+    def assert_raises_msg(exception_class, exception_message)
+      exception = orig_assert_raises(exception_class) { yield }
+      assert_match exception_message, exception.message
+      exception
+    end
   end
 
   class IntegrationTest < KubernetesDeploy::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,14 +39,14 @@ module KubernetesDeploy
     end
 
     alias_method :orig_assert_raises, :assert_raises
-    def assert_raises(*args, msg: nil)
-      case args.last
-      when Regexp, String
-        flunk("Please use assert_raises_msg to check the exception message,\n"\
-          "or use the msg keyword argument to specify a message to use when the assertion fails.")
+    def assert_raises(*exp, message: nil)
+      case exp.last
+      when String, Regexp
+        raise ArgumentError, "Please use the kwarg message instead of the positional one.\n"\
+          "To assert the message exception, use `assert_raises_msg` or the return value of `assert_raises`"
       else
-        args_for_orig = (args + Array(msg)).compact
-        orig_assert_raises(*args_for_orig) { yield }
+        exp += Array(message)
+        orig_assert_raises(*exp) { yield }
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,14 +43,14 @@ module KubernetesDeploy
       case exp.last
       when String, Regexp
         raise ArgumentError, "Please use the kwarg message instead of the positional one.\n"\
-          "To assert the message exception, use `assert_raises_msg` or the return value of `assert_raises`"
+          "To assert the message exception, use `assert_raises_message` or the return value of `assert_raises`"
       else
         exp += Array(message)
         orig_assert_raises(*exp) { yield }
       end
     end
 
-    def assert_raises_msg(exception_class, exception_message)
+    def assert_raises_message(exception_class, exception_message)
       exception = orig_assert_raises(exception_class) { yield }
       assert_match exception_message, exception.message
       exception

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,13 +39,14 @@ module KubernetesDeploy
     end
 
     alias_method :orig_assert_raises, :assert_raises
-    def assert_raises(*args)
+    def assert_raises(*args, msg: nil)
       case args.last
       when Regexp, String
-        flunk("Please use assert_raises_msg to check the exception message.\n"\
-          "That is not what the last argument of assert_raises does.")
+        flunk("Please use assert_raises_msg to check the exception message,\n"\
+          "or use the msg keyword argument to specify a message to use when the assertion fails.")
       else
-        orig_assert_raises(*args) { yield }
+        args_for_orig = (args + Array(msg)).compact
+        orig_assert_raises(*args_for_orig) { yield }
       end
     end
 

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 
 class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_requires_enumerable
-    err = assert_raises(ArgumentError) do
+    expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
+    assert_raises_msg(ArgumentError, expected_msg) do
       KubernetesDeploy::ResourceWatcher.new(Object.new)
     end
-    assert_equal "ResourceWatcher expects Enumerable collection, got `Object` instead", err.to_s
 
     KubernetesDeploy::ResourceWatcher.new([])
   end

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_requires_enumerable
     expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
-    assert_raises_msg(ArgumentError, expected_msg) do
+    assert_raises_message(ArgumentError, expected_msg) do
       KubernetesDeploy::ResourceWatcher.new(Object.new)
     end
 


### PR DESCRIPTION
I realized while working on a feature on this repo that we've been misusing `assert_raises`. We have a bunch of tests that assume the second arg will be asserted as the error message, whereas it is in fact just used as the assertion failure message. I wrote most of these mistakes myself, but I don't think I'm the only one with the misimpression (it was actually [originally suggested to me by a reviewer](https://github.com/Shopify/kubernetes-deploy/pull/24#discussion_r102931248)). This PR fixes the misuse, introduces a helper with the desired behaviour, and tries to prevent future confusion.