### PR TITLE
up the deployment/service timeout

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Deployment < KubernetesResource
-    TIMEOUT = 5.minutes
+    TIMEOUT = 7.minutes
 
     def sync
       raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Service < KubernetesResource
-    TIMEOUT = 5.minutes
+    TIMEOUT = 7.minutes
 
     def sync
       _, _err, st = kubectl.run("get", type, @name)


### PR DESCRIPTION
## Wat
Until the progressDeadline thing is done, I'd like to up the timeout to prevent core from failing the deploy.  

At the moment we get a few failures a day where it's only a few replicas of the total set that are missing like 1 or 2.  

I think if we bump this timeout it should alleviate the errors and allow for some variance on 5minutes.

@dwradcliffe