### PR TITLE
Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,4 @@ inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
-
-Layout/IndentHeredoc:
-  EnforcedStyle: active_support
+  TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kubernetes-deploy.gemspec

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 
 ## Prerequisites
 
+* Ruby 2.3+
 * Your cluster must be running Kubernetes v1.6.0 or higher
 * Each app must have a deploy directory containing its Kubernetes templates (see [Templates](#templates))
 * You must remove the` kubectl.kubernetes.io/last-applied-configuration` annotation from any resources in the namespace that are not included in your deploy directory. This annotation is added automatically when you create resources with `kubectl apply`. `kubernetes-deploy` will prune any resources that have this annotation and are not in the deploy directory.**

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"
 require "rake/testtask"
 

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kubernetes-deploy/version'
@@ -20,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "kubeclient", "~> 2.3"
   spec.add_dependency "googleauth", ">= 0.5"

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module KubernetesDeploy
   # Adds the methods kubernetes-deploy requires to your logger class.
   # These methods include helpers for logging consistent headings, as well as facilities for

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -116,7 +116,7 @@ module KubernetesDeploy
       @logger.debug(out)
       raise EjsonSecretError, err unless st.success?
     ensure
-      file.unlink if file
+      file&.unlink
     end
 
     def generate_secret_yaml(secret_name, secret_type, data)

--- a/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb
@@ -5,7 +5,7 @@ module KubernetesDeploy
   module KubeclientBuilder
     class GoogleFriendlyConfig < Kubeclient::Config
       def fetch_user_auth_options(user)
-        if user['auth-provider'] && (user['auth-provider']['name'] == 'gcp')
+        if user.dig('auth-provider', 'name') == 'gcp'
           { bearer_token: new_token }
         else
           super

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -13,11 +13,11 @@ module KubernetesDeploy
     LOG_LINE_COUNT = 250
 
     DEBUG_RESOURCE_NOT_FOUND_MESSAGE = "None found. Please check your usual logging service (e.g. Splunk)."
-    UNUSUAL_FAILURE_MESSAGE = <<-MSG.strip_heredoc
+    UNUSUAL_FAILURE_MESSAGE = <<~MSG
       It is very unusual for this resource type to fail to deploy. Please try the deploy again.
       If that new deploy also fails, contact your cluster administrator.
       MSG
-    STANDARD_TIMEOUT_MESSAGE = <<-MSG.strip_heredoc
+    STANDARD_TIMEOUT_MESSAGE = <<~MSG
       Kubernetes will continue to attempt to deploy this resource in the cluster, but at this point it is considered unlikely that it will succeed.
       If you have reason to believe it will succeed, retry the deploy to continue to monitor the rollout.
       MSG
@@ -268,7 +268,7 @@ module KubernetesDeploy
       file.write(YAML.dump(@definition))
       file
     ensure
-      file.close if file
+      file&.close
     end
 
     def statsd_tags

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -44,7 +44,7 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, definition:, logger:)
       # subclasses must also set these if they define their own initializer
-      @name = definition.fetch("metadata", {})["name"]
+      @name = definition.dig("metadata", "name")
       unless @name.present?
         logger.summary.add_paragraph("Rendered template content:\n#{definition.to_yaml}")
         raise FatalDeploymentError, "Template is missing required field metadata.name"

--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -54,7 +54,7 @@ module KubernetesDeploy
       if st.success?
         parsed = JSON.parse(service)
 
-        if parsed.fetch("spec", {}).fetch("clusterIP", "") != ""
+        if parsed.dig("spec", "clusterIP").present?
           # the service has an assigned cluster IP and is therefore functioning
           return true
         end
@@ -70,7 +70,7 @@ module KubernetesDeploy
       if st.success?
         parsed = JSON.parse(redis)
 
-        @cloudsql_resource_uuid = parsed.fetch("metadata", {}).fetch("uid", nil)
+        @cloudsql_resource_uuid = parsed.dig("metadata", "uid")
       end
     end
   end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -47,15 +47,15 @@ module KubernetesDeploy
     end
 
     def failure_message
-      @latest_rs.failure_message
+      @latest_rs&.failure_message
     end
 
     def timeout_message
       progress_seconds = @definition['spec']['progressDeadlineSeconds']
       if progress_seconds
-        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds. #{@latest_rs.timeout_message}"
+        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds. #{@latest_rs&.timeout_message}"
       else
-        @latest_rs.timeout_message
+        @latest_rs&.timeout_message
       end
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -56,7 +56,7 @@ module KubernetesDeploy
       if st.success?
         parsed = JSON.parse(service)
 
-        if parsed.fetch("spec", {}).fetch("clusterIP", "") != ""
+        if parsed.dig("spec", "clusterIP").present?
           return true
         end
       end
@@ -71,7 +71,7 @@ module KubernetesDeploy
       if st.success?
         parsed = JSON.parse(redis)
 
-        @redis_resource_uuid = parsed.fetch("metadata", {}).fetch("uid", nil)
+        @redis_resource_uuid = parsed.dig("metadata", "uid")
       end
     end
   end

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -86,7 +86,7 @@ module KubernetesDeploy
 
     def container_names
       regular_containers = @definition["spec"]["template"]["spec"]["containers"].map { |c| c["name"] }
-      init_containers = @definition["spec"]["template"]["spec"].fetch("initContainers", {}).map { |c| c["name"] }
+      init_containers = @definition["spec"]["template"]["spec"].fetch("initContainers", []).map { |c| c["name"] }
       regular_containers + init_containers
     end
 

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -3,7 +3,7 @@ module KubernetesDeploy
   class ResourceWatcher
     def initialize(resources, logger:, deploy_started_at: Time.now.utc)
       unless resources.is_a?(Enumerable)
-        raise ArgumentError, <<-MSG.strip_heredoc
+        raise ArgumentError, <<~MSG
           ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead
         MSG
       end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -125,7 +125,7 @@ module KubernetesDeploy
       else
         deploy_resources(resources, prune: prune, verify: false)
         @logger.summary.add_action("deployed #{resources.length} #{'resource'.pluralize(resources.length)}")
-        warning = <<-MSG.strip_heredoc
+        warning = <<~MSG
           Deploy result verification is disabled for this deploy.
           This means the desired changes were communicated to Kubernetes, but the deploy did not make sure they actually succeeded.
         MSG
@@ -245,7 +245,7 @@ module KubernetesDeploy
         yield doc unless doc.blank?
       end
     rescue Psych::SyntaxError => e
-      debug_msg = <<-INFO.strip_heredoc
+      debug_msg = <<~INFO
         Error message: #{e}
 
         Template content:
@@ -372,7 +372,7 @@ module KubernetesDeploy
         _, err, create_st = kubectl.run("create", "-f", r.file_path, log_failure: false)
 
         next if create_st.success?
-        raise FatalDeploymentError, <<-MSG.strip_heredoc
+        raise FatalDeploymentError, <<~MSG
           Failed to replace or create resource: #{r.id}
           #{err}
         MSG

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module KubernetesDeploy
   VERSION = "0.9.3"
 end

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -135,6 +135,6 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
     containers = deployment.spec.template.spec.containers
     app_container = containers.find { |c| c["name"] == "app" }
-    app_container && app_container.env.find { |n| n.name == "RESTARTED_AT" }
+    app_container&.env&.find { |n| n.name == "RESTARTED_AT" }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -171,7 +171,7 @@ module KubernetesDeploy
     end
 
     def self.delete_namespace(namespace)
-      kubeclient.delete_namespace(namespace) if namespace && !namespace.empty?
+      kubeclient.delete_namespace(namespace) if namespace.present?
     rescue KubeException => e
       raise unless e.to_s.include?("not found")
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ module KubernetesDeploy
 
       if ENV["PRINT_LOGS"]
         # Allows you to view the integration test output as a series of tophat scenarios
-        <<-MESSAGE.strip_heredoc.each_line { |l| $stderr.puts l }
+        <<~MESSAGE.each_line { |l| $stderr.puts l }
 
           \033[0;35m***************************************************************************
            Begin test: #{name}

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -17,7 +17,7 @@ class PodTest < KubernetesDeploy::TestCase
     pod.sync(fake_pod_data)
     assert pod.deploy_failed?
 
-    expected_msg = <<-STRING.strip_heredoc
+    expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
@@ -40,7 +40,7 @@ class PodTest < KubernetesDeploy::TestCase
     pod.sync(fake_pod_data)
     assert pod.deploy_failed?
 
-    expected_msg = <<-STRING.strip_heredoc
+    expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
@@ -79,7 +79,7 @@ class PodTest < KubernetesDeploy::TestCase
     pod.sync(fake_pod_data)
     assert pod.deploy_failed?
 
-    expected_msg = <<-STRING.strip_heredoc
+    expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
     STRING

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -83,7 +83,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
         count: 3,
         last_seen: start_time + 3.seconds,
         reason: "FailedSync",
-        message: <<-STRING.strip_heredoc
+        message: <<~STRING
           Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with ErrImagePull:
            \"rpc error: code = 2 desc = unknown blob\"
         STRING
@@ -94,7 +94,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
         count: 5,
         last_seen: start_time + 5.seconds,
         reason: "FailedSync",
-        message: <<-STRING.strip_heredoc
+        message: <<~STRING
           Error syncing pod, skipping: failed to \"StartContainer\" for \"test\" with CrashLoopBackOff: \"Back-
           off 1m20s restarting failed container=test pod=test-299526239-5vlj9_test(00cfb839-4k2p-11e7-a12d-73972af001c2)\"
         STRING


### PR DESCRIPTION
Upgrades our minimum requirement to Ruby 2.3. Also makes a few easy-win changes to 2.3-style squiggly heredocs, `dig` and `&.`.

The new `# frozen_string_literal: true` came from running `bx rubocop -a`. Dunno why it didn't care about those files until now.

Closes https://github.com/Shopify/kubernetes-deploy/issues/134