### PR TITLE
Daemon Set Fix

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -39,6 +39,7 @@ module KubernetesDeploy
     end
 
     def timeout_message
+      STANDARD_TIMEOUT_MESSAGE unless @pods.present?
       @pods.map(&:timeout_message).compact.uniq.join("\n")
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class DaemonSet < KubernetesResource
-    TIMEOUT = 7.minutes
+    TIMEOUT = 5.minutes
 
     def sync
       raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")
@@ -39,8 +39,11 @@ module KubernetesDeploy
     end
 
     def timeout_message
-      STANDARD_TIMEOUT_MESSAGE unless @pods.present?
-      @pods.map(&:timeout_message).compact.uniq.join("\n")
+      if @pods.present?
+        @pods.map(&:timeout_message).compact.uniq.join("\n")
+      else
+        STANDARD_TIMEOUT_MESSAGE
+      end
     end
 
     def deploy_timed_out?

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -12,7 +12,7 @@ module KubernetesDeploy
         @current_generation = daemonset_data["metadata"]["generation"]
         @observed_generation = daemonset_data["status"]["observedGeneration"]
         @rollout_data = daemonset_data["status"]
-          .slice("currentNumberScheduled", "desiredNumberScheduled", "numberReady", "numberAvailable")
+          .slice("currentNumberScheduled", "desiredNumberScheduled", "numberReady")
         @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas}" }.join(", ")
         @pods = find_pods(daemonset_data)
       else # reset
@@ -26,7 +26,7 @@ module KubernetesDeploy
 
     def deploy_succeeded?
       @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["currentNumberScheduled"].to_i &&
-      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["numberAvailable"].to_i &&
+      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["numberReady"].to_i &&
       @current_generation == @observed_generation
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class DaemonSet < KubernetesResource
-    TIMEOUT = 5.minutes
+    TIMEOUT = 7.minutes
 
     def sync
       raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -47,7 +47,11 @@ module KubernetesDeploy
     end
 
     def timeout_message
-      @pods.map(&:timeout_message).compact.uniq.join("\n")
+      if @pods.present?
+        @pods.map(&:timeout_message).compact.uniq.join("\n")
+      else
+        STANDARD_TIMEOUT_MESSAGE
+      end
     end
 
     def deploy_timed_out?

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -18,7 +18,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{ReplicaSet/bare-replica-set\s+1 replica, 1 availableReplica, 1 readyReplica},
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
       %r{Service/web\s+Selects at least 1 pod},
-      %r{DaemonSet/nginx\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady, 1 numberAvailable}
+      %r{DaemonSet/nginx\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady}
     ])
   end
 


### PR DESCRIPTION
## What?
- In order to check for a successful deploy we were using `numberAvailable` from the ds status field
- `numberAvailable` is the number of pods that have been ready for at least `minReadySeconds`
- I have been seeing flakiness in the `numberAvailable` status being upgraded causing deploys to fail [here](https://shipit.shopify.io/shopify/k8s-cluster-services/production/deploys/466283)
  - Successive deploys have failed on different clusters, different portions of the deploy
  - In all failures I checked the status field of the daemon sets and `numberReady` was always up to date whereas `numberAvailable` was often off by one. Sometimes it would resolve itself whereas sometimes it never resolved or only resolved when I force killed a pod

## Other issues?
- tier1 has 180 nodes which makes the 5 min timeout too low due to the `minReadyRequirements`
- Also ran into a failure where `@pods` were empty for the timeout message and caused a failure

Not sure if this is the best way to fix it, open to ideas. In the meantime I'll keep 👀 

cc/ @KnVerey @kirs @Shopify/cloudplatform 