### PR TITLE
Fix passing env vars into the task runneR

### DIFF
--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -106,7 +106,7 @@ module KubernetesDeploy
       container.args = args
       container.env ||= []
 
-      env_args = env_vars.map do |key, value|
+      env_args = env_vars.map do |env|
         key, value = env.split('=', 2)
         { name: key, value: value }
       end

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -65,6 +65,23 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     end
   end
 
+  def test_run_with_env_vars
+    deploy_fixtures("hello-cloud", subset: ["template-runner.yml"])
+
+    task_runner = build_task_runner
+    assert task_runner.run(
+      task_template: 'hello-cloud-template-runner',
+      entrypoint: nil,
+      args: %w(rake some_task)
+      env_vars: ['ENV=VAR1']
+    )
+
+    pods = kubeclient.get_pods(namespace: @namespace)
+    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
+    assert_equal %w(rake some_task), pods.first.spec.containers.first.args
+    assert_equal 'ENV', pods.first.spec.containers.env.first.name
+  end
+
   private
 
   def valid_run_params

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -72,14 +72,15 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     assert task_runner.run(
       task_template: 'hello-cloud-template-runner',
       entrypoint: nil,
-      args: %w(rake some_task)
+      args: %w(rake some_task),
       env_vars: ['ENV=VAR1']
     )
 
     pods = kubeclient.get_pods(namespace: @namespace)
     assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
     assert_equal %w(rake some_task), pods.first.spec.containers.first.args
-    assert_equal 'ENV', pods.first.spec.containers.env.first.name
+    assert_equal 'ENV', pods.first.spec.containers.first.env.last.name
+    assert_equal 'VAR1', pods.first.spec.containers.first.env.last.value
   end
 
   private


### PR DESCRIPTION
@jordanwheeler noticed that the code to pass ENV vars into the task runner was broken. This fixes it and adds a test case.