### PR TITLE
Groundwork for output overhaul

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -10,7 +10,7 @@ template_dir = nil
 allow_protected_ns = false
 prune = true
 bindings = {}
-verbose_log_tags = false
+verbose_log_prefix = false
 
 ARGV.options do |opts|
   opts.on("--bindings=BINDINGS", Array, "k1=v1,k2=v2") do |binds|
@@ -26,7 +26,7 @@ ARGV.options do |opts|
   opts.on("--allow-protected-ns") { allow_protected_ns = true }
   opts.on("--no-prune") { prune = false }
   opts.on("--template-dir=DIR") { |v| template_dir = v }
-  opts.on("--verbose-log-tags") { verbose_log_tags = true }
+  opts.on("--verbose-log-prefix") { verbose_log_prefix = true }
   opts.parse!
 end
 
@@ -47,7 +47,7 @@ end
 
 namespace = ARGV[0]
 context = ARGV[1]
-logger = KubernetesDeploy::Logger.build(namespace, context, verbose_tags: verbose_log_tags)
+logger = KubernetesDeploy::FormattedLogger.build(namespace, context, verbose_prefix: verbose_log_prefix)
 
   runner = KubernetesDeploy::Runner.new(
     namespace: namespace,
@@ -60,7 +60,7 @@ logger = KubernetesDeploy::Logger.build(namespace, context, verbose_tags: verbos
 
 KubernetesDeploy::Runner.with_friendly_errors do
   runner.run(
-    skip_wait: skip_wait,
+    verify_result: !skip_wait,
     allow_protected_ns: allow_protected_ns,
     prune: prune
   )

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -49,19 +49,18 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context, verbose_prefix: verbose_log_prefix)
 
-  runner = KubernetesDeploy::Runner.new(
-    namespace: namespace,
-    context: context,
-    current_sha: revision,
-    template_dir: template_dir,
-    bindings: bindings,
-    logger: logger
-  )
+runner = KubernetesDeploy::Runner.new(
+  namespace: namespace,
+  context: context,
+  current_sha: revision,
+  template_dir: template_dir,
+  bindings: bindings,
+  logger: logger
+)
 
-KubernetesDeploy::Runner.with_friendly_errors do
-  runner.run(
-    verify_result: !skip_wait,
-    allow_protected_ns: allow_protected_ns,
-    prune: prune
-  )
-end
+success = runner.run(
+  verify_result: !skip_wait,
+  allow_protected_ns: allow_protected_ns,
+  prune: prune
+)
+exit 1 unless success

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -10,6 +10,7 @@ template_dir = nil
 allow_protected_ns = false
 prune = true
 bindings = {}
+verbose_log_tags = false
 
 ARGV.options do |opts|
   opts.on("--bindings=BINDINGS", Array, "k1=v1,k2=v2") do |binds|
@@ -25,6 +26,7 @@ ARGV.options do |opts|
   opts.on("--allow-protected-ns") { allow_protected_ns = true }
   opts.on("--no-prune") { prune = false }
   opts.on("--template-dir=DIR") { |v| template_dir = v }
+  opts.on("--verbose-log-tags") { verbose_log_tags = true }
   opts.parse!
 end
 
@@ -43,16 +45,23 @@ revision = ENV.fetch('REVISION') do
   exit 1
 end
 
-KubernetesDeploy::Runner.with_friendly_errors do
+namespace = ARGV[0]
+context = ARGV[1]
+logger = KubernetesDeploy::Logger.build(namespace, context, verbose_tags: verbose_log_tags)
+
   runner = KubernetesDeploy::Runner.new(
-    namespace: ARGV[0],
-    context: ARGV[1],
+    namespace: namespace,
+    context: context,
     current_sha: revision,
     template_dir: template_dir,
-    wait_for_completion: !skip_wait,
-    allow_protected_ns: allow_protected_ns,
-    prune: prune,
-    bindings: bindings
+    bindings: bindings,
+    logger: logger
   )
-  runner.run
+
+KubernetesDeploy::Runner.with_friendly_errors do
+  runner.run(
+    skip_wait: skip_wait,
+    allow_protected_ns: allow_protected_ns,
+    prune: prune
+  )
 end

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -16,7 +16,6 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
-KubernetesDeploy::Runner.with_friendly_errors do
-  restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
-  restart.perform(raw_deployments)
-end
+restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
+success = restart.perform(raw_deployments)
+exit 1 unless success

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -14,7 +14,7 @@ end
 
 namespace = ARGV[0]
 context = ARGV[1]
-logger = KubernetesDeploy::Logger.build(namespace, context)
+logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 KubernetesDeploy::Runner.with_friendly_errors do
   restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -12,7 +12,11 @@ ARGV.options do |opts|
   opts.parse!
 end
 
+namespace = ARGV[0]
+context = ARGV[1]
+logger = KubernetesDeploy::Logger.build(namespace, context)
+
 KubernetesDeploy::Runner.with_friendly_errors do
-  restart = KubernetesDeploy::RestartTask.new(namespace: ARGV[0], context: ARGV[1])
+  restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
   restart.perform(raw_deployments)
 end

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -26,11 +26,10 @@ runner = KubernetesDeploy::RunnerTask.new(
   logger: logger
 )
 
- KubernetesDeploy::Runner.with_friendly_errors do
-  runner.run(
-    task_template: template,
-    entrypoint: entrypoint,
-    args: ARGV[2..-1],
-    env_vars: env_vars
-  )
-end
+success = runner.run(
+  task_template: template,
+  entrypoint: entrypoint,
+  args: ARGV[2..-1],
+  env_vars: env_vars
+)
+exit 1 unless success

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -18,7 +18,7 @@ end
 
 namespace = ARGV[0]
 context = ARGV[1]
-logger = KubernetesDeploy::Logger.build(namespace, context)
+logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 runner = KubernetesDeploy::RunnerTask.new(
   namespace: namespace,

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -16,9 +16,14 @@ ARGV.options do |opts|
   opts.parse!
 end
 
+namespace = ARGV[0]
+context = ARGV[1]
+logger = KubernetesDeploy::Logger.build(namespace, context)
+
 runner = KubernetesDeploy::RunnerTask.new(
-  namespace: ARGV[0],
-  context: ARGV[1],
+  namespace: namespace,
+  context: context,
+  logger: logger
 )
 
  KubernetesDeploy::Runner.with_friendly_errors do

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "kubeclient", "~> 2.3"
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"
+  spec.add_dependency "colorize", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -5,11 +5,11 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/hash/keys'
+require 'colorized_string'
 
 require 'kubernetes-deploy/errors'
 require 'kubernetes-deploy/logger'
 require 'kubernetes-deploy/runner'
 
 module KubernetesDeploy
-  include Logger
 end

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -8,7 +8,7 @@ require 'active_support/core_ext/hash/keys'
 require 'colorized_string'
 
 require 'kubernetes-deploy/errors'
-require 'kubernetes-deploy/logger'
+require 'kubernetes-deploy/formatted_logger'
 require 'kubernetes-deploy/runner'
 
 module KubernetesDeploy

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -2,7 +2,6 @@
 require 'json'
 require 'base64'
 require 'open3'
-require 'kubernetes-deploy/logger'
 require 'kubernetes-deploy/kubectl'
 
 module KubernetesDeploy
@@ -18,13 +17,11 @@ module KubernetesDeploy
     EJSON_SECRETS_FILE = "secrets.ejson"
     EJSON_KEYS_SECRET = "ejson-keys"
 
-    def initialize(namespace:, context:, template_dir:)
+    def initialize(namespace:, context:, template_dir:, logger:)
       @namespace = namespace
       @context = context
       @ejson_file = "#{template_dir}/#{EJSON_SECRETS_FILE}"
-
-      raise FatalDeploymentError, "Cannot create secrets without a namespace" if @namespace.blank?
-      raise FatalDeploymentError, "Cannot create secrets without a context" if @context.blank?
+      @logger = logger
     end
 
     def secret_changes_required?
@@ -42,7 +39,7 @@ module KubernetesDeploy
       with_decrypted_ejson do |decrypted|
         secrets = decrypted[MANAGED_SECRET_EJSON_KEY]
         unless secrets.present?
-          KubernetesDeploy.logger.warn("#{EJSON_SECRETS_FILE} does not have key #{MANAGED_SECRET_EJSON_KEY}."\
+          @logger.warn("#{EJSON_SECRETS_FILE} does not have key #{MANAGED_SECRET_EJSON_KEY}."\
             "No secrets will be created.")
           return
         end
@@ -63,9 +60,9 @@ module KubernetesDeploy
         next unless secret_managed?(secret)
         next if ejson_secret_names.include?(secret_name)
 
-        KubernetesDeploy.logger.info("Pruning secret #{secret_name}")
-        out, err, st = run_kubectl("delete", "secret", secret_name)
-        KubernetesDeploy.logger.debug(out)
+        @logger.info("Pruning secret #{secret_name}")
+        out, err, st = kubectl.run("delete", "secret", secret_name)
+        @logger.debug(out)
         raise EjsonSecretError, err unless st.success?
       end
     end
@@ -103,15 +100,15 @@ module KubernetesDeploy
 
     def create_or_update_secret(secret_name, secret_type, data)
       msg = secret_exists?(secret_name) ? "Updating secret #{secret_name}" : "Creating secret #{secret_name}"
-      KubernetesDeploy.logger.info(msg)
+      @logger.info(msg)
 
       secret_yaml = generate_secret_yaml(secret_name, secret_type, data)
       file = Tempfile.new(secret_name)
       file.write(secret_yaml)
       file.close
 
-      out, err, st = run_kubectl("apply", "--filename=#{file.path}")
-      KubernetesDeploy.logger.debug(out)
+      out, err, st = kubectl.run("apply", "--filename=#{file.path}")
+      @logger.debug(out)
       raise EjsonSecretError, err unless st.success?
     ensure
       file.unlink if file
@@ -144,7 +141,7 @@ module KubernetesDeploy
     end
 
     def secret_exists?(secret_name)
-      _out, _err, st = run_kubectl("get", "secret", secret_name)
+      _out, _err, st = kubectl.run("get", "secret", secret_name)
       st.success?
     end
 
@@ -166,7 +163,7 @@ module KubernetesDeploy
     end
 
     def decrypt_ejson(key_dir)
-      KubernetesDeploy.logger.info("Decrypting #{EJSON_SECRETS_FILE}")
+      @logger.info("Decrypting #{EJSON_SECRETS_FILE}")
       # ejson seems to dump both errors and output to STDOUT
       out_err, st = Open3.capture2e("EJSON_KEYDIR=#{key_dir} ejson decrypt #{@ejson_file}")
       raise EjsonSecretError, out_err unless st.success?
@@ -176,7 +173,7 @@ module KubernetesDeploy
     end
 
     def fetch_private_key_from_secret
-      KubernetesDeploy.logger.info("Fetching ejson private key from secret #{EJSON_KEYS_SECRET}")
+      @logger.info("Fetching ejson private key from secret #{EJSON_KEYS_SECRET}")
 
       secret = run_kubectl_json("get", "secret", EJSON_KEYS_SECRET)
       encoded_private_key = secret["data"][public_key]
@@ -189,14 +186,14 @@ module KubernetesDeploy
 
     def run_kubectl_json(*args)
       args += ["--output=json"]
-      out, err, st = run_kubectl(*args)
+      out, err, st = kubectl.run(*args)
       raise EjsonSecretError, err unless st.success?
       result = JSON.parse(out)
       result.fetch('items', result)
     end
 
-    def run_kubectl(*args)
-      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context, log_failure: false)
+    def kubectl
+      @kubectl ||= Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: false)
     end
   end
 end

--- a/lib/kubernetes-deploy/formatted_logger.rb
+++ b/lib/kubernetes-deploy/formatted_logger.rb
@@ -2,13 +2,13 @@
 require 'logger'
 
 module KubernetesDeploy
-  module Logger
-    def self.build(namespace, context, stream = $stderr, verbose_tags: false)
-      l = ::Logger.new(stream)
+  class FormattedLogger < Logger
+    def self.build(namespace, context, stream = $stderr, verbose_prefix: false)
+      l = new(stream)
       l.level = level_from_env
 
       l.formatter = proc do |severity, datetime, _progname, msg|
-        middle = verbose_tags ? "[#{context}][#{namespace}]" : ""
+        middle = verbose_prefix ? "[#{context}][#{namespace}]" : ""
         colorized_line = ColorizedString.new("[#{severity}][#{datetime}]#{middle}\t#{msg}\n")
 
         case severity
@@ -22,11 +22,6 @@ module KubernetesDeploy
           colorized_line
         end
       end
-
-      def l.blank_line(level = :info)
-        public_send(level, "")
-      end
-
       l
     end
 
@@ -39,7 +34,10 @@ module KubernetesDeploy
         ::Logger::INFO
       end
     end
-
     private_class_method :level_from_env
+
+    def blank_line(level = :info)
+      public_send(level, "")
+    end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -5,39 +5,31 @@ require 'kubernetes-deploy/kubectl'
 
 module KubernetesDeploy
   class KubernetesResource
-    def self.logger=(value)
-      @logger = value
-    end
-
-    def self.logger
-      @logger ||= begin
-        l = ::Logger.new($stderr)
-        l.formatter = proc do |_severity, datetime, _progname, msg|
-          "[KUBESTATUS][#{datetime}]\t#{msg}\n"
-        end
-        l
-      end
-    end
-
     attr_reader :name, :namespace, :file, :context
     attr_writer :type, :deploy_started
 
     TIMEOUT = 5.minutes
 
-    def self.for_type(type, name, namespace, context, file)
-      case type
-      when 'cloudsql' then Cloudsql.new(name, namespace, context, file)
-      when 'configmap' then ConfigMap.new(name, namespace, context, file)
-      when 'deployment' then Deployment.new(name, namespace, context, file)
-      when 'pod' then Pod.new(name, namespace, context, file)
-      when 'redis' then Redis.new(name, namespace, context, file)
-      when 'bugsnag' then Bugsnag.new(name, namespace, context, file)
-      when 'ingress' then Ingress.new(name, namespace, context, file)
-      when 'persistentvolumeclaim' then PersistentVolumeClaim.new(name, namespace, context, file)
-      when 'service' then Service.new(name, namespace, context, file)
-      when 'podtemplate' then PodTemplate.new(name, namespace, context, file)
-      when 'poddisruptionbudget' then PodDisruptionBudget.new(name, namespace, context, file)
-      else self.new(name, namespace, context, file).tap { |r| r.type = type }
+    def self.for_type(type:, name:, namespace:, context:, file:, logger:)
+      subclass = case type
+      when 'cloudsql' then Cloudsql
+      when 'configmap' then ConfigMap
+      when 'deployment' then Deployment
+      when 'pod' then Pod
+      when 'redis' then Redis
+      when 'bugsnag' then Bugsnag
+      when 'ingress' then Ingress
+      when 'persistentvolumeclaim' then PersistentVolumeClaim
+      when 'service' then Service
+      when 'podtemplate' then PodTemplate
+      when 'poddisruptionbudget' then PodDisruptionBudget
+      end
+
+      if subclass
+        subclass.new(name: name, namespace: namespace, context: context, file: file, logger: logger)
+      else
+        inst = new(name: name, namespace: namespace, context: context, file: file, logger: logger)
+        inst.tap { |r| r.type = type }
       end
     end
 
@@ -49,9 +41,13 @@ module KubernetesDeploy
       self.class.timeout
     end
 
-    def initialize(name, namespace, context, file)
-      # subclasses must also set these
-      @name, @namespace, @context, @file = name, namespace, context, file
+    def initialize(name:, namespace:, context:, file:, logger:)
+      # subclasses must also set these if they define their own initializer
+      @name = name
+      @namespace = namespace
+      @context = context
+      @file = file
+      @logger = logger
     end
 
     def id
@@ -68,7 +64,7 @@ module KubernetesDeploy
 
     def deploy_succeeded?
       if @deploy_started && !@success_assumption_warning_shown
-        KubernetesDeploy.logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
+        @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
         @success_assumption_warning_shown = true
       end
       true
@@ -123,14 +119,11 @@ module KubernetesDeploy
     end
 
     def log_status
-      KubernetesResource.logger.info("[#{@context}][#{@namespace}] #{JSON.dump(status_data)}")
+      @logger.info("[KUBESTATUS] #{JSON.dump(status_data)}")
     end
 
-    def run_kubectl(*args)
-      raise FatalDeploymentError, "Namespace missing for namespaced command" if @namespace.blank?
-      raise KubectlError, "Explicit context is required to run this command" if @context.blank?
-
-      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context, log_failure: false)
+    def kubectl
+      @kubectl ||= Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: false)
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -25,10 +25,11 @@ module KubernetesDeploy
       when 'poddisruptionbudget' then PodDisruptionBudget
       end
 
