### PR TITLE
Improve handling of KubernetesResource tempfiles/templates

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -44,7 +44,8 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, definition:, logger:)
       # subclasses must also set these if they define their own initializer
-      unless @name = definition.fetch("metadata", {})["name"]
+      @name = definition.fetch("metadata", {})["name"]
+      unless @name.present?
         logger.summary.add_paragraph("Rendered template content:\n#{definition.to_yaml}")
         raise FatalDeploymentError, "Template is missing required field metadata.name"
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -23,7 +23,7 @@ module KubernetesDeploy
             pod = Pod.new(
               namespace: namespace,
               context: context,
-              template: pod_json,
+              definition: pod_json,
               logger: @logger,
               parent: "#{@name.capitalize} deployment",
               deploy_started: @deploy_started

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -20,17 +20,15 @@ module KubernetesDeploy
         if st.success?
           pods_json = JSON.parse(pod_list)["items"]
           pods_json.each do |pod_json|
-            pod_name = pod_json["metadata"]["name"]
             pod = Pod.new(
-              name: pod_name,
               namespace: namespace,
               context: context,
-              file: nil,
+              template: pod_json,
+              logger: @logger,
               parent: "#{@name.capitalize} deployment",
-              logger: @logger
+              deploy_started: @deploy_started
             )
-            pod.deploy_started = @deploy_started
-            pod.interpret_json_data(pod_json)
+            pod.sync(pod_json)
 
             if !@representative_pod && pod_probably_new?(pod_json)
               @representative_pod = pod

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -4,11 +4,11 @@ module KubernetesDeploy
     TIMEOUT = 10.minutes
     SUSPICIOUS_CONTAINER_STATES = %w(ImagePullBackOff RunContainerError ErrImagePull).freeze
 
-    def initialize(namespace:, context:, template:, logger:, parent: nil, deploy_started: nil)
+    def initialize(namespace:, context:, definition:, logger:, parent: nil, deploy_started: nil)
       @parent = parent
       @deploy_started = deploy_started
-      @containers = template["spec"]["containers"].map { |c| c["name"] }
-      super(namespace: namespace, context: context, template: template, logger: logger)
+      @containers = definition["spec"]["containers"].map { |c| c["name"] }
+      super(namespace: namespace, context: context, definition: definition, logger: logger)
     end
 
     def sync(pod_data = nil)

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -70,8 +70,8 @@ module KubernetesDeploy
 
     def wait_for_rollout(kubeclient_resources)
       resources = kubeclient_resources.map do |d|
-        template = d.to_h.deep_stringify_keys
-        Deployment.new(namespace: @namespace, context: @context, template: template, logger: @logger)
+        definition = d.to_h.deep_stringify_keys
+        Deployment.new(namespace: @namespace, context: @context, definition: definition, logger: @logger)
       end
       watcher = ResourceWatcher.new(resources, logger: @logger)
       watcher.run

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -70,7 +70,8 @@ module KubernetesDeploy
 
     def wait_for_rollout(kubeclient_resources)
       resources = kubeclient_resources.map do |d|
-        Deployment.new(name: d.metadata.name, namespace: @namespace, context: @context, file: nil, logger: @logger)
+        template = d.to_h.deep_stringify_keys
+        Deployment.new(namespace: @namespace, context: @context, template: template, logger: @logger)
       end
       watcher = ResourceWatcher.new(resources, logger: @logger)
       watcher.run

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -181,14 +181,13 @@ module KubernetesDeploy
     def find_bad_file_from_kubectl_output(stderr)
       # Output example:
       # Error from server (BadRequest): error when creating "/path/to/configmap-gqq5oh.yml20170411-33615-t0t3m":
-      match = stderr.match(%r{BadRequest.*"(?<path>\/\S+\.ya?ml\S+)"})
+      match = stderr.match(%r{BadRequest.*"(?<path>\/\S+\.ya?ml\S*)"})
       return unless match
 
       path = match[:path]
       if path.present? && File.file?(path)
-        suspicious_file = File.read(path)
+        File.read(path)
       end
-      [File.basename(path, ".*"), suspicious_file]
     end
 
     def deploy_has_priority_resources?(resources)
@@ -217,48 +216,38 @@ module KubernetesDeploy
       Dir.foreach(@template_dir) do |filename|
         next unless filename.end_with?(".yml.erb", ".yml", ".yaml", ".yaml.erb")
 
-        split_templates(filename) do |tempfile|
-          resource_id = discover_resource_via_dry_run(tempfile)
-          type, name = resource_id.split("/", 2) # e.g. "pod/web-198612918-dzvfb"
-          resources << KubernetesResource.for_type(type: type, name: name, namespace: @namespace, context: @context,
-            file: tempfile, logger: @logger)
-          @logger.info "  - #{resource_id}"
+        split_templates(filename) do |template|
+          r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, template: template)
+          validate_template_via_dry_run(r.file, filename)
+          resources << r
+          @logger.info "  - #{r.id}"
         end
       end
       resources
     end
 
