### PR TITLE
Fail the deploy when unmanaged pod predates it

### DIFF
--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -385,6 +385,22 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(/The Deployment "web" is invalid.*`selector` does not match template `labels`/)
   end
 
+  def test_output_when_unmanaged_pod_preexists
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "unmanaged-pod.yml.erb"]) do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["metadata"]["name"] = "oops-it-is-static"
+    end
+    assert_equal true, success, "Deploy failed when it was expected to succeed"
+
+    # Second deploy should fail because unmanaged pod already exists
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "unmanaged-pod.yml.erb"]) do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["metadata"]["name"] = "oops-it-is-static"
+    end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+    assert_logs_match("Unmanaged pods like Pod/oops-it-is-static must have unique names on every deploy")
+  end
+
   private
 
   def count_by_revisions(pods)


### PR DESCRIPTION
Fixes https://github.com/Shopify/kubernetes-deploy/issues/108

The problem was that the unmanaged pod name was hardcoded on that repo. The first deploy (the one where it spent a while trying to pull the container, then ultimately failed because of a missing rake task) successfully ran that pod. Subsequent deploys then tried to deploy the same pod, which therefore looked like it succeeded before the deploy even started. 

If it weren't for the `nil` bug, it would have dumped its logs during `Checking initial resource statuses`, which also would have been bad. IMO the deploy should fail immediately in that case, because if you `apply` a pod that has already run, it won't do anything, and these pods are expected to run during each deploy.

Here's what that deploy would have shown if this patch were in:

![image](https://user-images.githubusercontent.com/4789493/26858691-c0a62a26-4b00-11e7-965a-4794e404dc17.png)