+      opts = { name: name, namespace: namespace, context: context, file: file, logger: logger }
       if subclass
-        subclass.new(name: name, namespace: namespace, context: context, file: file, logger: logger)
+        subclass.new(**opts)
       else
-        inst = new(name: name, namespace: namespace, context: context, file: file, logger: logger)
+        inst = new(**opts)
         inst.tap { |r| r.type = type }
       end
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
@@ -3,19 +3,12 @@ module KubernetesDeploy
   class Bugsnag < KubernetesResource
     TIMEOUT = 1.minute
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-      @secret_found = false
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      @secret_found = false
+      _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       if @found
-        secrets, _err, _st = run_kubectl("get", "secrets", "--output=name")
+        secrets, _err, _st = kubectl.run("get", "secrets", "--output=name")
         @secret_found = secrets.split.any? { |s| s.end_with?("-bugsnag") }
       end
       @status = @secret_found ? "Available" : "Unknown"

--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class Cloudsql < KubernetesResource
     TIMEOUT = 10.minutes
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       @status = if cloudsql_proxy_deployment_exists? && mysql_service_exists?
         "Provisioned"
@@ -41,7 +34,7 @@ module KubernetesDeploy
     private
 
     def cloudsql_proxy_deployment_exists?
-      deployment, _err, st = run_kubectl("get", "deployments", "cloudsql-proxy", "-o=json")
+      deployment, _err, st = kubectl.run("get", "deployments", "cloudsql-proxy", "-o=json")
 
       if st.success?
         parsed = JSON.parse(deployment)
@@ -56,7 +49,7 @@ module KubernetesDeploy
     end
 
     def mysql_service_exists?
-      service, _err, st = run_kubectl("get", "services", "mysql", "-o=json")
+      service, _err, st = kubectl.run("get", "services", "mysql", "-o=json")
 
       if st.success?
         parsed = JSON.parse(service)

--- a/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class ConfigMap < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @status = st.success? ? "Available" : "Unknown"
       @found = st.success?
       log_status

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class Deployment < KubernetesResource
     TIMEOUT = 5.minutes
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      json_data, _err, st = run_kubectl("get", type, @name, "--output=json")
+      json_data, _err, st = kubectl.run("get", type, @name, "--output=json")
       @found = st.success?
       @rollout_data = {}
       @status = nil
@@ -20,14 +13,21 @@ module KubernetesDeploy
       if @found
         @rollout_data = JSON.parse(json_data)["status"]
           .slice("updatedReplicas", "replicas", "availableReplicas", "unavailableReplicas")
-        @status, _err, _ = run_kubectl("rollout", "status", type, @name, "--watch=false") if @deploy_started
+        @status, _err, _ = kubectl.run("rollout", "status", type, @name, "--watch=false") if @deploy_started
 
-        pod_list, _err, st = run_kubectl("get", "pods", "-a", "-l", "name=#{name}", "--output=json")
+        pod_list, _err, st = kubectl.run("get", "pods", "-a", "-l", "name=#{name}", "--output=json")
         if st.success?
           pods_json = JSON.parse(pod_list)["items"]
           pods_json.each do |pod_json|
             pod_name = pod_json["metadata"]["name"]
-            pod = Pod.new(pod_name, namespace, context, nil, parent: "#{@name.capitalize} deployment")
+            pod = Pod.new(
+              name: pod_name,
+              namespace: namespace,
+              context: context,
+              file: nil,
+              parent: "#{@name.capitalize} deployment",
+              logger: @logger
+            )
             pod.deploy_started = @deploy_started
             pod.interpret_json_data(pod_json)
             @pods << pod

--- a/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class Ingress < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @status = st.success? ? "Created" : "Unknown"
       @found = st.success?
       log_status

--- a/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class PersistentVolumeClaim < KubernetesResource
     TIMEOUT = 5.minutes
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      @status, _err, st = run_kubectl("get", type, @name, "--output=jsonpath={.status.phase}")
+      @status, _err, st = kubectl.run("get", type, @name, "--output=jsonpath={.status.phase}")
       @found = st.success?
       log_status
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -3,15 +3,8 @@ module KubernetesDeploy
   class PodDisruptionBudget < KubernetesResource
     TIMEOUT = 10.seconds
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       @status = @found ? "Available" : "Unknown"
       log_status

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class PodTemplate < KubernetesResource
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @status = st.success? ? "Available" : "Unknown"
       @found = st.success?
       log_status

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -4,15 +4,8 @@ module KubernetesDeploy
     TIMEOUT = 5.minutes
     UUID_ANNOTATION = "redis.stable.shopify.io/owner_uid"
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       @status = if redis_deployment_exists? && redis_service_exists?
         "Provisioned"
@@ -42,7 +35,7 @@ module KubernetesDeploy
     private
 
     def redis_deployment_exists?
-      deployment, _err, st = run_kubectl("get", "deployments", "redis-#{redis_resource_uuid}", "-o=json")
+      deployment, _err, st = kubectl.run("get", "deployments", "redis-#{redis_resource_uuid}", "-o=json")
 
       if st.success?
         parsed = JSON.parse(deployment)
@@ -57,7 +50,7 @@ module KubernetesDeploy
     end
 
     def redis_service_exists?
