### PR TITLE
Make deployments fail faster when they are likely doomed

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -124,7 +124,7 @@ module KubernetesDeploy
 
       events = fetch_events
       if events.present?
-        helpful_info << "  - Events:"
+        helpful_info << "  - Events (common success events excluded):"
         events.each do |identifier, event_hashes|
           event_hashes.each { |event| helpful_info << "      [#{identifier}]\t#{event}" }
         end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -139,6 +139,11 @@ module KubernetesDeploy
         else
           sorted_logs = container_logs.sort_by { |_, log_lines| log_lines.length }
           sorted_logs.each do |identifier, log_lines|
+            if log_lines.empty?
+              helpful_info << "  - Logs from container '#{identifier}': #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
+              next
+            end
+
             helpful_info << "  - Logs from container '#{identifier}' (last #{LOG_LINE_COUNT} lines shown):"
             log_lines.each do |line|
               helpful_info << "      #{line}"
@@ -220,7 +225,8 @@ module KubernetesDeploy
           %[(eq .involvedObject.kind "#{kind}")],
           %[(eq .involvedObject.name "#{name}")],
           '(ne .reason "Started")',
-          '(ne .reason "Created")'
+          '(ne .reason "Created")',
+          '(ne .reason "SuccessfulCreate")'
         ]
         condition_start = "{{if and #{and_conditions.join(' ')}}}"
         field_part = FIELDS.map { |f| "{{#{f}}}" }.join(%({{print "#{FIELD_SEPARATOR}"}}))

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -226,7 +226,10 @@ module KubernetesDeploy
           %[(eq .involvedObject.name "#{name}")],
           '(ne .reason "Started")',
           '(ne .reason "Created")',
-          '(ne .reason "SuccessfulCreate")'
+          '(ne .reason "SuccessfulCreate")',
+          '(ne .reason "Scheduled")',
+          '(ne .reason "Pulling")',
+          '(ne .reason "Pulled")'
         ]
         condition_start = "{{if and #{and_conditions.join(' ')}}}"
         field_part = FIELDS.map { |f| "{{#{f}}}" }.join(%({{print "#{FIELD_SEPARATOR}"}}))

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -45,6 +45,14 @@ module KubernetesDeploy
       @latest_rs && @latest_rs.deploy_failed?
     end
 
+    def failure_message
+      @latest_rs.failure_message
+    end
+
+    def timeout_message
+      @latest_rs.timeout_message
+    end
+
     def deploy_timed_out?
       super || @latest_rs && @latest_rs.deploy_timed_out?
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -6,21 +6,14 @@ module KubernetesDeploy
     def sync
       _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
