### PR TITLE
Add a dev.yml which uses dev's minikube support to get Shopify employees set up quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Based on this specification `kubernetes-run` will create a new pod with the entr
 
 ## Setup
 
+If you work for Shopify, just run `dev up`, but otherwise:
+
 1. [Install kubectl version 1.6.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) and make sure it is in your path
 2. [Install minikube](https://kubernetes.io/docs/getting-started-guides/minikube/#installation) (required to run the test suite)
 3. Check out the repo

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,18 @@
+---
+name: kubernetes-deploy
+up:
+  - ruby: 2.3.2
+  - bundler
+  - minikube
+
+minikube: {}
+
+commands:
+  test:
+    run: bundle exec rake test
+  tophat:
+    run: PRINT_LOGS=1 bundle exec ruby -I test test/integration/kubernetes_deploy_test.rb -n/${1}/
+    desc: Tophat a change by running a test scenario with logging output enabled.
+    syntax:
+      optional:
+        argument: TEST_REGEX

--- a/dev.yml
+++ b/dev.yml
@@ -1,13 +1,17 @@
 ---
 name: kubernetes-deploy
 up:
-  - ruby: 2.3.2
+  - ruby: 2.3.3
   - bundler
-  - minikube
-
-minikube: {}
-
+  - homebrew:
+    - Caskroom/cask/minikube
+  - custom:
+      name: Minikube Cluster
+      met?: test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured')
+      meet: minikube start --vm-driver=xhyve --kubernetes-version=v1.7.5
+      down: minikube stop
 commands:
+  reset-minikube: minikube delete && rm -rf ~/.minikube
   test:
     run: bundle exec rake test
   tophat:


### PR DESCRIPTION
Getting `kubectl` and `minikube` isn't the hardest thing in the world but it turns out `dev` is actually pretty good at it. Dev isn't open source but since the majority of contributors are likely to be Shopifiers I figure we may as well add the file that makes it real easy for us to get set up with the normal `dev up` command. I don't think the `dev.yml` will ever have anything sensitive in it so I think this is safe from a security and privacy standpoint.

Thoughts? I 🎩 'd and the test suite passes locally after `dev up`ing. 