-      service, _err, st = run_kubectl("get", "services", "redis-#{redis_resource_uuid}", "-o=json")
+      service, _err, st = kubectl.run("get", "services", "redis-#{redis_resource_uuid}", "-o=json")
 
       if st.success?
         parsed = JSON.parse(service)
@@ -73,7 +66,7 @@ module KubernetesDeploy
     def redis_resource_uuid
       return @redis_resource_uuid if defined?(@redis_resource_uuid) && @redis_resource_uuid
 
-      redis, _err, st = run_kubectl("get", "redises", @name, "-o=json")
+      redis, _err, st = kubectl.run("get", "redises", @name, "-o=json")
       if st.success?
         parsed = JSON.parse(redis)
 

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -3,18 +3,11 @@ module KubernetesDeploy
   class Service < KubernetesResource
     TIMEOUT = 5.minutes
 
-    def initialize(name, namespace, context, file)
-      @name = name
-      @namespace = namespace
-      @context = context
-      @file = file
-    end
-
     def sync
-      _, _err, st = run_kubectl("get", type, @name)
+      _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       if @found
-        endpoints, _err, st = run_kubectl("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
+        endpoints, _err, st = kubectl.run("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
         @num_endpoints = (st.success? ? endpoints.split.length : 0)
       else
         @num_endpoints = 0

--- a/lib/kubernetes-deploy/logger.rb
+++ b/lib/kubernetes-deploy/logger.rb
@@ -3,43 +3,43 @@ require 'logger'
 
 module KubernetesDeploy
   module Logger
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
+    def self.build(namespace, context, stream = $stderr, verbose_tags: false)
+      l = ::Logger.new(stream)
+      l.level = level_from_env
 
-    module ClassMethods
-      def logger=(other)
-        @logger = other
-      end
+      l.formatter = proc do |severity, datetime, _progname, msg|
+        middle = verbose_tags ? "[#{context}][#{namespace}]" : ""
+        colorized_line = ColorizedString.new("[#{severity}][#{datetime}]#{middle}\t#{msg}\n")
 
-      def logger
-        @logger ||= begin
-          l = ::Logger.new($stderr)
-          l.level = level_from_env
-          l.formatter = proc do |severity, datetime, _progname, msg|
-            log_text = "[#{severity}][#{datetime}]\t#{msg}"
-            case severity
-            when "FATAL" then "\033[0;31m#{log_text}\x1b[0m\n" # red
-            when "ERROR", "WARN" then "\033[0;33m#{log_text}\x1b[0m\n" # yellow
-            when "INFO" then "\033[0;36m#{log_text}\x1b[0m\n" # blue
-            else "#{log_text}\n"
-            end
-          end
-          l
-        end
-      end
-
-      private
-
-      def level_from_env
-        return ::Logger::DEBUG if ENV["DEBUG"]
-
-        if ENV["LEVEL"]
-          ::Logger.const_get(ENV["LEVEL"].upcase)
+        case severity
+        when "FATAL"
+          colorized_line.red
+        when "ERROR", "WARN"
+          colorized_line.yellow
+        when "INFO"
+          msg =~ /^\[(KUBESTATUS|Pod)/ ? colorized_line : colorized_line.blue
         else
-          ::Logger::INFO
+          colorized_line
         end
       end
+
+      def l.blank_line(level = :info)
+        public_send(level, "")
+      end
+
+      l
     end
+
+    def self.level_from_env
+      return ::Logger::DEBUG if ENV["DEBUG"]
+
+      if ENV["LEVEL"]
+        ::Logger.const_get(ENV["LEVEL"].upcase)
+      else
+        ::Logger::INFO
+      end
+    end
+
+    private_class_method :level_from_env
   end
 end

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -61,6 +61,10 @@ module KubernetesDeploy
 
       names = deployments.map { |d| "`#{d.metadata.name}`" }
       @logger.info "Restart of #{names.sort.join(', ')} deployments succeeded"
+      true
+    rescue FatalDeploymentError => error
+      @logger.fatal "#{error.class}: #{error.message}"
+      false
     end
 
     private

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -25,7 +25,7 @@ module KubernetesDeploy
     HTTP_OK_RANGE = 200..299
     ANNOTATION = "shipit.shopify.io/restart"
 
-    def initialize(context:, namespace:, logger: KubernetesDeploy.logger)
+    def initialize(context:, namespace:, logger:)
       @context = context
       @namespace = namespace
       @logger = logger
@@ -66,8 +66,10 @@ module KubernetesDeploy
     private
 
     def wait_for_rollout(kubeclient_resources)
-      resources = kubeclient_resources.map { |d| Deployment.new(d.metadata.name, @namespace, @context, nil) }
-      watcher = ResourceWatcher.new(resources)
+      resources = kubeclient_resources.map do |d|
+        Deployment.new(name: d.metadata.name, namespace: @namespace, context: @context, file: nil, logger: @logger)
+      end
+      watcher = ResourceWatcher.new(resources, logger: @logger)
       watcher.run
     end
 

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -85,7 +85,7 @@ module KubernetesDeploy
       @id = current_sha[0...8] + "-#{SecureRandom.hex(4)}" if current_sha
     end
 
-    def run(skip_wait: false, allow_protected_ns: false, prune: true)
+    def run(verify_result: true, allow_protected_ns: false, prune: true)
       phase_heading("Validating configuration")
       validate_configuration(allow_protected_ns: allow_protected_ns, prune: prune)
 
@@ -120,7 +120,7 @@ module KubernetesDeploy
 
       deploy_resources(resources, prune: prune)
 
-      return if skip_wait
+      return unless verify_result
       wait_for_completion(resources)
       report_final_status(resources)
     rescue FatalDeploymentError => error

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -70,39 +70,24 @@ module KubernetesDeploy
 
     def self.with_friendly_errors
       yield
-    rescue FatalDeploymentError => error
-      KubernetesDeploy.logger.fatal <<-MSG
-#{error.class}: #{error.message}
-  #{error.backtrace && error.backtrace.join("\n  ")}
-MSG
+    rescue FatalDeploymentError
       exit 1
     end
 
-    def initialize(namespace:, current_sha:, context:, template_dir:,
-      wait_for_completion:, allow_protected_ns: false, prune: true, bindings: {})
+    def initialize(namespace:, context:, current_sha:, template_dir:, logger:, bindings: {})
       @namespace = namespace
       @context = context
       @current_sha = current_sha
       @template_dir = File.expand_path(template_dir)
+      @logger = logger
+      @bindings = bindings
       # Max length of podname is only 63chars so try to save some room by truncating sha to 8 chars
       @id = current_sha[0...8] + "-#{SecureRandom.hex(4)}" if current_sha
-      @wait_for_completion = wait_for_completion
-      @allow_protected_ns = allow_protected_ns
-      @prune = prune
-      @bindings = bindings
     end
 
-    def wait_for_completion?
-      @wait_for_completion
-    end
-
-    def allow_protected_ns?
-      @allow_protected_ns
-    end
-
-    def run
+    def run(skip_wait: false, allow_protected_ns: false, prune: true)
       phase_heading("Validating configuration")
-      validate_configuration
+      validate_configuration(allow_protected_ns: allow_protected_ns, prune: prune)
 
       phase_heading("Identifying deployment target")
       confirm_context_exists
@@ -114,7 +99,12 @@ MSG
       phase_heading("Checking initial resource statuses")
       resources.each(&:sync)
 
-      ejson = EjsonSecretProvisioner.new(namespace: @namespace, context: @context, template_dir: @template_dir)
+      ejson = EjsonSecretProvisioner.new(
+        namespace: @namespace,
+        context: @context,
+        template_dir: @template_dir,
+        logger: @logger
+      )
       if ejson.secret_changes_required?
         phase_heading("Deploying kubernetes secrets from #{EjsonSecretProvisioner::EJSON_SECRETS_FILE}")
         ejson.run
@@ -124,15 +114,18 @@ MSG
       predeploy_priority_resources(resources)
 
       phase_heading("Deploying all resources")
-      if PROTECTED_NAMESPACES.include?(@namespace) && @prune
+      if PROTECTED_NAMESPACES.include?(@namespace) && prune
         raise FatalDeploymentError, "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
       end
 
-      deploy_resources(resources, prune: @prune)
+      deploy_resources(resources, prune: prune)
 
-      return unless wait_for_completion?
+      return if skip_wait
       wait_for_completion(resources)
       report_final_status(resources)
+    rescue FatalDeploymentError => error
+      @logger.fatal "#{error.class}: #{error.message}"
+      raise error
     end
 
     def template_variables
@@ -154,7 +147,7 @@ MSG
 
     def server_major_version
       @server_major_version ||= begin
-        out, _, _ = run_kubectl('version', '--short')
+        out, _, _ = kubectl.run('version', '--short')
         matchdata = /Server Version: v(?<version>\d\.\d)/.match(out)
         raise "Could not determine server version" unless matchdata[:version]
         matchdata[:version]
@@ -172,10 +165,10 @@ MSG
       path = match[:path]
       if path.present? && File.file?(path)
         suspicious_file = File.read(path)
-        KubernetesDeploy.logger.warn("Inspecting the file mentioned in the error message (#{path})")
-        KubernetesDeploy.logger.warn(suspicious_file)
+        @logger.warn("Inspecting the file mentioned in the error message (#{path})")
+        @logger.warn(suspicious_file)
       else
-        KubernetesDeploy.logger.warn("Detected a file (#{path.inspect}) referenced in the kubectl stderr " \
+        @logger.warn("Detected a file (#{path.inspect}) referenced in the kubectl stderr " \
           "but was unable to inspect it")
       end
     end
@@ -201,15 +194,16 @@ MSG
         split_templates(filename) do |tempfile|
           resource_id = discover_resource_via_dry_run(tempfile)
           type, name = resource_id.split("/", 2) # e.g. "pod/web-198612918-dzvfb"
-          resources << KubernetesResource.for_type(type, name, @namespace, @context, tempfile)
-          KubernetesDeploy.logger.info "Discovered template for #{resource_id}"
+          resources << KubernetesResource.for_type(type: type, name: name, namespace: @namespace, context: @context,
+            file: tempfile, logger: @logger)
+          @logger.info "Discovered template for #{resource_id}"
         end
       end
       resources
     end
 
     def discover_resource_via_dry_run(tempfile)
-      resource_id, _err, st = run_kubectl("create", "-f", tempfile.path, "--dry-run", "--output=name")
+      resource_id, _err, st = kubectl.run("create", "-f", tempfile.path, "--dry-run", "--output=name")
       raise FatalDeploymentError, "Dry run failed for template #{File.basename(tempfile.path)}." unless st.success?
       resource_id
     end
@@ -226,13 +220,13 @@ MSG
         yield f
       end
     rescue Psych::SyntaxError => e
-      KubernetesDeploy.logger.error(rendered_content)
+      @logger.error(rendered_content)
       raise FatalDeploymentError, "Template #{filename} cannot be parsed: #{e.message}"
     end
 
     def report_final_status(resources)
       if resources.all?(&:deploy_succeeded?)
-        log_green("Deploy succeeded!")
+        @logger.info("Deploy succeeded!")
       else
         fail_list = resources.select { |r| r.deploy_failed? || r.deploy_timed_out? }.map(&:id)
         raise FatalDeploymentError, "The following resources failed to deploy: #{fail_list.join(', ')}"
@@ -240,7 +234,7 @@ MSG
     end
 
     def wait_for_completion(watched_resources)
-      watcher = ResourceWatcher.new(watched_resources)
+      watcher = ResourceWatcher.new(watched_resources, logger: @logger)
       watcher.run
     end
 
@@ -255,7 +249,7 @@ MSG
       erb_template.result(erb_binding)
     end
 
-    def validate_configuration
+    def validate_configuration(allow_protected_ns:, prune:)
       errors = []
       if ENV["KUBECONFIG"].blank? || !File.file?(ENV["KUBECONFIG"])
         errors << "Kube config not found at #{ENV['KUBECONFIG']}"
@@ -274,15 +268,15 @@ MSG
       if @namespace.blank?
         errors << "Namespace must be specified"
       elsif PROTECTED_NAMESPACES.include?(@namespace)
-        if allow_protected_ns? && @prune
+        if allow_protected_ns && prune
           errors << "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
-        elsif allow_protected_ns?
+        elsif allow_protected_ns
           warning = <<-WARNING.strip_heredoc
           You're deploying to protected namespace #{@namespace}, which cannot be pruned.
           Existing resources can only be removed manually with kubectl. Removing templates from the set deployed will have no effect.
           ***Please do not deploy to #{@namespace} unless you really know what you are doing.***
           WARNING
-          KubernetesDeploy.logger.warn(warning)
+          @logger.warn(warning)
         else
           errors << "Refusing to deploy to protected namespace '#{@namespace}'"
         end
@@ -293,17 +287,17 @@ MSG
       end
 
       raise FatalDeploymentError, "Configuration invalid: #{errors.join(', ')}" unless errors.empty?
-      KubernetesDeploy.logger.info("All required parameters and files are present")
+      @logger.info("All required parameters and files are present")
     end
 
     def deploy_resources(resources, prune: false)
-      KubernetesDeploy.logger.info("Deploying resources:")
+      @logger.info("Deploying resources:")
 
       # Apply can be done in one large batch, the rest have to be done individually
       applyables, individuals = resources.partition { |r| r.deploy_method == :apply }
 
       individuals.each do |r|
-        KubernetesDeploy.logger.info("- #{r.id}")
+        @logger.info("- #{r.id}")
         r.deploy_started = Time.now.utc
         case r.deploy_method
         when :replace
@@ -315,15 +309,14 @@ MSG
           raise ArgumentError, "Unexpected deploy method! (#{r.deploy_method.inspect})"
         end
 
+        next if st.success?
+        # it doesn't exist so we can't replace it
+        _, err, st = kubectl.run("create", "-f", r.file.path, log_failure: false)
         unless st.success?
-          # it doesn't exist so we can't replace it
-          _, err, st = run_kubectl("create", "-f", r.file.path)
-          unless st.success?
-            raise FatalDeploymentError, <<-MSG.strip_heredoc
-              Failed to replace or create resource: #{r.id}
-              #{err}
-            MSG
-          end
+          raise FatalDeploymentError, <<-MSG.strip_heredoc
+            Failed to replace or create resource: #{r.id}
+            #{err}
+          MSG
         end
       end
 
@@ -335,7 +328,7 @@ MSG
 
       command = ["apply"]
       resources.each do |r|
-        KubernetesDeploy.logger.info("- #{r.id}")
+        @logger.info("- #{r.id}")
         command.push("-f", r.file.path)
         r.deploy_started = Time.now.utc
       end
@@ -345,7 +338,7 @@ MSG
         versioned_prune_whitelist.each { |type| command.push("--prune-whitelist=#{type}") }
       end
 
-      _, err, st = run_kubectl(*command)
+      _, err, st = kubectl.run(*command)
       unless st.success?
         inspect_kubectl_out_for_files(err)
         raise FatalDeploymentError, <<-MSG
@@ -356,32 +349,24 @@ MSG
     end
 
     def confirm_context_exists
-      out, err, st = run_kubectl("config", "get-contexts", "-o", "name", namespaced: false, with_context: false)
+      out, err, st = kubectl.run("config", "get-contexts", "-o", "name", use_namespace: false, use_context: false)
       available_contexts = out.split("\n")
       if !st.success?
         raise FatalDeploymentError, err
       elsif !available_contexts.include?(@context)
         raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
       end
-      KubernetesDeploy.logger.info("Context #{@context} found")
+      @logger.info("Context #{@context} found")
     end
 
     def confirm_namespace_exists
-      _, _, st = run_kubectl("get", "namespace", @namespace, namespaced: false)
+      _, _, st = kubectl.run("get", "namespace", @namespace, use_namespace: false, log_failure: false)
       raise FatalDeploymentError, "Namespace #{@namespace} not found" unless st.success?
-      KubernetesDeploy.logger.info("Namespace #{@namespace} found")
+      @logger.info("Namespace #{@namespace} found")
     end
 
-    def run_kubectl(*args, namespaced: true, with_context: true)
-      if namespaced
-        raise KubectlError, "Namespace missing for namespaced command" if @namespace.blank?
-      end
-
-      if with_context
-        raise KubectlError, "Explicit context is required to run this command" if @context.blank?
-      end
-
-      Kubectl.run_kubectl(*args, namespace: @namespace, context: @context)
+    def kubectl
+      @kubectl ||= Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: true)
     end
   end
 end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -297,9 +297,9 @@ module KubernetesDeploy
         r.deploy_started = Time.now.utc
         case r.deploy_method
         when :replace
-          _, _, st = run_kubectl("replace", "-f", r.file.path)
+          _, _, st = kubectl.run("replace", "-f", r.file.path, log_failure: false)
         when :replace_force
-          _, _, st = run_kubectl("replace", "--force", "-f", r.file.path)
+          _, _, st = kubectl.run("replace", "--force", "-f", r.file.path, log_failure: false)
         else
           # Fail Fast! This is a programmer mistake.
           raise ArgumentError, "Unexpected deploy method! (#{r.deploy_method.inspect})"

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -39,6 +39,10 @@ module KubernetesDeploy
       phase_heading("Creating pod")
       @logger.info("Starting task runner pod: '#{rendered_template.metadata.name}'")
       @kubeclient.create_pod(rendered_template)
+      true
+    rescue FatalDeploymentError => error
+      @logger.fatal "#{error.class}: #{error.message}"
+      false
     end
 
     private

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -24,7 +24,15 @@ module KubernetesDeploy
       @context = context
     end
 
-    def run(task_template:, entrypoint:, args:, env_vars: [])
+    def run(*args)
+      run!(*args)
+      true
+    rescue FatalDeploymentError => error
+      @logger.fatal "#{error.class}: #{error.message}"
+      false
+    end
+
+    def run!(task_template:, entrypoint:, args:, env_vars: [])
       phase_heading("Validating configuration")
       validate_configuration(task_template, args)
 
@@ -39,10 +47,6 @@ module KubernetesDeploy
       phase_heading("Creating pod")
       @logger.info("Starting task runner pod: '#{rendered_template.metadata.name}'")
       @kubeclient.create_pod(rendered_template)
-      true
-    rescue FatalDeploymentError => error
-      @logger.fatal "#{error.class}: #{error.message}"
-      false
     end
 
     private

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -8,7 +8,6 @@ require 'kubernetes-deploy/kubectl'
 module KubernetesDeploy
   class RunnerTask
     include KubeclientBuilder
-    include Kubectl
     include UIHelpers
 
     class FatalTaskRunError < FatalDeploymentError; end
@@ -18,7 +17,7 @@ module KubernetesDeploy
       end
     end
 
-    def initialize(namespace:, context:, logger: KubernetesDeploy.logger)
+    def initialize(namespace:, context:, logger:)
       @logger = logger
       @namespace = namespace
       @kubeclient = build_v1_kubeclient(context)
@@ -38,7 +37,7 @@ module KubernetesDeploy
       validate_pod_spec(rendered_template)
 
       phase_heading("Creating pod")
-      KubernetesDeploy.logger.info("Starting task runner pod: '#{rendered_template.metadata.name}'")
+      @logger.info("Starting task runner pod: '#{rendered_template.metadata.name}'")
       @kubeclient.create_pod(rendered_template)
     end
 
@@ -73,7 +72,7 @@ module KubernetesDeploy
     end
 
     def get_template(template_name)
-      KubernetesDeploy.logger.info(
+      @logger.info(
         "Fetching task runner pod template: '#{template_name}' in namespace: '#{@namespace}'"
       )
 
@@ -89,7 +88,7 @@ module KubernetesDeploy
     end
 
     def build_pod_template(base_template, entrypoint, args, env_vars)
-      KubernetesDeploy.logger.info("Rendering template for task runner pod")
+      @logger.info("Rendering template for task runner pod")
 
       rendered_template = base_template.dup
       rendered_template.kind = 'Pod'
@@ -112,7 +111,7 @@ module KubernetesDeploy
 
       unique_name = rendered_template.metadata.name + "-" + SecureRandom.hex(8)
 
-      KubernetesDeploy.logger.warn("Name is too long, using '#{unique_name[0..62]}'") if unique_name.length > 63
+      @logger.warn("Name is too long, using '#{unique_name[0..62]}'") if unique_name.length > 63
       rendered_template.metadata.name = unique_name[0..62]
       rendered_template.metadata.namespace = @namespace
 
@@ -124,11 +123,8 @@ module KubernetesDeploy
       f.write recursive_to_h(pod).to_json
       f.close
 
-      _out, err, status = Kubectl.run_kubectl(
-        "apply", "--dry-run", "-f", f.path,
-        namespace: @namespace,
-        context: @context
-      )
+      kubectl = Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: true)
+      _out, err, status = kubectl.run("apply", "--dry-run", "-f", f.path)
 
       unless status.success?
         raise FatalTaskRunError, "Invalid pod spec: #{err}"

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -63,7 +63,7 @@ module KubernetesDeploy
       end
 
       begin
-        @kubeclient.get_namespace(@namespace)
+        @kubeclient.get_namespace(@namespace) if @namespace.present?
       rescue KubeException => e
         errors << if e.error_code == 404
           "Namespace was not found"

--- a/lib/kubernetes-deploy/ui_helpers.rb
+++ b/lib/kubernetes-deploy/ui_helpers.rb
@@ -8,12 +8,8 @@ module KubernetesDeploy
       @current_phase += 1
       heading = "Phase #{@current_phase}: #{phase_name}"
       padding = (100.0 - heading.length) / 2
-      KubernetesDeploy.logger.info("")
-      KubernetesDeploy.logger.info("#{'-' * padding.floor}#{heading}#{'-' * padding.ceil}")
-    end
-
-    def log_green(msg)
-      KubernetesDeploy.logger.info("\033[0;32m#{msg}\x1b[0m")
+      @logger.info("")
+      @logger.info("#{'-' * padding.floor}#{heading}#{'-' * padding.ceil}")
     end
   end
 end

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -51,12 +51,14 @@ module FixtureDeployHelper
       current_sha: SecureRandom.hex(6),
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       template_dir: dir,
-      wait_for_completion: wait,
-      allow_protected_ns: allow_protected_ns,
-      prune: prune,
+      logger: test_logger,
       bindings: bindings
     )
-    runner.run
+    runner.run(
+      skip_wait: !wait,
+      allow_protected_ns: allow_protected_ns,
+      prune: prune
+    )
   end
 
   private

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -55,7 +55,7 @@ module FixtureDeployHelper
       bindings: bindings
     )
     runner.run(
-      skip_wait: !wait,
+      verify_result: wait,
       allow_protected_ns: allow_protected_ns,
       prune: prune
     )

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -32,10 +32,13 @@ module FixtureDeployHelper
 
     yield fixtures if block_given?
 
+    success = false
     Dir.mktmpdir("fixture_dir") do |target_dir|
       write_fixtures_to_dir(fixtures, target_dir)
-      deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns, prune: prune, bindings: bindings)
+      success = deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns,
+        prune: prune, bindings: bindings)
     end
