### PR TITLE
Fail fast on image pull back off too

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -184,7 +184,8 @@ module KubernetesDeploy
           "Failed to start (exit #{exit_code}): #{@status['lastState']['terminated']['message']}"
         elsif limbo_reason == "CrashLoopBackOff"
           "Crashing repeatedly (exit #{exit_code}). See logs for more information."
-        elsif %w(ImagePullBackOff ErrImagePull).include?(limbo_reason) && limbo_message.match("not found")
+        elsif %w(ImagePullBackOff ErrImagePull).include?(limbo_reason) &&
+          limbo_message.match(/(?:not found)|(?:back-off)/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
         elsif limbo_message == "Generate Container Config Failed"


### PR DESCRIPTION
Apparently if we miss the state where one of the "not found" errors is printed, the message will start saying "Back-off pulling image" and the deploy will still hit the 5 min timeout. Here's the pod status from a deploy that reached the timeout after my doom detection PR shipped:

![image](https://user-images.githubusercontent.com/4789493/28139888-f697eb6c-6723-11e7-90e7-fe1bad855fa7.png)

@ibawt it is possible we'd enter this state after getting a few of the transient errors that you pointed out we shouldn't bail on. IMO it this change would alleviate more pain than it would cause though. WDYT?