-      if @found
-        endpoints, _err, st = kubectl.run("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
-        @num_endpoints = (st.success? ? endpoints.split.length : 0)
-      else
-        @num_endpoints = 0
-      end
-      @status = "#{@num_endpoints} endpoints"
+      @related_deployment_replicas = fetch_related_replica_count
+      @num_pods_selected = fetch_related_pod_count
+      @status = "Selects #{@num_pods_selected} #{'pod'.pluralize(@num_pods_selected)}"
     end
 
     def deploy_succeeded?
-      if exposes_zero_replica_deployment?
-        @num_endpoints == 0
-      else
-        @num_endpoints > 0
-      end
+      # We can't use endpoints if we want the service to be able to fail fast when the pods are down
+      @num_pods_selected > 0 || exposes_zero_replica_deployment?
     end
 
     def deploy_failed?
@@ -28,10 +21,7 @@ module KubernetesDeploy
     end
 
     def timeout_message
-      <<-MSG.strip_heredoc.strip
-        This service does not have any endpoints. If the related pods are failing, fixing them will solve this as well.
-        If the related pods are up, this service's selector is probably incorrect.
-      MSG
+      "This service does not seem to select any pods. This means its spec.selector is probably incorrect."
     end
 
     def exists?
@@ -41,19 +31,26 @@ module KubernetesDeploy
     private
 
     def exposes_zero_replica_deployment?
-      related_deployment_replicas && related_deployment_replicas == 0
+      @related_deployment_replicas == 0
     end
 
-    def related_deployment_replicas
-      @related_deployment_replicas ||= begin
-        selector = @definition["spec"]["selector"].map { |k, v| "#{k}=#{v}" }.join(",")
-        raw_json, _err, st = kubectl.run("get", "deployments", "--selector=#{selector}", "--output=json")
-        return unless st.success?
+    def selector
+      @selector ||= @definition["spec"]["selector"].map { |k, v| "#{k}=#{v}" }.join(",")
+    end
 
-        deployments = JSON.parse(raw_json)["items"]
-        return unless deployments.length == 1
-        deployments.first["spec"]["replicas"].to_i
-      end
+    def fetch_related_pod_count
+      raw_json, _err, st = kubectl.run("get", "pods", "--selector=#{selector}", "--output=json")
+      return 0 unless st.success?
+      JSON.parse(raw_json)["items"].length
+    end
+
+    def fetch_related_replica_count
+      raw_json, _err, st = kubectl.run("get", "deployments", "--selector=#{selector}", "--output=json")
+      return 1 unless st.success?
+
+      deployments = JSON.parse(raw_json)["items"]
+      return 1 unless deployments.length == 1
+      deployments.first["spec"]["replicas"].to_i
     end
   end
 end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -156,6 +156,7 @@ module KubernetesDeploy
 
       if success_count > 0
         @logger.summary.add_action("successfully deployed #{success_count} #{'resource'.pluralize(success_count)}")
+        successful_resources.map(&:sync) # make sure we're printing the latest on resources that succeeded early
         final_statuses = successful_resources.map(&:pretty_status).join("\n")
         @logger.summary.add_paragraph("#{ColorizedString.new('Successful resources').green}\n#{final_statuses}")
       end

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: bad-probe
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: web
+        app: crash-app
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+        ports:
+        - containerPort: 8000
+          name: http-alt
+        readinessProbe:
+          httpGet:
+            path: "/bad/ping/path"
+            port: 8000
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cannot-run
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        name: web
+        app: crash-app
+    spec:
+      containers:
+      - name: container-cannot-run
+        image: busybox
+        command: ["/some/bad/path"]

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -10,6 +10,9 @@ spec:
         name: web
         app: crash-app
     spec:
+      initContainers:
+      - name: successful-init
+        image: hello-world:latest
       containers:
       - name: container-cannot-run
         image: busybox

--- a/test/fixtures/invalid/crash_loop.yml
+++ b/test/fixtures/invalid/crash_loop.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: crash-loop
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        name: web
+        app: crash-app
+    spec:
+      containers:
+      - name: crash-loop-back-off
+        image: nginx:alpine
+        command: ["/usr/sbin/nginx", "-s", "stop"]

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: init-crash
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: web
+        app: crash-app
+    spec:
+      initContainers:
+      - name: init-crash-loop-back-off
+        image: busybox
+        command: ["ls", "/not-a-dir"]
+      containers:
+      - name: app
+        image: nginx:alpine

--- a/test/fixtures/invalid/missing_volumes.yml
+++ b/test/fixtures/invalid/missing_volumes.yml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: missing-volumes
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: web
+        app: crash-app
+    spec:
+      containers:
+      - name: mounts-missing-volumes
+        image: nginx:alpine
+        volumeMounts:
+        - mountPath: /server-cert
+          name: server-cert
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: catphotoscom

--- a/test/fixtures/long-running/jobs.yml.erb
+++ b/test/fixtures/long-running/jobs.yml.erb
@@ -1,3 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multi-replica
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: http
+  selector:
+    name: jobs
+    app: fixtures
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -8,13 +8,13 @@ spec:
     name: http
     targetPort: http
   selector:
-    name: jobs
+    name: undying
     app: fixtures
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: jobs
+  name: undying
 spec:
   replicas: 2
   revisionHistoryLimit: 1
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       labels:
-        name: jobs
+        name: undying
         app: fixtures
     spec:
       containers:

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -68,8 +68,10 @@ module FixtureDeployHelper
 
   def load_fixtures(set, subset)
     fixtures = {}
-    ejson_file = File.join(fixture_path(set), EJSON_FILENAME)
-    fixtures[EJSON_FILENAME] = JSON.parse(File.read(ejson_file)) if File.exist?(ejson_file)
+    if !subset || subset.include?("secrets.ejson")
+      ejson_file = File.join(fixture_path(set), EJSON_FILENAME)
+      fixtures[EJSON_FILENAME] = JSON.parse(File.read(ejson_file)) if File.exist?(ejson_file)
+    end
 
     Dir.glob("#{fixture_path(set)}/*.{yml,yaml}*").each do |filename|
       basename = File.basename(filename)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -226,7 +226,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Deployment/web: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
-      "app: Failing to generate container configuration: secrets \"monitoring-token\" not found",
+      "app: Failed to generate container configuration: secrets \"monitoring-token\" not found",
       "Final status: 3 replicas, 3 updatedReplicas, 3 unavailableReplicas"
     ], in_order: true)
 