+    success
   end
 
   def deploy_raw_fixtures(set, wait: true, bindings: {})

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -54,7 +54,7 @@ module FixtureDeployHelper
       current_sha: SecureRandom.hex(6),
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       template_dir: dir,
-      logger: test_logger,
+      logger: logger,
       bindings: bindings
     )
     runner.run(

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -167,7 +167,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
     end
     assert_equal false, success, "Deploy succeeded when it was expected to fail"
-    assert_logs_match(/The following priority resources failed to deploy: Pod\/unmanaged-pod/)
+    assert_logs_match(%r{The following priority resources failed to deploy: Pod\/unmanaged-pod})
 
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_unmanaged_pod_statuses("Failed")
@@ -183,7 +183,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
     end
     assert_equal false, success, "Deploy succeeded when it was expected to fail"
-    assert_logs_match(/The following priority resources failed to deploy: Pod\/unmanaged-pod/)
+    assert_logs_match(%r{The following priority resources failed to deploy: Pod\/unmanaged-pod})
     assert_logs_match(/DeadlineExceeded/)
   end
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -3,29 +3,29 @@ require 'test_helper'
 
 class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_full_hello_cloud_set_deploy_succeeds
-    deploy_fixtures("hello-cloud")
+    assert deploy_fixtures("hello-cloud")
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_all_up
   end
 
   def test_partial_deploy_followed_by_full_deploy
-    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "redis.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "redis.yml"])
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_all_redis_resources_up
     hello_cloud.assert_configmap_data_present
     hello_cloud.refute_managed_pod_exists
     hello_cloud.refute_web_resources_exist
 
-    deploy_fixtures("hello-cloud")
+    assert deploy_fixtures("hello-cloud")
     hello_cloud.assert_all_up
   end
 
   def test_pruning
-    deploy_fixtures("hello-cloud")
+    assert deploy_fixtures("hello-cloud")
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_all_up
 
-    deploy_fixtures("hello-cloud", subset: ["redis.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["redis.yml"])
     hello_cloud.assert_all_redis_resources_up
     hello_cloud.refute_configmap_data_exists
     hello_cloud.refute_managed_pod_exists
@@ -33,51 +33,48 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_pruning_disabled
-    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"])
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_configmap_data_present
 
-    deploy_fixtures("hello-cloud", subset: ["redis.yml"], prune: false)
+    assert deploy_fixtures("hello-cloud", subset: ["redis.yml"], prune: false)
     hello_cloud.assert_configmap_data_present
     hello_cloud.assert_all_redis_resources_up
   end
 
   def test_deploying_to_protected_namespace_with_override_does_not_prune
     KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
-      deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: false)
+      assert deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: false)
       hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
       hello_cloud.assert_all_up
       assert_logs_match(/cannot be pruned/)
       assert_logs_match(/Please do not deploy to #{@namespace} unless you really know what you are doing/)
 
-      deploy_fixtures("hello-cloud", subset: ["redis.yml"], allow_protected_ns: true, prune: false)
+      assert deploy_fixtures("hello-cloud", subset: ["redis.yml"], allow_protected_ns: true, prune: false)
       hello_cloud.assert_all_up
     end
   end
 
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
-    expected_msg = /Refusing to deploy to protected namespace .* pruning enabled/
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
-      KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
-        deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true)
-      end
+    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+      refute deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true)
     end
