### PR TITLE
Add "all" as an option to restart all deployments

### DIFF
--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -45,6 +45,11 @@ module KubernetesDeploy
         raise ArgumentError, "#perform takes at least one deployment to restart"
       end
 
+      if deployments_names == "all"
+        deployments_names = @v1beta1_kubeclient.get_deployments(namespace: @namespace).map { |d| d.metadata.name }
+        raise ArgumentError, "no deployments found in namespace #{@namespace}" if deployments_names.none?
+      end
+
       phase_heading("Triggering restart by touching ENV[RESTARTED_AT]")
       deployments = fetch_deployments(deployments_names.uniq)
       patch_kubeclient_deployments(deployments)
@@ -53,7 +58,7 @@ module KubernetesDeploy
       wait_for_rollout(deployments)
 
       names = deployments.map { |d| "`#{d.metadata.name}`" }
-      @logger.info "Restart of #{names.join(', ')} deployments succeeded"
+      @logger.info "Restart of #{names.sort.join(', ')} deployments succeeded"
     end
 
     private


### PR DESCRIPTION
I'm working on adding support for restarting deployments from the Shipit UI, and I think it would be useful to have an option to restart all of them (for instance web, jobs and redis).