-    def discover_resource_via_dry_run(tempfile)
+    def validate_template_via_dry_run(tempfile, original_filename)
       command = ["create", "-f", tempfile.path, "--dry-run", "--output=name"]
-      resource_id, err, st = kubectl.run(*command, log_failure: false)
+      _, err, st = kubectl.run(*command, log_failure: false)
+      return if st.success?
 
-      unless st.success?
-        debug_msg = <<-DEBUG_MSG.strip_heredoc
-          This usually means template '#{File.basename(tempfile.path, '.*')}' is not a valid Kubernetes template.
+      debug_msg = <<-DEBUG_MSG.strip_heredoc
+        This usually means template '#{original_filename}' is not a valid Kubernetes template.
+        Error from kubectl:
+          #{err}
+        Rendered template content:
+      DEBUG_MSG
+      debug_msg += File.read(tempfile.path)
+      @logger.summary.add_paragraph(debug_msg)
 
-          Error from kubectl:
-            #{err}
-
-          Rendered template content:
-        DEBUG_MSG
-        debug_msg += File.read(tempfile.path)
-        @logger.summary.add_paragraph(debug_msg)
-
-        raise FatalDeploymentError, "Kubectl dry run failed (command: #{Shellwords.join(command)})"
-      end
-      resource_id
+      raise FatalDeploymentError, "Kubectl dry run failed (command: #{Shellwords.join(command)})"
     end
 
     def split_templates(filename)
       file_content = File.read(File.join(@template_dir, filename))
       rendered_content = render_template(filename, file_content)
       YAML.load_stream(rendered_content) do |doc|
-        next if doc.blank?
-
-        f = Tempfile.new(filename)
-        f.write(YAML.dump(doc))
-        f.close
-        yield f
+        yield doc unless doc.blank?
       end
     rescue Psych::SyntaxError => e
       debug_msg = <<-INFO.strip_heredoc
@@ -273,23 +262,14 @@ module KubernetesDeploy
     end
 
     def record_apply_failure(err)
-      file_name, file_content = find_bad_file_from_kubectl_output(err)
-      if file_name
-        debug_msg = <<-HELPFUL_MESSAGE.strip_heredoc
-          This usually means your template named '#{file_name}' is invalid.
-
-          Error from kubectl:
-            #{err}
-
-          Rendered template content:
-        HELPFUL_MESSAGE
-        debug_msg += file_content || "Failed to read file"
-      else
-        debug_msg = <<-FALLBACK_MSG
-          This usually means one of your templates is invalid, but we were unable to automatically identify which one.
-          Please inspect the error message from kubectl:
-            #{err}
-        FALLBACK_MSG
+      file_content = find_bad_file_from_kubectl_output(err)
+      debug_msg = <<-HELPFUL_MESSAGE.strip_heredoc
+        This usually means one of your templates is invalid.
+        Error from kubectl:
+          #{err}
+      HELPFUL_MESSAGE
+      if file_content
+        debug_msg += "Rendered template content:\n#{file_content}"
       end
 
       @logger.summary.add_paragraph(debug_msg)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -122,7 +122,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_equal false, success, "Deploy succeeded when it was expected to fail"
 
