### PR TITLE
Improve event fetching

### DIFF
--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -340,6 +340,9 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(/Back-off restarting failed container/) # event
     assert_logs_match("nginx: [error]") # app log
     assert_logs_match("ls: /not-a-dir: No such file or directory") # sidecar log
+
+    refute_logs_match(/Started container with id/)
+    refute_logs_match(/Created container with id/)
   end
 
   def test_failed_deploy_to_nonexistent_namespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,6 +105,14 @@ module KubernetesDeploy
       source_dir
     end
 
+    def stub_kubectl_response(*args, resp:, err: "", success: true, json: true)
+      resp = resp.to_json if json
+      response = [resp, err, stub(success?: success)]
+      KubernetesDeploy::Kubectl.any_instance.expects(:run)
+        .with(*args)
+        .returns(response)
+    end
+
     private
 
     def logging_assertion

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -114,13 +114,6 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     end
   end
 
-  def stub_kubectl_response(*args, resp:, err: "", success: true)
-    response = [resp.to_json, err, stub(success?: success)]
-    KubernetesDeploy::Kubectl.any_instance.expects(:run)
-      .with(*args)
-      .returns(response)
-  end
-
   def dummy_ejson_secret(data = correct_ejson_key_secret_data)
     dummy_secret_hash(data: data, name: 'ejson-keys', managed: false)
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -2,9 +2,123 @@
 require 'test_helper'
 
 class KubernetesResourceTest < KubernetesDeploy::TestCase
+  class DummyResource < KubernetesDeploy::KubernetesResource
+    def initialize(*)
+      super(name: 'test', namespace: 'test', context: 'test', file: nil, logger: @logger)
+    end
+
+    def exists?
+      true
+    end
+  end
+
   def test_service_and_deployment_timeouts_are_equal
     message = "Service and Deployment timeouts have to match since services are waiting to get endpoints " \
       "from their backing deployments"
     assert_equal KubernetesDeploy::Service.timeout, KubernetesDeploy::Deployment.timeout, message
+  end
+
+  def test_fetch_events_parses_tricky_events_correctly
+    start_time = Time.now.utc - 10.seconds
+    dummy = DummyResource.new(name: 'test', namespace: 'test', context: 'test', file: nil, logger: @logger)
+    dummy.deploy_started = start_time
+
+    tricky_events = dummy_events(start_time)
+    assert tricky_events.first[:message].count("\n") > 1, "Sanity check failed: inadequate newlines in test events"
+
+    stub_kubectl_response("get", "events", anything, resp: build_event_jsonpath(tricky_events), json: false)
+    events = dummy.fetch_events
+    assert_includes_dummy_events(events, first: true, second: true)
+  end
+
+  def test_fetch_events_excludes_events_from_previous_deploys
+    start_time = Time.now.utc - 10.seconds
+    dummy = DummyResource.new
+    dummy.deploy_started = start_time
+    mixed_time_events = dummy_events(start_time)
+    mixed_time_events.first[:last_seen] = 1.hour.ago
+
+    stub_kubectl_response("get", "events", anything, resp: build_event_jsonpath(mixed_time_events), json: false)
+    events = dummy.fetch_events
+    assert_includes_dummy_events(events, first: false, second: true)
+  end
+
+  def test_fetch_events_returns_empty_hash_when_jsonpath_results_empty
+    dummy = DummyResource.new
+    dummy.deploy_started = Time.now.utc - 10.seconds
+
+    stub_kubectl_response("get", "events", anything, resp: "", json: false)
+    events = dummy.fetch_events
+    assert_operator events, :empty?
+  end
+
+  def test_fetch_events_excludes_events_belonging_to_other_resources
+    start_time = Time.now.utc - 10.seconds
+    dummy = DummyResource.new
+    dummy.deploy_started = start_time
+
+    not_my_events = dummy_events(start_time)
+    not_my_events.first[:kind] = "Pod"
+    not_my_events.last[:name] = "some-other-thing"
+
+    stub_kubectl_response("get", "events", anything, resp: build_event_jsonpath(not_my_events), json: false)
+    events = dummy.fetch_events
+    assert_includes_dummy_events(events, first: false, second: false)
+  end
+
+  private
+
+  def assert_includes_dummy_events(events, first:, second:)
+    unless first || second
+      assert_operator events, :empty?
+      return
+    end
+
+    key = "DummyResource/test"
+    expected = { key => [] }
+    first_event = "FailedSync: Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with " \
+      "ErrImagePull: \"rpc error: code = 2 desc = unknown blob\" (3 events)"
+    expected[key] << first_event if first
+
+    second_event = "FailedSync: Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with " \
+      "CrashLoopBackOff: \"Back-off 1m20s restarting failed container=test pod=test-299526239-5vlj9_test" \
+      "(00cfb839-4k2p-11e7-a12d-73972af001c2)\" (5 events)"
+    expected[key] << second_event if second
+
+    assert_equal expected, events
+  end
+
+  def dummy_events(start_time)
+    [
+      {
+        kind: "DummyResource",
+        name: "test",
+        count: 3,
+        last_seen: start_time + 3.seconds,
+        reason: "FailedSync",
+        message: <<-STRING.strip_heredoc
+          Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with ErrImagePull:
+           \"rpc error: code = 2 desc = unknown blob\"
+        STRING
+      },
+      {
+        kind: "DummyResource",
+        name: "test",
+        count: 5,
+        last_seen: start_time + 5.seconds,
+        reason: "FailedSync",
+        message: <<-STRING.strip_heredoc
+          Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with CrashLoopBackOff: \"Back-
+          off 1m20s restarting failed container=test pod=test-299526239-5vlj9_test(00cfb839-4k2p-11e7-a12d-73972af001c2)\"
+        STRING
+      }
+    ]
+  end
+
+  def build_event_jsonpath(dummy_events)
+    separator = KubernetesDeploy::KubernetesResource::Event::JSONPATH_SEPARATOR
+    dummy_events.each_with_object([]) do |e, jsonpaths|
+      jsonpaths << [e[:kind], e[:name], e[:count], e[:last_seen].to_s, e[:reason], e[:message]].join("\t")
+    end.join(separator).concat(separator)
   end
 end


### PR DESCRIPTION
@Shopify/cloudplatform @kirs 

Makes a few improvements to the event fetching code:
* Fixes event parsing when the event message includes a newline (note: in a rather large sample of events, I didn't see newlines in any other relevant fields, and I didn't see any tabs)
* Excludes events that occurred before the deploy started (relevant for controllers, such as Deployment, that span multiple deploys)
* Cleans up the code around event fetching and adds some unit test cases