### PR TITLE
Use kubectl in EjsonSecretProvisioner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,4 @@ inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.1

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class FatalDeploymentError < StandardError; end
+  class KubectlError < StandardError; end
 
   class NamespaceNotFoundError < FatalDeploymentError
     def initialize(name, context)

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -113,11 +113,7 @@ MSG
       phase_heading("Checking initial resource statuses")
       resources.each(&:sync)
 
-      ejson = EjsonSecretProvisioner.new(
-        namespace: @namespace,
-        template_dir: @template_dir,
-        client: build_v1_kubeclient(@context)
-      )
+      ejson = EjsonSecretProvisioner.new(namespace: @namespace, context: @context, template_dir: @template_dir)
       if ejson.secret_changes_required?
         phase_heading("Deploying kubernetes secrets from #{EjsonSecretProvisioner::EJSON_SECRETS_FILE}")
         ejson.run


### PR DESCRIPTION
tl;dr `kubeclient` isn't working for some of our production clusters, so this switches `EjsonSecretProvisioner` over to `kubectl`--which is what the rest of the deploy process uses--for the time being. 

---

When I rolled out https://github.com/Shopify/kubernetes-deploy/pull/81 in shipit, I discovered that kubeclient does not seem to be working with our GCP clusters. It is failing with an SSL error on `client.discover` ([see this deploy](https://shipit.shopify.io/shopify/hackdays-gke-rails5/production/deploys/445001)). This may be a further piece to the work @xldenis already did in https://github.com/Shopify/kubernetes-deploy/pull/88; he is investigating.

The most meaningful change is that we need to write a tempfile to use `kubectl apply` for secret creation/update. Note that although the unit tests required surgery, the integration tests all passed as-is.

**Why not wait for the kubeclient fix?** 
The current consensus is still that we want to use a gem rather than kubectl for everything we can (which doesn't include "apply" operations) in the long run, but I didn't realize that none of the tasks that already use kubeclient had been tested in our production Shipit environment. This feature is high-priority, and switching to kubeclient is far from it. With the problems we've had, we may even want to reconsider this particular gem choice.

cc @Shopify/cloudplatform 