### PR TITLE
Add Support for PodDisruptionBudget Resources

### DIFF
--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -28,6 +28,14 @@ module KubernetesDeploy
       )
     end
 
+    def build_policy_v1beta1_kubeclient(context)
+      _build_kubeclient(
+        api_version: "v1beta1",
+        context: context,
+        endpoint_path: "/apis/policy/"
+      )
+    end
+
     def _build_kubeclient(api_version:, context:, endpoint_path: nil)
       config = GoogleFriendlyConfig.read(ENV.fetch("KUBECONFIG"))
       unless config.contexts.include?(context)

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -102,6 +102,7 @@ module KubernetesDeploy
 
     # Expected values: :apply, :replace, :replace_force
     def deploy_method
+      # TPRs must use update for now: https://github.com/kubernetes/kubernetes/issues/39906
       tpr? ? :replace : :apply
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -36,6 +36,7 @@ module KubernetesDeploy
       when 'persistentvolumeclaim' then PersistentVolumeClaim.new(name, namespace, context, file)
       when 'service' then Service.new(name, namespace, context, file)
       when 'podtemplate' then PodTemplate.new(name, namespace, context, file)
+      when 'poddisruptionbudget' then PodDisruptionBudget.new(name, namespace, context, file)
       else self.new(name, namespace, context, file).tap { |r| r.type = type }
       end
     end
@@ -97,6 +98,11 @@ module KubernetesDeploy
 
     def tpr?
       false
+    end
+
+    # Expected values: :apply, :replace, :replace_force
+    def deploy_method
+      tpr? ? :replace : :apply
     end
 
     def status_data

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class PodDisruptionBudget < KubernetesResource
+    TIMEOUT = 30.seconds
+
+    def initialize(name, namespace, context, file)
+      @name = name
+      @namespace = namespace
+      @context = context
+      @file = file
+    end
+
+    def sync
+      _, _err, st = run_kubectl("get", type, @name)
+      @found = st.success?
+      @status = @found ? "Available" : "Unknown"
+      log_status
+    end
+
+    def deploy_succeeded?
+      exists?
+    end
+
+    def deploy_method
+      :replace_force
+    end
+
+    def exists?
+      @found
+    end
+  end
+end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class PodDisruptionBudget < KubernetesResource
-    TIMEOUT = 30.seconds
+    TIMEOUT = 10.seconds
 
     def initialize(name, namespace, context, file)
       @name = name
@@ -22,6 +22,7 @@ module KubernetesDeploy
     end
 
     def deploy_method
+      # Required until https://github.com/kubernetes/kubernetes/issues/45398 changes
       :replace_force
     end
 

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -31,6 +31,7 @@ module KubernetesDeploy
       @logger = logger
       @kubeclient = build_v1_kubeclient(context)
       @v1beta1_kubeclient = build_v1beta1_kubeclient(context)
+      @policy_v1beta1_kubeclient = build_policy_v1beta1_kubeclient(context)
     end
 
     def perform(deployments_names = nil)

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -310,13 +310,16 @@ MSG
           _, _, st = run_kubectl("replace", "-f", r.file.path)
         when :replace_force
           _, _, st = run_kubectl("replace", "--force", "-f", r.file.path)
+        else
+          # Fail Fast! This is a programmer mistake.
+          raise "Unexpected deploy method! (#{r.deploy_method.inspect})"
         end
 
         unless st.success?
           # it doesn't exist so we can't replace it
           _, err, st = run_kubectl("create", "-f", r.file.path)
           unless st.success?
-            raise FatalDeploymentError, <<~MSG
+            raise FatalDeploymentError, <<-MSG.strip_heredoc
               Failed to replace or create resource: #{r.id}
               #{err}
             MSG

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -312,7 +312,7 @@ MSG
           _, _, st = run_kubectl("replace", "--force", "-f", r.file.path)
         else
           # Fail Fast! This is a programmer mistake.
-          raise "Unexpected deploy method! (#{r.deploy_method.inspect})"
+          raise ArgumentError, "Unexpected deploy method! (#{r.deploy_method.inspect})"
         end
 
         unless st.success?

--- a/test/fixtures/hello-cloud/disruption-budgets.yml
+++ b/test/fixtures/hello-cloud/disruption-budgets.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud

--- a/test/helpers/fixture_sets/hello-cloud.rb
+++ b/test/helpers/fixture_sets/hello-cloud.rb
@@ -12,6 +12,7 @@ module FixtureSetAssertions
       assert_all_redis_resources_up
       assert_configmap_data_present
       assert_podtemplate_runner_present
+      assert_poddisruptionbudget
     end
 
     def assert_unmanaged_pod_statuses(status, count = 1)
@@ -65,6 +66,12 @@ module FixtureSetAssertions
 
     def assert_podtemplate_runner_present
       assert_pod_templates_present("hello-cloud-template-runner")
+    end
+
+    def assert_poddisruptionbudget
+      budgets = policy_v1beta1_kubeclient.get_pod_disruption_budgets(namespace: namespace)
+      assert_equal 1, budgets.size, "Expected 1 PodDisruptionBudget"
+      assert_equal 2, budgets[0].spec.minAvailable, "Expected PodDisruptionBudget to be overridden"
     end
   end
 end

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -13,4 +13,8 @@ module KubeclientHelper
   def v1beta1_kubeclient
     @v1beta1_kubeclient ||= build_v1beta1_kubeclient(MINIKUBE_CONTEXT)
   end
+
+  def policy_v1beta1_kubeclient
+    @policy_v1beta1_kubeclient ||= build_policy_v1beta1_kubeclient(MINIKUBE_CONTEXT)
+  end
 end


### PR DESCRIPTION
This appears to be the first resource that we have to do a
replace --force to update.

So, that took a little bit of reworking.

Also, in trying to get the tests to fail properly I realized we weren't
checking the return value of the `create` when a replace failed.

Now if I don't return `:replace_force` for the `#deploy_method`, the
test fail.