### PR TITLE
Add Simplecov/Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 .byebug_history
 .ruby-version
+coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'pry-byebug'
 gem 'rubocop'
 gem 'timecop'
 gem 'byebug'
+gem 'codecov', require: false, group: :test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kubernetes-deploy [![Build status](https://badge.buildkite.com/0f2d4956d49fbc795f9c17b0a741a6aa9ea532738e5f872ac8.svg?branch=master)](https://buildkite.com/shopify/kubernetes-deploy-gem)
+# kubernetes-deploy [![Build status](https://badge.buildkite.com/0f2d4956d49fbc795f9c17b0a741a6aa9ea532738e5f872ac8.svg?branch=master)](https://buildkite.com/shopify/kubernetes-deploy-gem) [![codecov](https://codecov.io/gh/Shopify/kubernetes-deploy/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/kubernetes-deploy)
 
 `kubernetes-deploy` is a command line tool that helps you ship changes to a Kubernetes namespace and understand the result. At Shopify, we use it within our much-beloved, open-source [Shipit](https://github.com/Shopify/shipit-engine#kubernetes) deployment app.
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,16 @@
 # frozen_string_literal: true
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter 'test/'
+  end
+
+  if ENV["CODECOV_TOKEN"]
+    require 'codecov'
+    SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  end
+end
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'kubernetes-deploy'
 require 'kubeclient'


### PR DESCRIPTION
Adds Codecov, following the instructions in the Vault. See the report for this branch here: https://codecov.io/gh/Shopify/kubernetes-deploy/branch/codecov

The biggest gap is in coverage for the Shopify-specific TPRs. We have plans to replace those classes with generic CustomResourceDefinition support, so I don't think it is worth trying to cover them (which would be difficult, since minikube doesn't have those closed-source controllers).

With this in place, I think we can close https://github.com/Shopify/kubernetes-deploy/issues/47. We've added a lot of integration tests for both main flows and corner cases since then, and it shows in our coverage levels. We don't have as much in the way of unit tests, but I'm satisfied by the coverage overall and the ease of increasing it. Consequently, I don't think there's particular value in keeping https://github.com/Shopify/kubernetes-deploy/issues/48 open either.

Closes https://github.com/Shopify/kubernetes-deploy/issues/47
Closes https://github.com/Shopify/kubernetes-deploy/issues/48