### PR TITLE
Restart deployments with annotation

### DIFF
--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -8,16 +8,11 @@ require 'kubernetes-deploy/restart_task'
 
 raw_deployments = nil
 ARGV.options do |opts|
-  opts.on("--deployments=LIST") { |v| raw_deployments = v }
+  opts.on("--deployments=LIST") { |v| raw_deployments = v.split(",") }
   opts.parse!
-end
-
-if raw_deployments.nil?
-  puts "Failed: specify at least one deployment to restart with --deployments flag"
-  exit 1
 end
 
 KubernetesDeploy::Runner.with_friendly_errors do
   restart = KubernetesDeploy::RestartTask.new(namespace: ARGV[0], context: ARGV[1])
-  restart.perform(raw_deployments.split(","))
+  restart.perform(raw_deployments)
 end

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -34,6 +34,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: web
+  annotations:
+    shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
This is alternative to https://github.com/Shopify/kubernetes-deploy/pull/86

The problem: we want to have the magic restart button in Shipit but the app may have many deployments (web, jobs, redis, memcache) and it's not safe to restart all of them. We need a way to determine app deployments (web & jobs) that are safe to restart.

When I discussed it with @ibawt he had an idea of matching the container and app names. For instance to restart the `hackdays` app, we would fetch all deployments and see which of them have `hackdays` substring in the container address.

This is somewhat fuzzy and won't work for apps with generic name like "shopify". I suggest that we use special annotation to tell Shipit if the deployment is safe to restart.

cc @Shopify/cloudplatform 