### PR TITLE
Add concurrency to slowest parts

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -15,6 +15,7 @@ require 'kubernetes-deploy/errors'
 require 'kubernetes-deploy/formatted_logger'
 require 'kubernetes-deploy/runner'
 require 'kubernetes-deploy/statsd'
+require 'kubernetes-deploy/concurrency'
 
 module KubernetesDeploy
   KubernetesDeploy::StatsD.build

--- a/lib/kubernetes-deploy/concurrency.rb
+++ b/lib/kubernetes-deploy/concurrency.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  module Concurrency
+    MAX_THREADS = 8
+
+    def self.split_across_threads(all_work, &block)
+      return if all_work.empty?
+      raise ArgumentError, "Block of work is required" unless block_given?
+
+      slice_size = ((all_work.length + MAX_THREADS - 1) / MAX_THREADS)
+      threads = []
+      all_work.each_slice(slice_size) do |work_group|
+        threads << Thread.new { work_group.each(&block) }
+      end
+      threads.each(&:join)
+    end
+  end
+end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -14,7 +14,8 @@ module KubernetesDeploy
         @rollout_data = { "replicas" => 0 }.merge(deployment_data["status"]
           .slice("replicas", "updatedReplicas", "availableReplicas", "unavailableReplicas"))
         @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
-        @progress = deployment_data["status"]["conditions"].find { |condition| condition['type'] == 'Progressing' }
+        conditions = deployment_data.fetch("status", {}).fetch("conditions", [])
+        @progress = conditions.find { |condition| condition['type'] == 'Progressing' }
       else # reset
         @latest_rs = nil
         @rollout_data = { "replicas" => 0 }

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -21,7 +21,7 @@ module KubernetesDeploy
         end
         delay_sync_until = Time.now.utc + delay_sync # don't pummel the API if the sync is fast
 
-        @resources.each(&:sync)
+        KubernetesDeploy::Concurrency.split_across_threads(@resources, &:sync)
         newly_finished_resources, @resources = @resources.partition(&:deploy_finished?)
 
         if newly_finished_resources.present?

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -141,8 +141,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_equal false, success, "Deploy succeeded when it was expected to fail"
 
     assert_logs_match_all([
-      "Template validation failed (command: create -f",
-      "Invalid template: configmap-data.yml",
+      "Template validation failed",
+      /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
       "> Error from kubectl:",
       "error validating data: found invalid field myKey for v1.ObjectMeta",
       "> Rendered template content:",

--- a/test/unit/kubernetes-deploy/concurrency_test.rb
+++ b/test/unit/kubernetes-deploy/concurrency_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ConcurrencyTest < KubernetesDeploy::TestCase
+  class TestWork
+    attr_accessor :worked_by_threads
+    def initialize
+      @worked_by_threads = []
+    end
+  end
+
+  def test_split_across_threads_raises_without_a_block
+    assert_raises_message(ArgumentError, "Block of work is required") do
+      KubernetesDeploy::Concurrency.split_across_threads([TestWork.new])
+    end
+  end
+
+  def test_split_across_threads_works_with_zero_work
+    KubernetesDeploy::Concurrency.split_across_threads([]) do |individual|
+      individual.worked_by_threads << Thread.current.object_id
+    end
+    # nothing raised
+  end
+
+  def test_split_across_threads_works_with_one_work
+    all_work = [TestWork.new]
+    KubernetesDeploy::Concurrency.split_across_threads(all_work) do |individual|
+      individual.worked_by_threads << Thread.current.object_id
+    end
+    assert_work_distribution(all_work, [1])
+  end
+
+  def test_split_across_threads_splits_evenly_with_small_work
+    all_work = 2.times.with_object([]) { |_, all| all << TestWork.new }
+    KubernetesDeploy::Concurrency.split_across_threads(all_work) do |individual|
+      individual.worked_by_threads << Thread.current.object_id
+    end
+    assert_work_distribution(all_work, [1, 1])
+  end
+
+  def test_split_across_threads_splits_evenly_with_equal_work_and_threads
+    all_work = KubernetesDeploy::Concurrency::MAX_THREADS.times.with_object([]) { |_, all| all << TestWork.new }
+    KubernetesDeploy::Concurrency.split_across_threads(all_work) do |individual|
+      individual.worked_by_threads << Thread.current.object_id
+    end
+    assert_work_distribution(all_work, [1, 1, 1, 1, 1, 1, 1, 1])
+  end
+
+  def test_split_across_threads_splits_evenly_with_large_work
+    all_work = 31.times.with_object([]) { |_, all| all << TestWork.new }
+    KubernetesDeploy::Concurrency.split_across_threads(all_work) do |individual|
+      individual.worked_by_threads << Thread.current.object_id
+    end
+    assert_work_distribution(all_work, [4, 4, 4, 4, 4, 4, 4, 3])
+  end
+
+  private
+
+  def assert_work_distribution(all_work, expected)
+    assert all_work.all? { |w| w.worked_by_threads.length == 1 }, "Same work done by multiple threads somehow"
+    thread_map = all_work.each_with_object(Hash.new { |hash, key| hash[key] = 0 }) do |w, threads|
+      threads[w.worked_by_threads.first] += 1
+    end
+    assert_equal thread_map.values.sort, expected.sort
+  end
+end


### PR DESCRIPTION
## Problem

Our largest deploys (core) are spending a ton of time in template discovery and in the early polling cycles that involve the full (massive) set of templates. The following sanitized example is typical of a few deploys I checked:

```
[INFO][2017-07-20 01:23:13 +0000]    Discovering templates:
...
[INFO][2017-07-20 01:23:37 +0000]    ----------------------------Phase 2: Checking initial resource statuses 
# that was 24s of discovering things -- not great!
[INFO][2017-07-20 01:26:45 +0000]    Service/[thing]
# that was nearly 3 MINUTES for the initial sync. WTF!
```

I did some profiling using tests (see [this branch](https://github.com/Shopify/kubernetes-deploy/compare/threads...profile)--lmk if you think that'd be useful to commit to the repo), which supports this slowness. I would have expected that with a template set of the "hello-cloud" size, most of the time would be spent sleeping, but that isn't the case:

Before (main thread):
<img width="1525" alt="k8s-d-flame-before" src="https://user-images.githubusercontent.com/4789493/28588503-c70ffb94-7148-11e7-9f18-3ba59f081189.png">


## Solution

Arguably it would be a good idea in the long run to batch requests, i.e. request everything of a given type in the namespace at once and distribute the JSON to the appropriate instances' `sync`. However, since we're spending all of this time in IO wait, concurrency can help us here. Unlike batching, such concurrency is almost trivial to add. I think we should try it first.

After (main thread):
![image](https://user-images.githubusercontent.com/4789493/28588634-26e28866-7149-11e7-99bb-a41f4da9afad.png)

cc @Shopify/cloudplatform 