### PR TITLE
UUID for CloudSQL deployment

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -34,7 +34,7 @@ module KubernetesDeploy
     private
 
     def cloudsql_proxy_deployment_exists?
-      deployment, _err, st = kubectl.run("get", "deployments", "cloudsql-proxy", "-o=json")
+      deployment, _err, st = kubectl.run("get", "deployments", "cloudsql-#{cloudsql_resource_uuid}", "-o=json")
 
       if st.success?
         parsed = JSON.parse(deployment)
@@ -61,6 +61,17 @@ module KubernetesDeploy
       end
 
       false
+    end
+
+    def cloudsql_resource_uuid
+      return @cloudsql_resource_uuid if defined?(@cloudsql_resource_uuid) && @cloudsql_resource_uuid
+
+      redis, _err, st = kubectl.run("get", "cloudsqls", @name, "-o=json")
+      if st.success?
+        parsed = JSON.parse(redis)
+
+        @cloudsql_resource_uuid = parsed.fetch("metadata", {}).fetch("uid", nil)
+      end
     end
   end
 end

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,3 +1,3 @@
 module KubernetesDeploy
-  VERSION = "0.7.5"
+  VERSION = "0.7.6"
 end


### PR DESCRIPTION
**What**
After https://github.com/Shopify/cloudsql-controller/pull/74/files CloudSQL deployment names have changed to match the Redis model, e.g. `cloudsql-UUID` deployment names instead of harcoded `cloudsql-proxy`. This was based on https://github.com/Shopify/cloudsql-controller/pull/59#issuecomment-290811856.

**Problem**
We're currently failing to detect the status of CloudSQL deploys because of the name discrepancy.

**Solution**
Follow the same model we use for the Redis controllers.

/cc: @Shopify/cloudplatform 