### PR TITLE
Use any bundler

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"


### PR DESCRIPTION
I'd like to get this working with Shipit, but I'm getting:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.13)
  Current Bundler version:
    bundler (1.12.5)
This Gemfile requires a different version of Bundler.
```

(https://shipit.shopify.io/shopify/kubernetes-deploy/rubygems)

Could we just relax the requirement?

@KnVerey 