### PR TITLE
Replicaset awareness

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -136,10 +136,11 @@ module KubernetesDeploy
         if container_logs.blank? || container_logs.values.all?(&:blank?)
           helpful_info << "  - Logs: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
         else
-          helpful_info << "  - Logs (last #{LOG_LINE_COUNT} lines shown):"
-          container_logs.each do |identifier, logs|
-            logs.split("\n").each do |line|
-              helpful_info << "      [#{identifier}]\t#{line}"
+          sorted_logs = container_logs.sort_by { |_, log_lines| log_lines.length }
+          sorted_logs.each do |identifier, log_lines|
+            helpful_info << "  - Logs from container '#{identifier}' (last #{LOG_LINE_COUNT} lines shown):"
+            log_lines.each do |line|
+              helpful_info << "      #{line}"
             end
           end
         end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -4,78 +4,84 @@ module KubernetesDeploy
     TIMEOUT = 5.minutes
 
     def sync
-      json_data, _err, st = kubectl.run("get", type, @name, "--output=json")
+      raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")
       @found = st.success?
-      @rollout_data = {}
-      @status = nil
-      @representative_pod = nil
-      @pods = []
 
       if @found
-        @rollout_data = JSON.parse(json_data)["status"]
-          .slice("updatedReplicas", "replicas", "availableReplicas", "unavailableReplicas")
-        @status = @rollout_data.map { |replica_state, num| "#{num} #{replica_state}" }.join(", ")
-
-        pod_list, _err, st = kubectl.run("get", "pods", "-a", "-l", "name=#{name}", "--output=json")
-        if st.success?
-          pods_json = JSON.parse(pod_list)["items"]
-          pods_json.each do |pod_json|
-            pod = Pod.new(
-              namespace: namespace,
-              context: context,
-              definition: pod_json,
-              logger: @logger,
-              parent: "#{@name.capitalize} deployment",
-              deploy_started: @deploy_started
-            )
-            pod.sync(pod_json)
-
-            if !@representative_pod && pod_probably_new?(pod_json)
-              @representative_pod = pod
-            end
-            @pods << pod
-          end
-        end
+        deployment_data = JSON.parse(raw_json)
+        @latest_rs = find_latest_rs(deployment_data)
+        @rollout_data = { "replicas" => 0 }.merge(deployment_data["status"]
+          .slice("replicas", "updatedReplicas", "availableReplicas", "unavailableReplicas"))
+        @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
+      else # reset
+        @latest_rs = nil
+        @rollout_data = { "replicas" => 0 }
+        @status = nil
       end
-    end
-
-    def fetch_logs
-      @representative_pod ? @representative_pod.fetch_logs : {}
     end
 
     def fetch_events
       own_events = super
-      return own_events unless @representative_pod
-      own_events.merge(@representative_pod.fetch_events)
+      return own_events unless @latest_rs.present?
+      own_events.merge(@latest_rs.fetch_events)
+    end
+
+    def fetch_logs
+      return {} unless @latest_rs.present?
+      @latest_rs.fetch_logs
     end
 
     def deploy_succeeded?
-      return false unless @rollout_data.key?("availableReplicas")
-      # TODO: this should look at the current replica set's pods too
+      return false unless @latest_rs
+
+      @latest_rs.deploy_succeeded? &&
+      @latest_rs.desired_replicas == desired_replicas && # latest RS fully scaled up
       @rollout_data["updatedReplicas"].to_i == @rollout_data["replicas"].to_i &&
       @rollout_data["updatedReplicas"].to_i == @rollout_data["availableReplicas"].to_i
     end
 
     def deploy_failed?
-      # TODO: this should look at the current replica set's pods only or it'll never be true for rolling updates
-      @pods.present? && @pods.all?(&:deploy_failed?)
+      @latest_rs && @latest_rs.deploy_failed?
     end
 
     def deploy_timed_out?
-      # TODO: this should look at the current replica set's pods only or it'll never be true for rolling updates
-      super || @pods.present? && @pods.all?(&:deploy_timed_out?)
+      super || @latest_rs && @latest_rs.deploy_timed_out?
     end
 
     def exists?
       @found
     end
 
+    def desired_replicas
+      @definition["spec"]["replicas"].to_i
+    end
+
     private
 
