### PR TITLE
Test long-running pods together with revisionHistoryLimit

### DIFF
--- a/test/fixtures/long-running/jobs.yml.erb
+++ b/test/fixtures/long-running/jobs.yml.erb
@@ -4,6 +4,7 @@ metadata:
   name: jobs
 spec:
   replicas: 2
+  revisionHistoryLimit: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Adding `revisionHistoryLimit=1` to the long-running deployment fixture to make sure that it doesn't conflict with multiple revisions in the terminating state.

cc @ibawt 