### PR TITLE
Quick fixes to output changes

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -79,6 +79,7 @@ module KubernetesDeploy
           "logs",
           @name,
           "--timestamps=true",
+          "--container=#{container_name}",
           "--since-time=#{@deploy_started.to_datetime.rfc3339}"
         )
         container_logs["#{id}/#{container_name}"] = out

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -113,7 +113,16 @@ module KubernetesDeploy
 
       deploy_resources(resources, prune: prune)
 
-      return true unless verify_result
+      unless verify_result
+        @logger.summary.add_action("deployed #{resources.length} #{'resource'.pluralize(resources.length)}")
+        warning = <<-MSG.strip_heredoc
+          Deploy result verification is disabled for this deploy.
+          This means the desired changes were communicated to Kubernetes, but the deploy did not make sure they actually succeeded.
+        MSG
+        @logger.summary.add_paragraph(ColorizedString.new(warning).yellow)
+        return success = true
+      end
+
       wait_for_completion(resources)
       record_statuses(resources)
       success = resources.all?(&:deploy_succeeded?)

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -58,3 +58,6 @@ spec:
             configMapKeyRef:
               name: hello-cloud-configmap-data
               key: datapoint1
+      - name: sidecar
+        image: busybox
+        command: ["sleep", "8000"]

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -59,7 +59,7 @@ module FixtureSetAssertions
         label_selector: "name=#{dep_name},app=#{app_name}"
       )
       assert_equal 1, deployments.size, "Expected 1 #{dep_name} deployment, got #{deployments.size}"
-      available = deployments.first["status"]["availableReplicas"]
+      available = deployments.first["status"]["availableReplicas"].to_i
 
       msg = "Expected #{dep_name} deployment to have #{replicas} available replicas, saw #{available}"
       assert_equal replicas, available, msg

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -206,10 +206,11 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_wait_false_ignores_non_priority_resource_failures
     # web depends on configmap so will not succeed deployed alone
     assert deploy_fixtures("hello-cloud", subset: ["web.yml.erb"], wait: false)
-
-    pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=hello-cloud')
-    assert_equal 1, pods.size, "Unable to find web pod"
-    assert_equal "Pending", pods.first.status.phase
+    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+    hello_cloud.assert_deployment_up("web", replicas: 0) # it exists, but no pods available yet
+    assert_logs_match("Result: SUCCESS")
+    assert_logs_match("Deployed 3 resources")
+    assert_logs_match("Deploy result verification is disabled for this deploy.")
   end
 
   def test_extra_bindings_should_be_rendered

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -134,8 +134,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   def fetch_restarted_at(deployment_name)
     deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
     containers = deployment.spec.template.spec.containers
-    assert_equal 1, containers.size
-    env = containers.first.env
-    env && env.find { |n| n.name == "RESTARTED_AT" }
+    app_container = containers.find { |c| c["name"] == "app" }
+    app_container && app_container.env.find { |n| n.name == "RESTARTED_AT" }
   end
 end


### PR DESCRIPTION
A couple quick fixes to the output changes merged yesterday
- Actually use the container name when fetching the logs 🤦‍♀️ 
- Fix the result printed when result verification is turned off (it was printing "Deploy failed" and "no actions taken", and returning `true`).
- Hopefully improve `test_wait_false_ignores_non_priority_resource_failures`, which was flaking on CI.