+    assert_logs_match(/Refusing to deploy to protected namespace .* pruning enabled/)
   end
 
   def test_refuses_deploy_to_protected_namespace_without_override
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Refusing to deploy to protected namespace/) do
-      KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
-        deploy_fixtures("hello-cloud", prune: false)
-      end
+    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+      refute deploy_fixtures("hello-cloud", prune: false)
     end
+    assert_logs_match(/Refusing to deploy to protected namespace/)
   end
 
   def test_pvcs_are_not_pruned
-    deploy_fixtures("hello-cloud", subset: ["redis.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["redis.yml"])
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_all_redis_resources_up
 
-    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"])
     hello_cloud.assert_configmap_data_present
     hello_cloud.refute_redis_resources_exist(expect_pvc: true)
   end
@@ -91,32 +88,33 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "data" => { "foo" => "YmFy" }
     }
 
-    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
       fixtures["secret.yml"] = { "Secret" => secret }
     end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
 
     live_secret = kubeclient.get_secret("test", @namespace)
     assert_equal({ foo: "YmFy" }, live_secret["data"].to_h)
   end
 
   def test_invalid_yaml_fails_fast
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Template yaml-error.yml cannot be parsed/) do
-      deploy_dir(fixture_path("invalid"))
-    end
+    refute deploy_dir(fixture_path("invalid"))
+    assert_logs_match(/Template yaml-error.yml cannot be parsed/)
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, /Dry run failed for template configmap-data/) do
-      deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
-        configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
-        configmap["metadata"]["myKey"] = "uhOh"
-      end
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
+      configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
+      configmap["metadata"]["myKey"] = "uhOh"
     end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+
+    assert_logs_match(/Dry run failed for template configmap-data/)
     assert_logs_match(/error validating data\: found invalid field myKey for v1.ObjectMeta/)
   end
 
   def test_dynamic_erb_collection_works
-    deploy_raw_fixtures("collection-with-erb", bindings: { binding_test_a: 'foo', binding_test_b: 'bar' })
+    assert deploy_raw_fixtures("collection-with-erb", bindings: { binding_test_a: 'foo', binding_test_b: 'bar' })
 
     deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace)
     assert_equal 3, deployments.size
@@ -126,25 +124,26 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   # Reproduces k8s bug
   # https://github.com/kubernetes/kubernetes/issues/42057
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_on_apply
-    err = assert_raises(KubernetesDeploy::FatalDeploymentError) do
-      deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
-        configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
-        configmap["metadata"]["labels"] = {
-          "name" => { "not_a_name" => [1, 2] }
-        }
-      end
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
+      configmap = fixtures["configmap-data.yml"]["ConfigMap"].first
+      configmap["metadata"]["labels"] = {
+        "name" => { "not_a_name" => [1, 2] }
+      }
     end
-    assert_match(/The following command failed: apply/, err.to_s)
-    assert_match(/Error from server \(BadRequest\): error when creating/, err.to_s)
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+
+    assert_logs_match(/The following command failed: apply/)
+    assert_logs_match(/Error from server \(BadRequest\): error when creating/)
     assert_logs_match(/Inspecting the file mentioned in the error message/)
   end
 
   def test_dead_pods_in_old_replicaset_are_ignored
-    deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"], wait: false) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"], wait: false) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       # web pods will get killed after one second and will not be cleaned up
       deployment["spec"]["template"]["spec"]["activeDeadlineSeconds"] = 1
     end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
 
     initial_failed_pod_count = 0
     while initial_failed_pod_count < 1
@@ -152,7 +151,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       initial_failed_pod_count = pods.count { |pod| pod.status.phase == "Failed" }
     end
 
-    deploy_fixtures("hello-cloud", subset: ["web.yml.erb", "configmap-data.yml"])
+    assert deploy_fixtures("hello-cloud", subset: ["web.yml.erb", "configmap-data.yml"])
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=web,app=hello-cloud")
     running_pod_count = pods.count { |pod| pod.status.phase == "Running" }
     final_failed_pod_count = pods.count { |pod| pod.status.phase == "Failed" }
@@ -162,14 +161,13 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_bad_container_image_on_run_once_halts_and_fails_deploy
-    expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
-      deploy_fixtures("hello-cloud") do |fixtures|
-        pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
-        pod["spec"]["activeDeadlineSeconds"] = 1
-        pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
-      end
+    success = deploy_fixtures("hello-cloud") do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["spec"]["activeDeadlineSeconds"] = 1
+      pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
     end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+    assert_logs_match(/The following priority resources failed to deploy: Pod\/unmanaged-pod/)
 
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_unmanaged_pod_statuses("Failed")
@@ -179,20 +177,19 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_wait_false_still_waits_for_priority_resources
-    expected_msg = %r{The following priority resources failed to deploy: Pod\/unmanaged-pod}
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, expected_msg) do
-      deploy_fixtures("hello-cloud") do |fixtures|
-        pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
-        pod["spec"]["activeDeadlineSeconds"] = 1
-        pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
-      end
+    success = deploy_fixtures("hello-cloud") do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["spec"]["activeDeadlineSeconds"] = 1
+      pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
     end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+    assert_logs_match(/The following priority resources failed to deploy: Pod\/unmanaged-pod/)
     assert_logs_match(/DeadlineExceeded/)
   end
 
   def test_wait_false_ignores_non_priority_resource_failures
     # web depends on configmap so will not succeed deployed alone
-    deploy_fixtures("hello-cloud", subset: ["web.yml.erb"], wait: false)
+    assert deploy_fixtures("hello-cloud", subset: ["web.yml.erb"], wait: false)
 
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=hello-cloud')
     assert_equal 1, pods.size, "Unable to find web pod"
