### PR TITLE
Various StatsD improvements

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -187,18 +187,8 @@ module KubernetesDeploy
 
     def report_status_to_statsd(watch_time)
       unless @statsd_report_done
-        status = if deploy_failed?
-          "failure"
-        elsif deploy_timed_out?
-          "timeout"
-        elsif deploy_succeeded?
-          "success"
-        else
-          "unknown"
-        end
-        tags = %W(namespace:#{namespace} resource:#{id} type:#{type} sha:#{ENV['REVISION']} status:#{status})
-        ::StatsD.measure('resource.duration', watch_time * 1000, tags: tags)
-        ::StatsD.increment('resource.status', 1, tags: tags)
+        ::StatsD.measure('resource.duration', watch_time, tags: statsd_tags)
+        ::StatsD.increment('resource.status', 1, tags: statsd_tags)
         @statsd_report_done = true
       end
     end
@@ -271,6 +261,19 @@ module KubernetesDeploy
       file
     ensure
       file.close if file
+    end
+
+    def statsd_tags
+      status = if deploy_failed?
+        "failure"
+      elsif deploy_timed_out?
+        "timeout"
+      elsif deploy_succeeded?
+        "success"
+      else
+        "unknown"
+      end
+      %W(context:#{context} namespace:#{namespace} resource:#{id} type:#{type} sha:#{ENV['REVISION']} status:#{status})
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -188,7 +188,6 @@ module KubernetesDeploy
     def report_status_to_statsd(watch_time)
       unless @statsd_report_done
         ::StatsD.measure('resource.duration', watch_time, tags: statsd_tags)
-        ::StatsD.increment('resource.status', 1, tags: statsd_tags)
         @statsd_report_done = true
       end
     end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -105,9 +105,9 @@ module KubernetesDeploy
 
       if deploy_has_priority_resources?(resources)
         @logger.phase_heading("Predeploying priority resources")
-        ::StatsD.measure('duration.priority_resources', tags: statsd_tags) do
-          predeploy_priority_resources(resources)
-        end
+        start_priority_resource = Time.now.utc
+        predeploy_priority_resources(resources)
+        ::StatsD.measure('duration.priority_resources', (Time.now.utc - start_priority_resource), tags: statsd_tags)
       end
 
       @logger.phase_heading("Deploying all resources")
@@ -116,9 +116,9 @@ module KubernetesDeploy
       end
 
       if verify_result
-        ::StatsD.measure('duration.normal_resources', tags: statsd_tags) do
-          deploy_resources(resources, prune: prune, verify: true)
-        end
+        start_normal_resource = Time.now.utc
+        deploy_resources(resources, prune: prune, verify: true)
+        ::StatsD.measure('duration.normal_resources', (Time.now.utc - start_normal_resource), tags: statsd_tags)
         record_statuses(resources)
         success = resources.all?(&:deploy_succeeded?)
       else
@@ -136,7 +136,9 @@ module KubernetesDeploy
       success = false
     ensure
       @logger.print_summary(success)
-      ::StatsD.measure('duration.total', (Time.now.utc - start) * 1000.0, tags: statsd_tags)
+      status = success ? "success" : "failed"
+      ::StatsD.increment('status.all_resources', 1, tags: statsd_tags << "status:#{status}")
+      ::StatsD.measure('duration.all_resources', (Time.now.utc - start), tags: statsd_tags << "status:#{status}")
       success
     end
 
@@ -441,7 +443,7 @@ module KubernetesDeploy
     end
 
     def statsd_tags
-      %W(namespace:#{@namespace} sha:#{@current_sha})
+      %W(namespace:#{@namespace} sha:#{@current_sha} context:#{@context})
     end
   end
 end


### PR DESCRIPTION
Followup to: https://github.com/Shopify/kubernetes-deploy/pull/118

- Move from milliseconds to seconds on durations
- Report `context` on everything (eg. which cluster was deployed)
- Report status for the full deploy ( `status.total` )
- Report success/failure on the total metrics ( `"status:#{status}"`
