### PR TITLE
More output tweaks

### DIFF
--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -23,12 +23,12 @@ module KubernetesDeploy
       heading("Phase #{@current_phase}: #{phase_name}")
     end
 
-    def heading(text, secondary_msg = '', secondary_msg_color = :blue)
+    def heading(text, secondary_msg = '', secondary_msg_color = :light_blue)
       padding = (100.0 - (text.length + secondary_msg.length)) / 2
       blank_line
-      part1 = ColorizedString.new("#{'-' * padding.floor}#{text}").blue
+      part1 = ColorizedString.new("#{'-' * padding.floor}#{text}").light_blue
       part2 = ColorizedString.new(secondary_msg).colorize(secondary_msg_color)
-      part3 = ColorizedString.new('-' * padding.ceil).blue
+      part3 = ColorizedString.new('-' * padding.ceil).light_blue
       info(part1 + part2 + part3)
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -78,7 +78,6 @@ module KubernetesDeploy
         out, _err, _st = kubectl.run(
           "logs",
           @name,
-          "--timestamps=true",
           "--container=#{container_name}",
           "--since-time=#{@deploy_started.to_datetime.rfc3339}"
         )

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -337,8 +337,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match("Deployment/web: FAILED")
     assert_logs_match("Final status: 1 updatedReplicas, 1 replicas, 1 unavailableReplicas")
     assert_logs_match(%r{\[Deployment/web\].*Scaled up replica set web-}) # deployment event
-    assert_logs_match(/failed to "StartContainer" for "app" with CrashLoopBackOff/) # app event
-    assert_logs_match(/failed to "StartContainer" for "sidecar" with CrashLoopBackOff/) # sidecar event
+    assert_logs_match(/Back-off restarting failed container/) # event
     assert_logs_match("nginx: [error]") # app log
     assert_logs_match("ls: /not-a-dir: No such file or directory") # sidecar log
   end


### PR DESCRIPTION
This PR:
- Changes a test assertion that is failing on master. Events aren't fetched per-container, so search for one that is logged on account of both containers for greater stability.
- Changes headings back to light blue.
- Removes the kubectl logs timestamps. Most of our apps will be logging timestamps themselves, so this setting is causing log lines to have three of them (deploy's, kubectl logs' and the one from the app). Example:

```
[INFO][2017-06-01 19:35:12 +0000]	[Pod/db-migrate-f1f5fc7a-bc8df3ed/command-runner]	2017-06-01T19:35:09.640337963Z D, [2017-06-01T19:35:09.593895 #40] DEBUG -- :    (0.9ms)  BEGIN
```

@stefanmb 