@@ -200,7 +197,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_extra_bindings_should_be_rendered
-    deploy_fixtures('collection-with-erb', subset: ["conf_map.yml.erb"],
+    assert deploy_fixtures('collection-with-erb', subset: ["conf_map.yml.erb"],
       bindings: { binding_test_a: 'binding_test_a', binding_test_b: 'binding_test_b' })
 
     map = kubeclient.get_config_map('extra-binding', @namespace).data
@@ -216,7 +213,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
   def test_long_running_deployment
     2.times do
-      deploy_fixtures('long-running')
+      assert deploy_fixtures('long-running')
     end
 
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=jobs,app=fixtures')
@@ -229,15 +226,16 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_create_and_update_secrets_from_ejson
     ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
     ejson_cloud.create_ejson_keys_secret
-    deploy_fixtures("ejson-cloud")
+    assert deploy_fixtures("ejson-cloud")
     ejson_cloud.assert_all_up
     assert_logs_match(/Creating secret catphotoscom/)
     assert_logs_match(/Creating secret unused-secret/)
     assert_logs_match(/Creating secret monitoring-token/)
 
-    deploy_fixtures("ejson-cloud") do |fixtures|
+    success = deploy_fixtures("ejson-cloud") do |fixtures|
       fixtures["secrets.ejson"]["kubernetes_secrets"]["unused-secret"]["data"] = { "_test" => "a" }
     end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
     ejson_cloud.assert_secret_present('unused-secret', { "test" => "a" }, managed: true)
     ejson_cloud.assert_web_resources_up
     assert_logs_match(/Updating secret unused-secret/)
@@ -248,22 +246,23 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     ejson_cloud.create_ejson_keys_secret
 
     malformed = { "_bad_data" => %w(foo bar) }
-    assert_raises_message(KubernetesDeploy::EjsonSecretError, /Data for secret monitoring-token was invalid/) do
-      deploy_fixtures("ejson-cloud") do |fixtures|
-        fixtures["secrets.ejson"]["kubernetes_secrets"]["monitoring-token"]["data"] = malformed
-      end
+    success = deploy_fixtures("ejson-cloud") do |fixtures|
+      fixtures["secrets.ejson"]["kubernetes_secrets"]["monitoring-token"]["data"] = malformed
     end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+    assert_logs_match(/Data for secret monitoring-token was invalid/)
   end
 
   def test_pruning_of_secrets_created_from_ejson
     ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
     ejson_cloud.create_ejson_keys_secret
-    deploy_fixtures("ejson-cloud")
+    assert deploy_fixtures("ejson-cloud")
     ejson_cloud.assert_secret_present('unused-secret', managed: true)
 
-    deploy_fixtures("ejson-cloud") do |fixtures|
+    success = deploy_fixtures("ejson-cloud") do |fixtures|
       fixtures["secrets.ejson"]["kubernetes_secrets"].delete("unused-secret")
     end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
     assert_logs_match(/Pruning secret unused-secret/)
 
     # The removed secret was pruned
@@ -278,12 +277,13 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_pruning_of_existing_managed_secrets_when_ejson_file_has_been_deleted
     ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
     ejson_cloud.create_ejson_keys_secret
-    deploy_fixtures("ejson-cloud")
+    assert deploy_fixtures("ejson-cloud")
     ejson_cloud.assert_all_up
 
-    deploy_fixtures("ejson-cloud") do |fixtures|
+    success = deploy_fixtures("ejson-cloud") do |fixtures|
       fixtures.delete("secrets.ejson")
     end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
 
     assert_logs_match("Pruning secret unused-secret")
     assert_logs_match("Pruning secret catphotoscom")

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -106,7 +106,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       KubernetesDeploy::RestartTask.new(
         context: "walrus",
         namespace: @namespace,
-        logger: test_logger
+        logger: logger
       )
     end
   end
@@ -115,7 +115,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     restart = KubernetesDeploy::RestartTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: "walrus",
-      logger: test_logger
+      logger: logger
     )
     refute restart.perform(["web"])
     assert_logs_match("Namespace `walrus` not found in context `minikube`. Aborting the task.")
@@ -127,7 +127,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     KubernetesDeploy::RestartTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
-      logger: test_logger
+      logger: logger
     )
   end
 

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -15,7 +15,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     assert task_runner.run(
       task_template: 'hello-cloud-template-runner',
       entrypoint: ['/bin/bash'],
-      args: %w(echo "KUBERNETES-DEPLOY")
+      args: ["echo", "'KUBERNETES-DEPLOY'"]
     )
 
     assert_logs_match(/Starting task runner/)
@@ -68,8 +68,9 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     refute task_runner.run(
       task_template: 'hello-cloud-template-runner',
       entrypoint: ['/bin/bash'],
-      args: %w(echo "KUBERNETES-DEPLOY")
+      args: ["echo", "'KUBERNETES-DEPLOY'"]
     )
-    assert_logs_match(/Pod template `hello-cloud-template-runner` cannot be found in namespace: `.+`, context: `minikube`/)
+    expected = /Pod template `hello-cloud-template-runner` cannot be found in namespace: `.+`, context: `minikube`/
+    assert_logs_match(expected)
   end
 end

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -9,7 +9,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
-      logger: test_logger,
+      logger: logger,
     )
 
     assert task_runner.run(
@@ -29,7 +29,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
-      logger: test_logger,
+      logger: logger,
     )
 
     assert task_runner.run(
@@ -47,7 +47,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: "missing",
-      logger: test_logger,
+      logger: logger,
     )
 
     refute task_runner.run(
@@ -62,7 +62,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
-      logger: test_logger,
+      logger: logger,
     )
 
     refute task_runner.run(

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -9,6 +9,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
+      logger: test_logger,
     )
 
     task_runner.run(
@@ -26,6 +27,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: @namespace,
+      logger: test_logger,
     )
 
     pod = task_runner.run(

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -3,35 +3,32 @@ require 'test_helper'
 
 require 'kubernetes-deploy/runner_task'
 class RunnerTaskTest < KubernetesDeploy::IntegrationTest
-  def test_works
+  def test_run_works
     deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
 
-    task_runner = KubernetesDeploy::RunnerTask.new(
-      context: KubeclientHelper::MINIKUBE_CONTEXT,
-      namespace: @namespace,
-      logger: logger,
-    )
-
-    assert task_runner.run(
-      task_template: 'hello-cloud-template-runner',
-      entrypoint: ['/bin/bash'],
-      args: ["echo", "'KUBERNETES-DEPLOY'"]
-    )
+    task_runner = build_task_runner
+    assert task_runner.run(**valid_run_params)
 
     assert_logs_match(/Starting task runner/)
     pods = kubeclient.get_pods(namespace: @namespace)
     assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
   end
 
-  def test_substitutes_arguments
+  def test_run_bang_works
     deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
 
-    task_runner = KubernetesDeploy::RunnerTask.new(
-      context: KubeclientHelper::MINIKUBE_CONTEXT,
-      namespace: @namespace,
-      logger: logger,
-    )
+    task_runner = build_task_runner
+    task_runner.run!(**valid_run_params)
 
+    assert_logs_match(/Starting task runner/)
+    pods = kubeclient.get_pods(namespace: @namespace)
+    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
+  end
+
+  def test_run_substitutes_arguments
+    deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
+
+    task_runner = build_task_runner
     assert task_runner.run(
       task_template: 'hello-cloud-template-runner',
       entrypoint: nil,
@@ -43,13 +40,8 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     assert_equal %w(rake some_task), pods.first.spec.containers.first.args
   end
 
-  def test_missing_namespace
-    task_runner = KubernetesDeploy::RunnerTask.new(
-      context: KubeclientHelper::MINIKUBE_CONTEXT,
-      namespace: "missing",
-      logger: logger,
-    )
-
+  def test_run_with_missing_namespace
+    task_runner = build_task_runner(ns: "missing")
     refute task_runner.run(
       task_template: 'hello-cloud-template-runner',
       entrypoint: nil,
@@ -58,19 +50,28 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     assert_logs_match("Configuration invalid: Namespace was not found")
   end
 
-  def test_template_runner_template_missing
-    task_runner = KubernetesDeploy::RunnerTask.new(
-      context: KubeclientHelper::MINIKUBE_CONTEXT,
-      namespace: @namespace,
-      logger: logger,
-    )
-
-    refute task_runner.run(
-      task_template: 'hello-cloud-template-runner',
-      entrypoint: ['/bin/bash'],
-      args: ["echo", "'KUBERNETES-DEPLOY'"]
-    )
+  def test_run_with_template_runner_template_missing
+    task_runner = build_task_runner
+    refute task_runner.run(**valid_run_params)
     expected = /Pod template `hello-cloud-template-runner` cannot be found in namespace: `.+`, context: `minikube`/
     assert_logs_match(expected)
+  end
+
+  def test_run_bang_with_template_missing_raises_exception
+    task_runner = build_task_runner
+    message = /Pod template `hello-cloud-template-runner` cannot be found in namespace: `.+`, context: `minikube`/
+    assert_raises(KubernetesDeploy::RunnerTask::TaskTemplateMissingError, message: message) do
+      task_runner.run!(**valid_run_params)
+    end
+  end
+
+  private
+
+  def valid_run_params
+    { task_template: 'hello-cloud-template-runner', entrypoint: ['/bin/bash'], args: ["echo", "'KUBERNETES-DEPLOY'"] }
+  end
+
+  def build_task_runner(ns: @namespace)
+    KubernetesDeploy::RunnerTask.new(context: KubeclientHelper::MINIKUBE_CONTEXT, namespace: ns, logger: logger)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,8 @@ module KubernetesDeploy
       @logger_stream.rewind
       if times
         count = @logger_stream.read.scan(regexp).count
-        assert_equal times, count, "Expected #{regexp} to appear #{times} time(s) in the log, but appeared #{count} times"
+        fail_msg = "Expected #{regexp} to appear #{times} time(s) in the log, but it appeared #{count} times"
+        assert_equal times, count, fail_msg
       else
         assert_match regexp, @logger_stream.read
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,8 +24,8 @@ module KubernetesDeploy
       @logger_stream = StringIO.new
     end
 
-    def test_logger
-      @test_logger ||= begin
+    def logger
+      @logger ||= begin
         device = ENV["PRINT_LOGS"] ? $stderr : @logger_stream
         KubernetesDeploy::FormattedLogger.build(@namespace, KubeclientHelper::MINIKUBE_CONTEXT, device)
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,6 @@ require 'mocha/mini_test'
 Dir.glob(File.expand_path("../helpers/**/*.rb", __FILE__)).each { |file| require file }
 ENV["KUBECONFIG"] ||= "#{Dir.home}/.kube/config"
 
-WebMock.allow_net_connect!
 Mocha::Configuration.prevent(:stubbing_method_unnecessarily)
 Mocha::Configuration.prevent(:stubbing_non_existent_method)
 Mocha::Configuration.prevent(:stubbing_non_public_method)
@@ -93,10 +92,12 @@ module KubernetesDeploy
     include FixtureDeployHelper
 
     def run
+      WebMock.allow_net_connect!
       @namespace = TestProvisioner.claim_namespace(name)
       super
     ensure
       TestProvisioner.delete_namespace(@namespace)
+      WebMock.disable_net_connect!
     end
   end
 
@@ -144,6 +145,8 @@ module KubernetesDeploy
     end
   end
 
+  WebMock.allow_net_connect!
   TestProvisioner.prepare_pv("pv0001")
   TestProvisioner.prepare_pv("pv0002")
+  WebMock.disable_net_connect!
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,7 @@ module KubernetesDeploy
     def test_logger
       @test_logger ||= begin
         device = ENV["PRINT_LOGS"] ? $stderr : @logger_stream
-        KubernetesDeploy::Logger.build(@namespace, KubeclientHelper::MINIKUBE_CONTEXT, device)
+        KubernetesDeploy::FormattedLogger.build(@namespace, KubeclientHelper::MINIKUBE_CONTEXT, device)
       end
     end
 
@@ -46,10 +46,21 @@ module KubernetesDeploy
       @logger_stream.rewind
       if times
         count = @logger_stream.read.scan(regexp).count
-        assert_equal 1, count, "Expected #{regexp} to appear #{times} time(s) in the log, but appeared #{count} times"
+        assert_equal times, count, "Expected #{regexp} to appear #{times} time(s) in the log, but appeared #{count} times"
       else
         assert_match regexp, @logger_stream.read
       end
+    end
+
+    def refute_logs_match(regexp)
+      if ENV["PRINT_LOGS"]
+        assertion = "\033[0;35mrefute_logs_match(#{regexp.inspect})\033[0;33m"
+        $stderr.puts("\033[0;33mWARNING: Skipping #{assertion} while logs are redirected to stderr\033[0m")
+        return
+      end
+
+      @logger_stream.rewind
+      refute_match regexp, @logger_stream.read
     end
 
     def assert_raises(*exp, message: nil)

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -153,7 +153,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
       namespace: 'test',
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       template_dir: dir,
-      logger: test_logger
+      logger: logger
     )
   end
 end

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def setup
-    KubernetesDeploy::Kubectl.expects(:run_kubectl).never
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
     super
   end
 
@@ -116,8 +116,8 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def stub_kubectl_response(*args, resp:, err: "", success: true)
     response = [resp.to_json, err, stub(success?: success)]
-    KubernetesDeploy::Kubectl.expects(:run_kubectl)
-      .with(*args, namespace: 'test', context: 'minikube', log_failure: false)
+    KubernetesDeploy::Kubectl.any_instance.expects(:run)
+      .with(*args)
       .returns(response)
   end
 
@@ -152,7 +152,8 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     KubernetesDeploy::EjsonSecretProvisioner.new(
       namespace: 'test',
       context: KubeclientHelper::MINIKUBE_CONTEXT,
-      template_dir: dir
+      template_dir: dir,
+      logger: test_logger
     )
   end
 end

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class KubectlTest < KubernetesDeploy::TestCase
+  def setup
+    Open3.expects(:capture3).never
+    super
+  end
+
+  def test_raises_if_initialized_with_null_context
+    assert_raises_message(ArgumentError, "context is required") do
+      KubernetesDeploy::Kubectl.new(namespace: 'test', context: nil, logger: test_logger, log_failure_by_default: true)
+    end
+  end
+
+  def test_raises_if_initialized_with_null_namespace
+    assert_raises_message(ArgumentError, "namespace is required") do
+      KubernetesDeploy::Kubectl.new(namespace: nil, context: 'test', logger: test_logger, log_failure_by_default: true)
+    end
+  end
+
+  def test_run_constructs_the_expected_command_and_returns_the_correct_values
+    stub_open3(%w(kubectl get pods -a --output=json --namespace=testn --context=testc), resp: "{ items: [] }")
+
+    out, err, st = build_kubectl.run("get", "pods", "-a", "--output=json")
+    assert st.success?
+    assert_equal "{ items: [] }", out
+    assert_equal "", err
+  end
+
+  def test_run_omits_context_flag_if_use_context_is_false
+    stub_open3(%w(kubectl get pods -a --output=json --namespace=testn), resp: "{ items: [] }")
+    build_kubectl.run("get", "pods", "-a", "--output=json", use_context: false)
+  end
+
+  def test_run_omits_namespace_flag_if_use_namespace_is_false
+    stub_open3(%w(kubectl get pods -a --output=json --context=testc), resp: "{ items: [] }")
+    build_kubectl.run("get", "pods", "-a", "--output=json", use_namespace: false)
+  end
+
+  def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_unspecified
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).twice
+    build_kubectl(log_failure_by_default: true).run("get", "pods")
+  end
+
+  def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_also_true
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).twice
+    build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: true)
+  end
+
+  def test_run_does_not_log_failures_when_log_failure_by_default_is_true_and_override_is_false
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).never
+    build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: false)
+  end
+
+  def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_unspecified
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).never
+    build_kubectl(log_failure_by_default: false).run("get", "pods")
+  end
+
+  def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_also_false
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).never
+    build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: false)
+  end
+
+  def test_run_logs_failures_when_log_failure_by_default_is_false_and_override_is_true
+    stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
+    test_logger.expects(:warn).twice
+    build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: true)
+  end
+
+  private
+
+  def build_kubectl(log_failure_by_default: true)
+    KubernetesDeploy::Kubectl.new(namespace: 'testn', context: 'testc', logger: test_logger,
+      log_failure_by_default: log_failure_by_default)
+  end
+
+  def stub_open3(command, resp:, err: "", success: true)
+    Open3.expects(:capture3).with(*command).returns([resp, err, stub(success?: success)])
+  end
+end

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -40,38 +40,38 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_unspecified
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).twice
     build_kubectl(log_failure_by_default: true).run("get", "pods")