-    def pod_probably_new?(pod_json)
-      return false unless @deploy_started
-      # Shitty, brittle workaround to identify a pod from the new ReplicaSet before implementing ReplicaSet awareness
-      Time.parse(pod_json["metadata"]["creationTimestamp"]) >= (@deploy_started - 30.seconds)
+    def find_latest_rs(deployment_data)
+      label_string = deployment_data["spec"]["selector"]["matchLabels"].map { |k, v| "#{k}=#{v}" }.join(",")
+      raw_json, _err, st = kubectl.run("get", "replicasets", "--output=json", "--selector=#{label_string}")
+      return unless st.success?
+
+      all_rs_data = JSON.parse(raw_json)["items"]
+      current_revision = deployment_data["metadata"]["annotations"]["deployment.kubernetes.io/revision"]
+
+      latest_rs_data = all_rs_data.find do |rs|
+        rs["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == deployment_data["metadata"]["uid"] } &&
+        rs["metadata"]["annotations"]["deployment.kubernetes.io/revision"] == current_revision
+      end
+      return unless latest_rs_data.present?
+
+      rs = ReplicaSet.new(
+        namespace: namespace,
+        context: context,
+        definition: latest_rs_data,
+        logger: @logger,
+        parent: "#{@name.capitalize} deployment",
+        deploy_started: @deploy_started
+      )
+      rs.sync(latest_rs_data)
+      rs
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class ReplicaSet < KubernetesResource
+    TIMEOUT = 5.minutes
+
+    def initialize(namespace:, context:, definition:, logger:, parent: nil, deploy_started: nil)
+      @parent = parent
+      @deploy_started = deploy_started
+      @rollout_data = { "replicas" => 0 }
+      @pods = []
+      super(namespace: namespace, context: context, definition: definition, logger: logger)
+    end
+
+    def sync(rs_data = nil)
+      if rs_data.blank?
+        raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")
+        rs_data = JSON.parse(raw_json) if st.success?
+      end
+
+      if rs_data.present?
+        @found = true
+        @rollout_data = { "replicas" => 0 }.merge(rs_data["status"]
+          .slice("replicas", "availableReplicas", "readyReplicas"))
+        @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
+        @pods = find_pods(rs_data)
+      else # reset
+        @found = false
+        @rollout_data = { "replicas" => 0 }
+        @status = nil
+        @pods = []
+      end
+    end
+
+    def deploy_succeeded?
+      @rollout_data["replicas"].to_i == @rollout_data["availableReplicas"].to_i &&
+      @rollout_data["replicas"].to_i == @rollout_data["readyReplicas"].to_i
+    end
+
+    def deploy_failed?
+      @pods.present? && @pods.all?(&:deploy_failed?)
+    end
+
+    def deploy_timed_out?
+      super || @pods.present? && @pods.all?(&:deploy_timed_out?)
+    end
+
+    def exists?
+      @found
+    end
+
+    def desired_replicas
+      @definition["spec"]["replicas"].to_i
+    end
+
+    def fetch_events
+      own_events = super
+      return own_events unless @pods.present?
+      own_events.merge(@pods.first.fetch_events)
+    end
+
+    def fetch_logs
+      container_names.each_with_object({}) do |container_name, container_logs|
+        out, _err, _st = kubectl.run(
+          "logs",
+          id,
+          "--container=#{container_name}",
+          "--since-time=#{@deploy_started.to_datetime.rfc3339}",
+          "--tail=#{LOG_LINE_COUNT}"
+        )
+        container_logs[container_name] = out.split("\n")
+      end
+    end
+
+    private
+
+    def unmanaged?
+      @parent.blank?
+    end
+
+    def container_names
+      @definition["spec"]["template"]["spec"]["containers"].map { |c| c["name"] }
+    end
+
+    def find_pods(rs_data)
+      label_string = rs_data["spec"]["selector"]["matchLabels"].map { |k, v| "#{k}=#{v}" }.join(",")
+      raw_json, _err, st = kubectl.run("get", "pods", "-a", "--output=json", "--selector=#{label_string}")
+      return [] unless st.success?
+
+      all_pods = JSON.parse(raw_json)["items"]
+      all_pods.each_with_object([]) do |pod_data, relevant_pods|
+        next unless pod_data["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == rs_data["metadata"]["uid"] }
+        pod = Pod.new(
+          namespace: namespace,
+          context: context,
+          definition: pod_data,
+          logger: @logger,
+          parent: "#{@name.capitalize} replica set",
+          deploy_started: @deploy_started
+        )
+        pod.sync(pod_data)
+        relevant_pods << pod
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -18,6 +18,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   pod_template
   bugsnag
   pod_disruption_budget
+  replica_set
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
 end

--- a/test/fixtures/hello-cloud/bare_replica_set.yml
+++ b/test/fixtures/hello-cloud/bare_replica_set.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  labels:
+    app: hello-cloud
+    name: bare-replica-set
+  name: bare-replica-set
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: bare-replica-set
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: bare-replica-set
+    spec:
+      containers:
+      - image: nginx:alpine
+        name: app
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -65,6 +65,18 @@ module FixtureSetAssertions
       assert_equal replicas, available, msg
     end
 
+    def assert_replica_set_up(rs_name, replicas:)
+      replica_sets = v1beta1_kubeclient.get_replica_sets(
+        namespace: namespace,
+        label_selector: "name=#{rs_name},app=#{app_name}"
+      )
+      assert_equal 1, replica_sets.size, "Expected 1 #{rs_name} replica set, got #{replica_sets.size}"
+      available = replica_sets.first["status"]["availableReplicas"]
+
+      msg = "Expected #{rs_name} replica_sets to have #{replicas} available replicas, saw #{available}"
+      assert_equal replicas, available, msg
+    end
+
     def assert_pvc_status(pvc_name, status)
       pvc = kubeclient.get_persistent_volume_claims(
         namespace: namespace,

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -13,6 +13,7 @@ module FixtureSetAssertions
       assert_configmap_data_present
       assert_podtemplate_runner_present
       assert_poddisruptionbudget
+      assert_bare_replicaset_up
     end
 
     def assert_unmanaged_pod_statuses(status, count = 1)
@@ -72,6 +73,11 @@ module FixtureSetAssertions
       budgets = policy_v1beta1_kubeclient.get_pod_disruption_budgets(namespace: namespace)
       assert_equal 1, budgets.size, "Expected 1 PodDisruptionBudget"
       assert_equal 2, budgets[0].spec.minAvailable, "Expected PodDisruptionBudget to be overridden"
+    end
+
+    def assert_bare_replicaset_up
+      assert_pod_status("bare-replica-set", "Running")
+      assert assert_replica_set_up("bare-replica-set", replicas: 1)
     end
   end
 end

--- a/test/unit/kubernetes-deploy/logger_test.rb
+++ b/test/unit/kubernetes-deploy/logger_test.rb
@@ -52,15 +52,15 @@ class FormattedLoggerTest < KubernetesDeploy::TestCase
     # [FATAL][2017-05-19 20:07:31 -0400]\t
     # [FATAL][2017-05-19 20:07:31 -0400]\tFatal
 
-    @logger_stream.rewind
-    scanner = StringScanner.new(@logger_stream.read)
-
-    assert scanner.scan_until(/^\[INFO\].*\]\tFYI$/)
-    assert scanner.scan_until(/^\[INFO\].*\]\t$/)
-    assert scanner.scan_until(/^\[WARN\].*\]\tWarning$/)
-    assert scanner.scan_until(/^\[WARN\].*\]\t$/)
-    assert scanner.scan_until(/^\[ERROR\].*\]\tError$/)
-    assert scanner.scan_until(/^\[FATAL\].*\]\t$/)
-    assert scanner.scan_until(/^\[FATAL\].*\]\tFatal$/)
+    entries = [
+      /^\[INFO\].*\]\tFYI$/,
+      /^\[INFO\].*\]\t$/,
+      /^\[WARN\].*\]\tWarning$/,
+      /^\[WARN\].*\]\t$/,
+      /^\[ERROR\].*\]\tError$/,
+      /^\[FATAL\].*\]\t$/,
+      /^\[FATAL\].*\]\tFatal$/
+    ]
+    assert_logs_match_all(entries, in_order: true)
   end
 end


