### PR TITLE
Set desired_replicas from API definition, not yaml

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -9,6 +9,7 @@ module KubernetesDeploy
 
       if @found
         deployment_data = JSON.parse(raw_json)
+        @desired_replicas = deployment_data["spec"]["replicas"].to_i
         @latest_rs = find_latest_rs(deployment_data)
         @rollout_data = { "replicas" => 0 }.merge(deployment_data["status"]
           .slice("replicas", "updatedReplicas", "availableReplicas", "unavailableReplicas"))
@@ -35,8 +36,8 @@ module KubernetesDeploy
       return false unless @latest_rs
 
       @latest_rs.deploy_succeeded? &&
-      @latest_rs.desired_replicas == desired_replicas && # latest RS fully scaled up
-      @rollout_data["updatedReplicas"].to_i == @rollout_data["replicas"].to_i &&
+      @latest_rs.desired_replicas == @desired_replicas && # latest RS fully scaled up
+      @rollout_data["updatedReplicas"].to_i == @desired_replicas &&
       @rollout_data["updatedReplicas"].to_i == @rollout_data["availableReplicas"].to_i
     end
 
@@ -50,10 +51,6 @@ module KubernetesDeploy
 
     def exists?
       @found
-    end
-
-    def desired_replicas
-      @definition["spec"]["replicas"].to_i
     end
 
     private

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -475,6 +475,14 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
   end
 
+  def test_success_detection_tolerates_out_of_band_deployment_scaling
+    success = deploy_fixtures("hello-cloud", subset: ["web.yml.erb", "configmap-data.yml"]) do |fixtures|
+      definition = fixtures["web.yml.erb"]["Deployment"].first
+      definition["spec"].delete("replicas")
+    end
+    assert_equal true, success, "Failed to deploy deployment with dynamic replica count"
+  end
+
   private
 
   def count_by_revisions(pods)


### PR DESCRIPTION
@ibawt @n1koo @stefanmb This should fix the issue we ran into in v0.7.9 for some of our less cookie-cutter deployments.
cc @kirs 

`spec.replicas` can inherit a default value or otherwise be set out of band, so the value in the yaml file is not necessarily the actual desired replica count. The `.spec.replicas` value retrieved from the API is correct (I checked this on a couple of the deployments that were failing), and it is what HPAs update when they scale a deployment.