### PR TITLE
Don't log command failures in EjsonSecretProvisioner

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -193,7 +193,7 @@ module KubernetesDeploy
     end
 
     def run_kubectl(*args)
-      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context)
+      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context, log_failure: false)
     end
   end
 end

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -117,7 +117,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def stub_kubectl_response(*args, resp:, err: "", success: true)
     response = [resp.to_json, err, stub(success?: success)]
     KubernetesDeploy::Kubectl.expects(:run_kubectl)
-      .with(*args, namespace: 'test', context: 'minikube')
+      .with(*args, namespace: 'test', context: 'minikube', log_failure: false)
       .returns(response)
   end
 


### PR DESCRIPTION
In all cases other than `secret_exists?`, we already raise an error with the stderr text if the command fails, making the failure logging redundant. And for `secret_exists?` we don't want to log an error on failure, because the failure is very likely 404. Here's an example of the useless warning this gets rid of:

![image](https://cloud.githubusercontent.com/assets/4789493/25869039/e2cba97c-34cc-11e7-954c-8e4b87ad853b.png)
