### PR TITLE
Handle rare unstable deploy result

### DIFF
--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -71,7 +71,7 @@ module KubernetesDeploy
       # Example:
       # # The resulting summary will begin with "Created 3 secrets and failed to deploy 2 resources"
       # @logger.summary.add_action("created 3 secrets")
-      # @logger.summary.add_cation("failed to deploy 2 resources")
+      # @logger.summary.add_action("failed to deploy 2 resources")
       def add_action(sentence_fragment)
         @actions_taken << sentence_fragment
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -7,10 +7,16 @@ module KubernetesDeploy
       _, _err, st = kubectl.run("get", type, @name)
       @found = st.success?
       @related_deployment_replicas = fetch_related_replica_count
-      @status = if @num_pods_selected = fetch_related_pod_count
-        "Selects #{@num_pods_selected} #{'pod'.pluralize(@num_pods_selected)}"
-      else
+      @num_pods_selected = fetch_related_pod_count
+    end
+
+    def status
+      if @num_pods_selected.blank?
         "Failed to count related pods"
+      elsif selects_some_pods?
+        "Selects at least 1 pod"
+      else
+        "Selects 0 pods"
       end
     end
 

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -417,7 +417,7 @@ module KubernetesDeploy
       return unless pruned.present?
 
       @logger.info("The following resources were pruned: #{pruned.join(', ')}")
-      @logger.summary.add_action("pruned #{pruned.length} resources")
+      @logger.summary.add_action("pruned #{pruned.length} #{'resource'.pluralize(pruned.length)}")
     end
 
     def confirm_context_exists

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -157,7 +157,6 @@ module KubernetesDeploy
 
       if success_count > 0
         @logger.summary.add_action("successfully deployed #{success_count} #{'resource'.pluralize(success_count)}")
-        successful_resources.map(&:sync) # make sure we're printing the latest on resources that succeeded early
         final_statuses = successful_resources.map(&:pretty_status).join("\n")
         @logger.summary.add_paragraph("#{ColorizedString.new('Successful resources').green}\n#{final_statuses}")
       end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -17,7 +17,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       %r{ReplicaSet/bare-replica-set\s+1 replica, 1 availableReplica, 1 readyReplica},
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
-      %r{Service/web\s+Selects 1 pod}
+      %r{Service/web\s+Selects at least 1 pod}
     ])
   end
 
@@ -324,7 +324,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_long_running_deployment
     2.times do
       assert deploy_fixtures('long-running')
-      assert_logs_match(%r{Service/multi-replica\s+Selects 2 pods})
+      assert_logs_match(%r{Service/multi-replica\s+Selects at least 1 pod})
     end
 
     pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=undying,app=fixtures')
@@ -332,7 +332,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
     count = count_by_revisions(pods)
     assert_equal [2, 2], count.values
-    assert_logs_match(%r{Service/multi-replica\s+Selects 4 pods})
+    assert_logs_match(%r{Service/multi-replica\s+Selects at least 1 pod})
   end
 
   def test_create_and_update_secrets_from_ejson


### PR DESCRIPTION
Since shipping the doom detection PR, I've seen two really strange deploy results, where the deploy says it failed but has no failure reason and lists all the resources as successes. In [the clearest case](https://shipit.shopify.io/shopify/services-db/production/deploys/463168) it seems the new sync added to make sure we print the latest info in the summary failed (my theory: related to the master upgrade we did around then), resetting many resource statuses to Unknown. In the other, two of the supposedly "successful" resources list unavailable pods.

It is unavoidably possible for the resources to go from fully up to not fully up between last poll and status output. This is a consequence of how Kubernetes works, and not necessarily indicative of a problem. Instead of restarting the polling in this case, IMO we should stick to our original conclusion re:success and pass the deploy. As a rule, the "status" we print should reflect the condition used to determine that success, without being overly specific.

This PR removes the additional summary-time sync and adjusts `Service` to print a less specific status.

@Shopify/cloudplatform @n1koo @dwradcliffe  - The issue this fixes could affect core deploy stability. I'm on vacation tomorrow. Feel free to review and merge without me.