@@ -243,7 +243,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Deployment/cannot-run: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
-      "container-cannot-run: Failing to pull image some-invalid-image:badtag.",
+      "container-cannot-run: Failed to pull image some-invalid-image:badtag.",
       "Did you wait for it to be built and pushed to the registry before deploying?"
     ], in_order: true)
   end
@@ -275,7 +275,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Deployment/cannot-run: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
-      "container-cannot-run: Failing to start (exit 127):",
+      "container-cannot-run: Failed to start (exit 127):",
       "Container command '/some/bad/path' not found or does not exist."
     ], in_order: true)
   end
@@ -289,8 +289,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Failed to deploy 1 priority resource",
       %r{Pod\/unmanaged-pod-\w+-\w+: FAILED},
-      "The following containers are in a state that is unlikely to be recoverable:",
-      "hello-cloud: Failing to pull image hello-world:thisImageIsBad"
+      "The following containers encountered errors:",
+      "hello-cloud: Failed to pull image hello-world:thisImageIsBad"
     ])
   end
 
@@ -327,7 +327,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       assert_logs_match(%r{Service/multi-replica\s+Selects 2 pods})
     end
 
-    pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=jobs,app=fixtures')
+    pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=undying,app=fixtures')
     assert_equal 4, pods.size
 
     count = count_by_revisions(pods)
@@ -421,7 +421,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Your pods are running, but the following containers seem to be failing their readiness probes:",
       "app must respond with a good status code at '/bad/ping/path'",
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
-      "Successfully assigned bad-probe", # event
+      "Scaled up replica set bad-probe-", # event
     ], in_order: true)
 
     # Debug info for missing volume timeout
@@ -437,7 +437,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "The following containers are in a state that is unlikely to be recoverable:",
       "init-crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: 2 replicas, 2 updatedReplicas, 2 unavailableReplicas",
-      "Successfully assigned init-crash", # event
+      "Scaled up replica set init-crash-", # event
       "ls: /not-a-dir: No such file or directory" # log
     ], in_order: true)
 
