### PR TITLE
Fix negative argument (ArgumentError)

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -183,7 +183,7 @@ module KubernetesDeploy
     end
 
     def pretty_status
-      padding = " " * (50 - id.length)
+      padding = " " * [50 - id.length, 1].max
       msg = exists? ? status : "not found"
       "#{id}#{padding}#{msg}"
     end

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,3 +1,3 @@
 module KubernetesDeploy
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
Ran into this error while touching things too late at night.

This should fix it. 

```[INFO][2017-06-02 03:02:43 +0000]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2017-06-02 03:02:43 +0000]	No actions taken
/usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/lib/kubernetes-deploy/kubernetes_resource.rb:186:in `*': negative argument (ArgumentError)
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/lib/kubernetes-deploy/kubernetes_resource.rb:186:in `pretty_status'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/lib/kubernetes-deploy/runner.rb:91:in `block in run'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/lib/kubernetes-deploy/runner.rb:91:in `each'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/lib/kubernetes-deploy/runner.rb:91:in `run'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/lib/ruby/gems/2.3.0/gems/kubernetes-deploy-0.7.0/exe/kubernetes-deploy:61:in `<top (required)>'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/bin/kubernetes-deploy:22:in `load'
	from /usr/lib/ruby-shopify/ruby-shopify-2.3.3/bin/kubernetes-deploy:22:in `<main>'
kubernetes-deploy pipa-test pipa-test exited with status 1```