-    assert_logs_match(/'configmap-data' is not a valid Kubernetes template/)
+    assert_logs_match(/'configmap-data.yml' is not a valid Kubernetes template/)
     assert_logs_match(/error validating data\: found invalid field myKey for v1.ObjectMeta/)
   end
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -403,6 +403,21 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
   end
 
+  def test_deploy_aborts_immediately_if_unmanged_pod_spec_missing
+    success = deploy_fixtures("hello-cloud", subset: ["unmanaged-pod.yml.erb"]) do |fixtures|
+      definition = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      definition.delete("spec")
+    end
+    assert_equal false, success, "Deploy succeeded when it was expected to fail"
+
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Template is missing required field spec.containers",
+      "Rendered template content:",
+      "kind: Pod"
+    ], in_order: true)
+  end
+
   private
 
   def count_by_revisions(pods)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,7 @@ module KubernetesDeploy
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|
         unless times
-          assert_match regexp, logs
+          assert_match regexp, logs, "'#{regexp}' not found in the following logs:\n#{logs}"
           return
         end
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -4,7 +4,8 @@ require 'test_helper'
 class KubernetesResourceTest < KubernetesDeploy::TestCase
   class DummyResource < KubernetesDeploy::KubernetesResource
     def initialize(*)
-      super(name: 'test', namespace: 'test', context: 'test', file: nil, logger: @logger)
+      template = { "kind" => "DummyResource", "metadata" => { "name" => "test" } }
+      super(namespace: 'test', context: 'test', template: template, logger: @logger)
     end
 
     def exists?
@@ -20,7 +21,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
   def test_fetch_events_parses_tricky_events_correctly
     start_time = Time.now.utc - 10.seconds
-    dummy = DummyResource.new(name: 'test', namespace: 'test', context: 'test', file: nil, logger: @logger)
+    dummy = DummyResource.new
     dummy.deploy_started = start_time
 
     tricky_events = dummy_events(start_time)

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 class KubernetesResourceTest < KubernetesDeploy::TestCase
   class DummyResource < KubernetesDeploy::KubernetesResource
     def initialize(*)
-      template = { "kind" => "DummyResource", "metadata" => { "name" => "test" } }
-      super(namespace: 'test', context: 'test', template: template, logger: @logger)
+      definition = { "kind" => "DummyResource", "metadata" => { "name" => "test" } }
+      super(namespace: 'test', context: 'test', definition: definition, logger: @logger)
     end
 
     def exists?


### PR DESCRIPTION
This is a refactor split out of https://github.com/Shopify/kubernetes-deploy/pull/107 to make it more reviewable. It includes the change to simplify `Pod`'s public API (aka get rid of `Pod#interpret_json_data`) discussed on that PR, plus the bigger change described below.

### Before

Two possible paths:
- If we start with a file in the deploy directory, we split it into one tempfile per resource in `runner.rb`, then initialize the instance with `file: tempfile`. If we later need the parsed template (which we do as of the linked PR), we need to either re-parse the tempfile or fetch it from the API.
- If we start with a child resource we discovered during a sync (e.g. a pod that is a child of a deployment), we initialize the instance with `file: nil`. To make the template available later (which again is necessary as of the linked PR), we need to add another parameter to the initializer to pass in the template data (which we already got from the API when we discovered the resource).

### After

One path: Always pass a parsed template into the initializer. It turns out we already _always_ have this when we create the instance. In the child resource case, this is obvious; we got it from the API. As it turns out, in the deploy directory case, we are generating and discarding it in `Runner#split_templates`. The trick is to use that copy to initialize the instance, and have the instance itself lazily create the tempfile if we need it.