@@ -466,8 +466,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
     assert_logs_match_all([
       "Failed to deploy 1 priority resource",
-      "hello-cloud: Failing to start (exit 127): Container command '/some/bad/path' not found or does not exist.",
-      "Successfully assigned unmanaged-pod-", # from an event
+      "hello-cloud: Failed to start (exit 127): Container command '/some/bad/path' not found or does not exist.",
+      "Error response from daemon", # from an event
       "no such file or directory" # from logs
     ], in_order: true)
     refute_logs_match(/no such file or directory.*Result\: FAILURE/m) # logs not also displayed before summary

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class PodTest < KubernetesDeploy::TestCase
+  def test_deploy_failed_is_true_for_missing_image_error
+    pod = build_pod(pod_spec)
+    fake_status = fake_status_with_container_state(
+      "state" => {
+        "waiting" => {
+          "message" => "rpc error: code = 2 desc = Error: image library/some-invalid-image not found",
+          "reason" => "ImagePullBackOff"
+        }
+      }
+    )
+
+    fake_pod_data = pod_spec.merge(fake_status)
+    pod.sync(fake_pod_data)
+    assert pod.deploy_failed?
+
+    expected_msg = <<-STRING.strip_heredoc
+      The following containers encountered errors:
+      > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
+    STRING
+    assert_equal expected_msg, pod.failure_message
+  end
+
+  def test_deploy_failed_is_true_for_missing_tag_error
+    pod = build_pod(pod_spec)
+    message = "rpc error: code = 2 desc = Tag thisImageIsBad not found in repository docker.io/library/hello-world"
+    fake_status = fake_status_with_container_state(
+      "state" => {
+        "waiting" => {
+          "message" => message,
+          "reason" => "ErrImagePull"
+        }
+      }
+    )
+
+    fake_pod_data = pod_spec.merge(fake_status)
+    pod.sync(fake_pod_data)
+    assert pod.deploy_failed?
+
+    expected_msg = <<-STRING.strip_heredoc
+      The following containers encountered errors:
+      > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
+    STRING
+    assert_equal expected_msg, pod.failure_message
+  end
+
+  def test_deploy_failed_is_false_for_intermittent_image_error
+    pod = build_pod(pod_spec)
+    fake_status = fake_status_with_container_state(
+      "state" => {
+        "waiting" => {
+          "message" => "Failed to pull image 'gcr.io/*': rpc error: code = 2 desc = net/http: request canceled",
+          "reason" => "ImagePullBackOff"
+        }
+      }
+    )
+
+    fake_pod_data = pod_spec.merge(fake_status)
+    pod.sync(fake_pod_data)
+    refute pod.deploy_failed?
+    assert_nil pod.failure_message
+  end
+
+  private
+
+  def pod_spec
+    @pod_spec ||= YAML.load_file(File.join(fixture_path('hello-cloud'), 'unmanaged-pod.yml.erb'))
+  end
+
+  def fake_status_with_container_state(state)
+    {
+      "status" => {
+        "phase" => "Pending",
+        "containerStatuses" => [
+          {
+            "lastState" => {},
+            "name" => "hello-cloud",
+            "ready" => false,
+            "restartCount" => 0
+          }.merge(state)
+        ]
+      }
+    }
+  end
+
+  def build_pod(spec)
+    KubernetesDeploy::Pod.new(
+      namespace: 'test',
+      context: 'minikube',
+      definition: spec,
+      logger: @logger,
+      deploy_started: Time.now.utc
+    )
+  end
+end


### PR DESCRIPTION
@Shopify/cloudplatform @kirs 

## What?

Minimize the frequency with which doomed deploys result in a timeout. If we can detect that it is doomed, we should fail fast!

## Why?

Timeouts are currently super common, especially when apps are onboarding. There's nothing worse than having to repeatedly wait 5 minutes to see what the problem is, and in some cases not getting an obvious failure reason even then.

## How?

Implements a `Container` class inside `Pod` that knows how to detect several of the most common doom conditions:
* container mounting secret that doesn't exist
* crashing init container
* crashing regular container
* container command doesn't exist
* bad container image (e.g. path is wrong, or image build not finished)

When any of these conditions is present, `pod.deploy_failed?` will be true. If all of the current replicaSet's pods have failed, the `deployment.deploy_failed?` will be true as well.

It also leverages this new class to improve the timeout message when the readiness probe is failing (but does not make the deploy fail, since who knows how long an arbitrary pod is supposed to take to become ready). Sadly it does not improve anything in the cases of mounting a non-existent volume, as I couldn't find any way to deduce that fact from the pod status (events already do tell you this today though).

## Review

Please give special attention to the kubernetes logic here -- could this fail deploys too eagerly? are the checks too fragile? does it make bad assumptions about potential mixes of pod/container states? etc.

Check out the comments on the test titles for examples of the resulting deploy summary sections.