### PR TITLE
Add Daemon Set resource

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class DaemonSet < KubernetesResource
+    TIMEOUT = 5.minutes
+
+    def sync
+      raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")
+      @found = st.success?
+
+      if @found
+        daemonset_data = JSON.parse(raw_json)
+        @current_generation = daemonset_data["metadata"]["generation"]
+        @observed_generation = daemonset_data["status"]["observedGeneration"]
+        @rollout_data = daemonset_data["status"]
+          .slice("currentNumberScheduled", "desiredNumberScheduled", "numberReady", "numberAvailable")
+        @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas}" }.join(", ")
+        @pods = find_pods(daemonset_data)
+      else # reset
+        @rollout_data = { "currentNumberScheduled" => 0 }
+        @current_generation = 1 # to make sure the current and observed generations are different
+        @observed_generation = 0
+        @status = nil
+        @pods = []
+      end
+    end
+
+    def deploy_succeeded?
+      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["currentNumberScheduled"].to_i &&
+      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["numberAvailable"].to_i &&
+      @current_generation == @observed_generation
+    end
+
+    def deploy_failed?
+      @pods.present? && @pods.any?(&:deploy_failed?)
+    end
+
+    def failure_message
+      @pods.map(&:failure_message).compact.uniq.join("\n")
+    end
+
+    def timeout_message
+      @pods.map(&:timeout_message).compact.uniq.join("\n")
+    end
+
+    def deploy_timed_out?
+      super || @pods.present? && @pods.any?(&:deploy_timed_out?)
+    end
+
+    def exists?
+      @found
+    end
+
+    def fetch_events
+      own_events = super
+      return own_events unless @pods.present?
+      most_useful_pod = @pods.find(&:deploy_failed?) || @pods.find(&:deploy_timed_out?) || @pods.first
+      own_events.merge(most_useful_pod.fetch_events)
+    end
+
+    def fetch_logs
+      most_useful_pod = @pods.find(&:deploy_failed?) || @pods.find(&:deploy_timed_out?) || @pods.first
+      most_useful_pod.fetch_logs
+    end
+
+    private
+
+    def find_pods(ds_data)
+      label_string = ds_data["spec"]["selector"]["matchLabels"].map { |k, v| "#{k}=#{v}" }.join(",")
+      raw_json, _err, st = kubectl.run("get", "pods", "-a", "--output=json", "--selector=#{label_string}")
+      return [] unless st.success?
+
+      all_pods = JSON.parse(raw_json)["items"]
+      current_generation = ds_data["metadata"]["generation"]
+
+      latest_pods = all_pods.find_all do |pods|
+        pods["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == ds_data["metadata"]["uid"] } &&
+        pods["metadata"]["labels"]["pod-template-generation"].to_i == current_generation.to_i
+      end
+      return unless latest_pods.present?
+
+      latest_pods.each_with_object([]) do |pod_data, relevant_pods|
+        pod = Pod.new(
+          namespace: namespace,
+          context: context,
+          definition: pod_data,
+          logger: @logger,
+          parent: "#{@name.capitalize} daemon set",
+          deploy_started: @deploy_started
+        )
+        pod.sync(pod_data)
+        relevant_pods << pod
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -20,6 +20,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   pod_disruption_budget
   replica_set
   service_account
+  daemon_set
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
 end

--- a/test/fixtures/hello-cloud/daemon_set.yml
+++ b/test/fixtures/hello-cloud/daemon_set.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -126,6 +126,13 @@ module FixtureSetAssertions
       assert desired.present?, "Service account #{name} does not exist"
     end
 
+    def assert_daemon_set_present(name)
+      labels = "name=#{name},app=#{app_name}"
+      daemon_sets = v1beta1_kubeclient.get_daemon_sets(namespace: namespace, label_selector: labels)
+      desired = daemon_sets.find { |ds| ds.metadata.name == name }
+      assert desired.present?, "Daemon set #{name} does not exist"
+    end
+
     def assert_annotated(obj, annotation)
       annotations = obj.metadata.annotations.to_h.stringify_keys
       assert annotations.key?(annotation), "Expected secret to have annotation #{annotation}, but it did not"

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -15,6 +15,7 @@ module FixtureSetAssertions
       assert_poddisruptionbudget
       assert_bare_replicaset_up
       assert_all_service_accounts_up
+      assert_daemon_set_up
     end
 
     def assert_unmanaged_pod_statuses(status, count = 1)
@@ -83,6 +84,10 @@ module FixtureSetAssertions
 
     def assert_all_service_accounts_up
       assert_service_account_present("build-robot")
+    end
+
+    def assert_daemon_set_up
+      assert_daemon_set_present("nginx")
     end
   end
 end


### PR DESCRIPTION
## What?
- Adds daemon set as a kubernetes resource
- Replicates logic built into the Replica Set resource [here](https://github.com/Shopify/kubernetes-deploy/blob/master/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb)
- Adds a test for successful and timed out deploy for a daemon set
- The timeout currently is the same as a replica set

cc/ @Shopify/cloudplatform 