### PR TITLE
Add `context` and `namespace` template variables

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -137,6 +137,8 @@ module KubernetesDeploy
       {
         'current_sha' => @current_sha,
         'deployment_id' => @id,
+        'context' => @context,
+        'namespace' => @namespace,
       }.merge(@bindings)
     end
 

--- a/test/unit/kubernetes-deploy/runner_test.rb
+++ b/test/unit/kubernetes-deploy/runner_test.rb
@@ -31,4 +31,19 @@ class RunnerTest < KubernetesDeploy::TestCase
   ensure
     ENV["KUBECONFIG"] = original_env
   end
+
+  def test_template_variables
+    runner = KubernetesDeploy::Runner.new(
+      namespace: "mynamespace",
+      context: "mycontext",
+      logger: logger,
+      current_sha: "somesha",
+      template_dir: "unknown",
+    )
+
+    variables = runner.template_variables
+    assert_equal "mycontext", variables["context"]
+    assert_equal "mynamespace", variables["namespace"]
+    assert_equal "somesha", variables["current_sha"]
+  end
 end


### PR DESCRIPTION
I have a need to know the region a pod is in at runtime, but curling the GCP metadata is turning out to be flaky (sometimes it's empty), and trying to expose it from a node label doesn't appear to be possible.

I _can_ infer it from the kube context though, so exposing it to the template solves a problem for me. I added the namespace for good measure while I was in there.

🎩 'ed locally against some test CI agents.