+    assert_logs_match("[WARN]", 2)
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_also_true
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).twice
     build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: true)
+    assert_logs_match("[WARN]", 2)
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_true_and_override_is_false
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).never
     build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: false)
+    refute_logs_match("[WARN]")
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_unspecified
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).never
     build_kubectl(log_failure_by_default: false).run("get", "pods")
+    refute_logs_match("[WARN]")
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_also_false
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).never
     build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: false)
+    refute_logs_match("[WARN]")
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_false_and_override_is_true
     stub_open3(%w(kubectl get pods --namespace=testn --context=testc), resp: "", err: "oops", success: false)
-    test_logger.expects(:warn).twice
     build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: true)
+    assert_logs_match("[WARN]", 2)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -9,13 +9,13 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_raises_if_initialized_with_null_context
     assert_raises_message(ArgumentError, "context is required") do
-      KubernetesDeploy::Kubectl.new(namespace: 'test', context: nil, logger: test_logger, log_failure_by_default: true)
+      KubernetesDeploy::Kubectl.new(namespace: 'test', context: nil, logger: logger, log_failure_by_default: true)
     end
   end
 
   def test_raises_if_initialized_with_null_namespace
     assert_raises_message(ArgumentError, "namespace is required") do
-      KubernetesDeploy::Kubectl.new(namespace: nil, context: 'test', logger: test_logger, log_failure_by_default: true)
+      KubernetesDeploy::Kubectl.new(namespace: nil, context: 'test', logger: logger, log_failure_by_default: true)
     end
   end
 
@@ -77,7 +77,7 @@ class KubectlTest < KubernetesDeploy::TestCase
   private
 
   def build_kubectl(log_failure_by_default: true)
-    KubernetesDeploy::Kubectl.new(namespace: 'testn', context: 'testc', logger: test_logger,
+    KubernetesDeploy::Kubectl.new(namespace: 'testn', context: 'testc', logger: logger,
       log_failure_by_default: log_failure_by_default)
   end
 

--- a/test/unit/kubernetes-deploy/logger_test.rb
+++ b/test/unit/kubernetes-deploy/logger_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require 'test_helper'
 
-class LoggerTest < KubernetesDeploy::TestCase
+class FormattedLoggerTest < KubernetesDeploy::TestCase
   def test_build
-    new_logger = KubernetesDeploy::Logger.build('test-ns', 'minikube', @logger_stream)
+    new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
     assert new_logger.is_a?(::Logger)
     assert_equal ::Logger::INFO, new_logger.level
     refute_nil new_logger.formatter
@@ -12,7 +12,7 @@ class LoggerTest < KubernetesDeploy::TestCase
   def test_debug_log_level_from_env
     original_env = ENV["DEBUG"]
     ENV["DEBUG"] = "lol"
-    new_logger = KubernetesDeploy::Logger.build('test-ns', 'minikube', @logger_stream)
+    new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
     assert_equal ::Logger::DEBUG, new_logger.level
   ensure
     ENV["DEBUG"] = original_env
@@ -21,20 +21,20 @@ class LoggerTest < KubernetesDeploy::TestCase
   def test_warn_log_level_from_env
     original_env = ENV["LEVEL"]
     ENV["LEVEL"] = "warn"
-    new_logger = KubernetesDeploy::Logger.build('test-ns', 'minikube', @logger_stream)
+    new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
     assert_equal ::Logger::WARN, new_logger.level
   ensure
     ENV["LEVEL"] = original_env
   end
 
   def test_verbose_tag_mode
-    new_logger = KubernetesDeploy::Logger.build('test-ns', 'minikube', @logger_stream, verbose_tags: true)
+    new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream, verbose_prefix: true)
     new_logger.info("This should have namespace and context information")
     assert_logs_match(/^\[INFO\].*\[minikube\]\[test-ns\]\tThis should have namespace and context information$/)
   end
 
   def test_blank_line
-    new_logger = KubernetesDeploy::Logger.build('test-ns', 'minikube', @logger_stream)
+    new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
     new_logger.info("FYI")
     new_logger.blank_line
     new_logger.warn("Warning")

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -5,16 +5,16 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_requires_enumerable
     expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
     assert_raises_message(ArgumentError, expected_msg) do
-      KubernetesDeploy::ResourceWatcher.new(Object.new, logger: test_logger)
+      KubernetesDeploy::ResourceWatcher.new(Object.new, logger: logger)
     end
 
-    KubernetesDeploy::ResourceWatcher.new([], logger: test_logger)
+    KubernetesDeploy::ResourceWatcher.new([], logger: logger)
   end
 
   def test_success_with_mock_resource
     resource = build_mock_resource
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -24,7 +24,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_failure_with_mock_resource
     resource = build_mock_resource(final_status: "failed")
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -35,7 +35,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_timeout_from_resource
     resource = build_mock_resource(final_status: "timeout")
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -49,7 +49,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     third = build_mock_resource(final_status: "failed", hits_to_complete: 3, name: "third")
     fourth = build_mock_resource(final_status: "success", hits_to_complete: 4, name: "fourth")
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([first, second, third, fourth], logger: test_logger)
+    watcher = KubernetesDeploy::ResourceWatcher.new([first, second, third, fourth], logger: logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for first, second, third, fourth with 4s timeout/)

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -5,16 +5,16 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   def test_requires_enumerable
     expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
     assert_raises_message(ArgumentError, expected_msg) do
-      KubernetesDeploy::ResourceWatcher.new(Object.new)
+      KubernetesDeploy::ResourceWatcher.new(Object.new, logger: test_logger)
     end
 
-    KubernetesDeploy::ResourceWatcher.new([])
+    KubernetesDeploy::ResourceWatcher.new([], logger: test_logger)
   end
 
   def test_success_with_mock_resource
     resource = build_mock_resource
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -22,9 +22,9 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   end
 
   def test_failure_with_mock_resource
-    resource = build_mock_resource("failed")
+    resource = build_mock_resource(final_status: "failed")
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -33,9 +33,9 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   end
 
   def test_timeout_from_resource
-    resource = build_mock_resource("timeout")
+    resource = build_mock_resource(final_status: "timeout")
 
-    watcher = KubernetesDeploy::ResourceWatcher.new([resource])
+    watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: test_logger)
     watcher.run(delay_sync: 0.1)
 
     assert_logs_match(/Waiting for web-pod with 1s timeout/)
@@ -43,28 +43,57 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     assert_logs_match(/Spent (\S+)s waiting for web-pod/)
   end
 
