### PR TITLE
Strip leading underscores from ejson keys in secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ Since their data is only base64 encoded, Kubernetes secrets should not be commit
 6. Encrypt the file: `ejson encrypt /PATH/TO/secrets.ejson`
 7. Commit the encrypted file and deploy as usual. The deploy will create secrets from the data in the `kubernetes_secrets` key.
 
+**Note**: Since leading underscores in ejson keys are used to skip encryption of the associated value, `kubernetes-deploy` will strip these leading underscores when it creates the keys for the Kubernetes secret data. For example, given the ejson data below, the `monitoring-token` secret will have keys `api-token` and `property` (_not_ `_property`):
+```json
+{
+  "_public_key": "YOUR_PUBLIC_KEY",
+  "kubernetes_secrets": {
+    "monitoring-token": {
+      "_type": "kubernetes.io/tls",
+      "data": {
+        "api-token": "EJ[ENCRYPTED]",
+        "_property": "some unencrypted value"
+      }
+    }
+  }
+```
+
 ### Running one off tasks
 
 To trigger a one-off job such as a rake task _outside_ of a deploy, use the following command:

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -122,7 +122,10 @@ module KubernetesDeploy
         raise EjsonSecretError, "Data for secret #{secret_name} was invalid. Only key-value pairs are permitted."
       end
       encoded_data = data.each_with_object({}) do |(key, value), encoded|
-        encoded[key] = Base64.encode64(value)
+        # Leading underscores in ejson keys are used to skip encryption of the associated value
+        # To support this ejson feature, we need to exclude these leading underscores from the secret's keys
+        secret_key = key.sub(/\A_/, '')
+        encoded[secret_key] = Base64.encode64(value)
       end
 
       secret = {

--- a/test/fixtures/ejson-cloud/secrets.ejson
+++ b/test/fixtures/ejson-cloud/secrets.ejson
@@ -15,7 +15,9 @@
     "monitoring-token": {
       "_type": "Opaque",
       "data": {
-        "api-token": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:yiXxO6D4W5/wtYNoOoxzllkTrw+XZ8Bx:gXL/hMM2JNlTJ1stmrHCGXQqWsELg5j9i5Mfmlz7ww21p2mUfQ==]"}
+        "api-token": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:yiXxO6D4W5/wtYNoOoxzllkTrw+XZ8Bx:gXL/hMM2JNlTJ1stmrHCGXQqWsELg5j9i5Mfmlz7ww21p2mUfQ==]",
+        "_service": "Datadog"
+      }
     }
   }
 }

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -29,7 +29,10 @@ module FixtureSetAssertions
       assert_secret_present("ejson-keys")
       cert_data = { "tls.crt" => "this-is-the-certificate", "tls.key" => "this-is-the-key" }
       assert_secret_present("catphotoscom", cert_data, type: "kubernetes.io/tls", managed: true)
-      assert_secret_present("monitoring-token", { "api-token" => "this-is-the-api-token" }, managed: true)
+
+      token_data = { "api-token" => "this-is-the-api-token", "service" => "Datadog" } # Impt: it isn't _service: Datadog
+      assert_secret_present("monitoring-token", token_data, managed: true)
+
       assert_secret_present("unused-secret", { "this-is-for-testing-deletion" => "true" }, managed: true)
     end
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -235,11 +235,10 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(/Creating secret unused-secret/)
     assert_logs_match(/Creating secret monitoring-token/)
 
-    updated_data = { "_test" => "a" }
     deploy_fixtures("ejson-cloud") do |fixtures|
-      fixtures["secrets.ejson"]["kubernetes_secrets"]["unused-secret"]["data"] = updated_data
+      fixtures["secrets.ejson"]["kubernetes_secrets"]["unused-secret"]["data"] = { "_test" => "a" }
     end
-    ejson_cloud.assert_secret_present('unused-secret', updated_data, managed: true)
+    ejson_cloud.assert_secret_present('unused-secret', { "test" => "a" }, managed: true)
     ejson_cloud.assert_web_resources_up
     assert_logs_match(/Updating secret unused-secret/)
   end


### PR DESCRIPTION
Since leading underscores in ejson keys are used to skip encryption of the associated value, `kubernetes-deploy` should strip these leading underscores when it creates the keys for the Kubernetes secret data. 

cc @Shopify/cloudplatform 