### PR DESCRIPTION
@Shopify/cloudplatform 

This PR makes `KubernetesResource::Deployment` aware of replica sets. This should fix a number of outstanding issues:
- Pod warnings get shown for pods that are being shut down, in the case where the last deploy was bad and the current one is actually succeeding (very confusing output)
- The way we try to identify a representative pod for the purpose of outputting related events and logs on failed deploy is sketchy (https://github.com/Shopify/kubernetes-deploy/pull/98#discussion_r119244951) and could theoretically still select a pod from the wrong RS.
- Rolling updates currently cannot fail, and will never time out on the basis of their pod states ([notes in code](https://github.com/Shopify/kubernetes-deploy/blob/master/lib/kubernetes-deploy/kubernetes_resource/deployment.rb#L62-L67))

Fixes https://github.com/Shopify/kubernetes-deploy/issues/36
Fixes https://github.com/Shopify/kubernetes-deploy/issues/42 (with small amount of extra code + test)

## Problem

We currently make the link between a deployment and its pods by looking for a "name" label. This is super fragile, since we're not using the full selector set, plus the presence of that label is a Shopify convention, not a k8s requirement. Furthermore, even using the full selector set does not guarantee you're looking at the right pods if you've gotten yourself into a really bad state (selector overlap). Ideally we'd connect Deployments to the pods we care about in a robust way; this is much easier to do as of Kubernetes 1.6 (see "Additional context" below).

## Solution

This PR uses the full set of label selectors to grab all possibly relevant RS. It then uses the new `ownerReferences` information to select the RS it owns, and the `deployment.kubernetes.io/revision` to select the current RS. That RS in turn uses label selectors and `ownerReferences` to list its pods.

## Additional context

- kubectl itself identifies the new replicaset by calculating and comparing pod template hashes: https://github.com/kubernetes/kubernetes/blob/a9f5065833d782ea93a6f462674fc7d3fb3affe7/pkg/controller/deployment/util/deployment_util.go#L611-L622. I don' know whether they plan to switch to the new attributes I'm using here, but either way, that approach is not feasible for us.
- `ownerReferences` were added to Deployment in 1.6. The [PR](https://github.com/kubernetes/kubernetes/pull/35676) that introduced them mentions they will be used for RS garbage collection. However, the [issue it resolved](https://github.com/kubernetes/kubernetes/issues/33845) mentions use cases like ours here.
- The `deployment.kubernetes.io/revision` annotation is much older (circa 1.2). According to the [PR](https://github.com/kubernetes/kubernetes/pull/19581) introducing it, the rollout history and rollback features leverage it.  