+  def test_wait_logging_when_resources_do_not_finish_together
+    first = build_mock_resource(final_status: "success", hits_to_complete: 1, name: "first")
+    second = build_mock_resource(final_status: "timeout", hits_to_complete: 2, name: "second")
+    third = build_mock_resource(final_status: "failed", hits_to_complete: 3, name: "third")
+    fourth = build_mock_resource(final_status: "success", hits_to_complete: 4, name: "fourth")
+
+    watcher = KubernetesDeploy::ResourceWatcher.new([first, second, third, fourth], logger: test_logger)
+    watcher.run(delay_sync: 0.1)
+
+    assert_logs_match(/Waiting for first, second, third, fourth with 4s timeout/)
+    assert_logs_match(/second failed to deploy with status 'timeout'/)
+    assert_logs_match(/third failed to deploy with status 'failed'/)
+    assert_logs_match(/Spent (\S+)s waiting for first, second, third, fourth/)
+  end
+
   private
 
-  MockResource = Struct.new(:id, :timeout, :status) do
+  MockResource = Struct.new(:id, :hits_to_complete, :status) do
     def sync
       @hits ||= 0
       @hits += 1
     end
 
     def deploy_finished?
-      @hits > 3
+      deploy_succeeded? || deploy_failed? || deploy_timed_out?
+    end
+
+    def deploy_succeeded?
+      status == "success" && hits_complete?
     end
 
     def deploy_failed?
-      status == "failed"
+      status == "failed" && hits_complete?
     end
 
     def deploy_timed_out?
-      status == "timeout"
+      status == "timeout" && hits_complete?
+    end
+
+    def timeout
+      hits_to_complete
+    end
+
+    private
+
+    def hits_complete?
+      @hits >= hits_to_complete
     end
   end
 
-  def build_mock_resource(status = nil)
-    MockResource.new("web-pod", 1, status)
+  def build_mock_resource(final_status: "success", hits_to_complete: 1, name: "web-pod")
+    MockResource.new(name, hits_to_complete, final_status)
   end
 end

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -3,52 +3,20 @@ require 'test_helper'
 require 'kubernetes-deploy/runner_task'
 
 class RunnerTaskUnitTest < KubernetesDeploy::TestCase
-  def test_missing_namespace
-    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError,
-      message: "Configuration invalid: Namespace was not found") do
-      task_runner = KubernetesDeploy::RunnerTask.new(
-        context: KubeclientHelper::MINIKUBE_CONTEXT,
-        namespace: "missing",
-        logger: test_logger,
-      )
+  def test_invalid_configuration
+    task_runner = KubernetesDeploy::RunnerTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: nil,
+      logger: test_logger,
+    )
 
-      task_runner.run(
-        task_template: 'hello-cloud-template-runner',
-        entrypoint: nil,
-        args: 'a'
-      )
-    end
-  end
-
-  def test_missing_arguments
-    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
-      task_runner = KubernetesDeploy::RunnerTask.new(
-        context: KubeclientHelper::MINIKUBE_CONTEXT,
-        namespace: @namespace,
-        logger: test_logger,
-      )
-
-      task_runner.run(
-        task_template: 'hello-cloud-template-runner',
-        entrypoint: nil,
-        args: nil
-      )
-    end
-  end
-
-  def test_missing_template
-    assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
-      task_runner = KubernetesDeploy::RunnerTask.new(
-        namespace: @namespace,
-        context: KubeclientHelper::MINIKUBE_CONTEXT,
-        logger: test_logger,
-      )
-
-      task_runner.run(
-        task_template: nil,
-        entrypoint: nil,
-        args: ['a']
-      )
-    end
+    refute task_runner.run(
+      task_template: nil,
+      entrypoint: nil,
+      args: nil
+    )
+    assert_logs_match(/Task template name can't be nil/)
+    assert_logs_match(/Namespace can't be empty/)
+    assert_logs_match(/Args can't be nil/)
   end
 end

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -8,20 +8,32 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
     super
   end
 
-  def test_invalid_configuration
+  def test_run_with_invalid_configuration
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: nil,
       logger: logger,
     )
 
-    refute task_runner.run(
-      task_template: nil,
-      entrypoint: nil,
-      args: nil
-    )
+    refute task_runner.run(task_template: nil, entrypoint: nil, args: nil)
     assert_logs_match(/Task template name can't be nil/)
     assert_logs_match(/Namespace can't be empty/)
     assert_logs_match(/Args can't be nil/)
+  end
+
+  def test_run_bang_with_invalid_configuration
+    task_runner = KubernetesDeploy::RunnerTask.new(
+      context: KubeclientHelper::MINIKUBE_CONTEXT,
+      namespace: nil,
+      logger: logger,
+    )
+
+    err = assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
+      task_runner.run!(task_template: nil, entrypoint: nil, args: nil)
+    end
+
+    assert_match(/Task template name can't be nil/, err.to_s)
+    assert_match(/Namespace can't be empty/, err.to_s)
+    assert_match(/Args can't be nil/, err.to_s)
   end
 end

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'test_helper'
+require 'kubernetes-deploy/runner_task'
 
 class RunnerTaskUnitTest < KubernetesDeploy::TestCase
   def test_missing_namespace
@@ -8,6 +9,7 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
       task_runner = KubernetesDeploy::RunnerTask.new(
         context: KubeclientHelper::MINIKUBE_CONTEXT,
         namespace: "missing",
+        logger: test_logger,
       )
 
       task_runner.run(
@@ -23,6 +25,7 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
       task_runner = KubernetesDeploy::RunnerTask.new(
         context: KubeclientHelper::MINIKUBE_CONTEXT,
         namespace: @namespace,
+        logger: test_logger,
       )
 
       task_runner.run(
@@ -37,7 +40,8 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
     assert_raises(KubernetesDeploy::RunnerTask::FatalTaskRunError) do
       task_runner = KubernetesDeploy::RunnerTask.new(
         namespace: @namespace,
-        context: KubeclientHelper::MINIKUBE_CONTEXT
+        context: KubeclientHelper::MINIKUBE_CONTEXT,
+        logger: test_logger,
       )
 
       task_runner.run(

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 require 'kubernetes-deploy/runner_task'
 
 class RunnerTaskUnitTest < KubernetesDeploy::TestCase
+  def setup
+    Kubeclient::Client.any_instance.stubs(:discover)
+    super
+  end
+
   def test_invalid_configuration
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -7,7 +7,7 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
     task_runner = KubernetesDeploy::RunnerTask.new(
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       namespace: nil,
-      logger: test_logger,
+      logger: logger,
     )
 
     refute task_runner.run(

--- a/test/unit/kubernetes-deploy/runner_test.rb
+++ b/test/unit/kubernetes-deploy/runner_test.rb
@@ -14,20 +14,20 @@ class RunnerTest < KubernetesDeploy::TestCase
 
     runner = KubernetesDeploy::Runner.new(
       namespace: "",
-      current_sha: "",
       context: "",
+      logger: test_logger,
+      current_sha: "",
       template_dir: "unknown",
-      wait_for_completion: true,
     )
-    error_msg = assert_raises(KubernetesDeploy::FatalDeploymentError) do
+    assert_raises_message(KubernetesDeploy::FatalDeploymentError, "Configuration invalid") do
       runner.run
-    end.to_s
+    end
 
-    assert_includes error_msg, "Kube config not found at /this-really-should/not-exist"
-    assert_includes error_msg, "Current SHA must be specified"
-    assert_includes error_msg, "Namespace must be specified"
-    assert_includes error_msg, "Context must be specified"
-    assert_match(/Template directory (\S+) doesn't exist/, error_msg)
+    assert_logs_match("Kube config not found at /this-really-should/not-exist")
+    assert_logs_match("Current SHA must be specified")
+    assert_logs_match("Namespace must be specified")
+    assert_logs_match("Context must be specified")
+    assert_logs_match(/Template directory (\S+) doesn't exist/)
 
   ensure
     ENV["KUBECONFIG"] = original_env

--- a/test/unit/kubernetes-deploy/runner_test.rb
+++ b/test/unit/kubernetes-deploy/runner_test.rb
@@ -15,7 +15,7 @@ class RunnerTest < KubernetesDeploy::TestCase
     runner = KubernetesDeploy::Runner.new(
       namespace: "",
       context: "",
-      logger: test_logger,
+      logger: logger,
       current_sha: "",
       template_dir: "unknown",
     )

--- a/test/unit/kubernetes-deploy/runner_test.rb
+++ b/test/unit/kubernetes-deploy/runner_test.rb
@@ -19,10 +19,9 @@ class RunnerTest < KubernetesDeploy::TestCase
       current_sha: "",
       template_dir: "unknown",
     )
-    assert_raises_message(KubernetesDeploy::FatalDeploymentError, "Configuration invalid") do
-      runner.run
-    end
+    runner.run
 
+    assert_logs_match("Configuration invalid")
     assert_logs_match("Kube config not found at /this-really-should/not-exist")
     assert_logs_match("Current SHA must be specified")
     assert_logs_match("Namespace must be specified")


### PR DESCRIPTION
@Shopify/cloudplatform 

## Background

This PR is groundwork for an overhaul of deploy output. See [these screenshots](https://gist.github.com/KnVerey/fed879e4da297f6e7bbd21fcfbb671b0) for a preview of the goal (this PR is extracted from wip branch [improve_output](https://github.com/Shopify/kubernetes-deploy/compare/improve_output)). Notable goals of the overhaul for the purposes of this PR:
- make log lines more consistent (same prefixes, consistent left margin, consistent formatting)
- get rid of redundant logging
- get rid of `KUBESTATUS` in favour of targeted debug information in a new summary section. We may yet build a visualization, but it won't be all that soon, and ideally it wouldn't be done at the expense of deploy log clarity.

## Purpose of this PR

These changes make the gem use a single logger instance with access to deploy context for all logging, whether it's done by the main command (e.g. KubernetesDeploy::Runner), the kubectl executor, a KubernetesResource, or something else. 
* That logger's tags (i.e. the `[INFO][2017-05-24][context][namespace]` prefix) can _optionally_ include the context and namespace; this is now off by default, since it's noise for everything but Core.**
* The kubestatus logging's tag is now additional to those output by the unified logger. However, this logging will be removed entirely in the follow-up.
* `ENV[PRINT_LOGS]` is available to make the test logger print to stderr, so you can easily use tests for tophatting output.

**Fundamentally, the reason this PR changes the logger and Kubectl from class-level to instance-level constructs is the need for them to access the current context/namespace and an aversion to making these globally available at the class level. If these tags weren't important to core (without them, you have no idea what log line came from what deploy process), this PR could be much simpler. :-/

Incidentally fixes 2/3 items in https://github.com/Shopify/kubernetes-deploy/issues/52.

## Rollout

This doesn't improve much on its own, so I don't currently intend to release a version for it. However, it also shouldn't make the output any worse, so if we need to do a release between this and my main PR merging, that's fine.

🎩  before merging:
- [x] eyeball output of all three commands via tests
- [x] eyeball output of a few success/failure deploys via tests
- [x] run the exes to make sure I didn't break them