### PR TITLE
Add resource types for automatically provisioned persistent volumes to the priority sequence

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -37,6 +37,8 @@ module KubernetesDeploy
       Redis
       Bugsnag
       ConfigMap
+      StorageClass
+      PersistentVolume
       PersistentVolumeClaim
       Pod
     )


### PR DESCRIPTION
If you want Kubernetes to automatically provision you a persistent volume to use with a persistent volume claim, you need the persistent volume resource to be created first, and if you are using a kubernetes plugin to create the persistent volume (like the GCS provisioner), the StorageClass that uses that plugin needs to be persisted first as well.

So, lets deploy those before we try to deploy any PersistentVolumes!

I'm not sure if templates that actually use these resources will work with our config in the current clusters (I donno how it gets it permissions or anything), but I figure we may as well teach the deploy tool the right order and dependencies regardless so no one else runs into the problem I did where PersistentVolumeClaims are deployed before the Volumes or StorageClasses!

See
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses
for more information