### PR TITLE
Improve output re: invalid templates

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -188,8 +188,8 @@ module KubernetesDeploy
     # Inspect the file referenced in the kubectl stderr
     # to make it easier for developer to understand what's going on
     def find_bad_files_from_kubectl_output(stderr)
-      # Output example:
-      # Error from server (BadRequest): error when creating "/path/to/configmap-gqq5oh.yml20170411-33615-t0t3m":
+      # stderr often contains one or more lines like the following, from which we can extract the file path(es):
+      # Error from server (TypeOfError): error when creating "/path/to/service-gqq5oh.yml": Service "web" is invalid:
       matches = stderr.scan(%r{"(?<path>\/\S+\.ya?ml\S*)"})
       matches.flatten if matches
     end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -158,7 +158,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_equal ["web-one", "web-three", "web-two"], deployments.map { |d| d.metadata.name }.sort
   end
 
-  # The next three tests reproduce a k8s bug - These problems should be caught during dry run
+  # The next three tests reproduce a k8s bug
+  # The dry run should catch these problems, but it does not. Instead, apply fails.
   # https://github.com/kubernetes/kubernetes/issues/42057
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_on_apply_and_prints_template
     success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|

--- a/test/unit/kubernetes-deploy/google_friendly_config_test.rb
+++ b/test/unit/kubernetes-deploy/google_friendly_config_test.rb
@@ -14,7 +14,7 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
   def test_auth_use_default_gcp_success
     config = KubernetesDeploy::KubeclientBuilder::GoogleFriendlyConfig.new(kubeconfig, "")
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
       .to_return(
         headers: { 'Content-Type' => 'application/json' },
         body: {
@@ -33,7 +33,7 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
   def test_auth_use_default_gcp_failure
     config = KubernetesDeploy::KubeclientBuilder::GoogleFriendlyConfig.new(kubeconfig, "")
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
       .to_return(
         headers: { 'Content-Type' => 'application/json' },
         body: '',


### PR DESCRIPTION
I set out this morning to add a quick fix for a spacing issue I noticed on a couple production deploys:

![image](https://user-images.githubusercontent.com/4789493/28393896-7fafc6ac-6cb7-11e7-900c-506f4f00ae87.png)

And then I went down a bit of rabbit hole. This PR:
- Fixes that spacing issue.
- Unifies recording of invalid templates (i.e. same code path for failed dry run and failed apply)
- Loosens file path identification to work with the new error examples
- Handles multiple invalid templates in a single apply failure
- Adds a warning on apply failures that some resources were likely created 

I'll post screenshots of the new test output inline.