### PR TITLE
Re-Add Daemon Sets

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -72,9 +72,10 @@ module KubernetesDeploy
       all_pods = JSON.parse(raw_json)["items"]
       template_generation = ds_data["spec"]["templateGeneration"]
 
-      latest_pods = all_pods.find_all do |pods|
-        pods["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == ds_data["metadata"]["uid"] } &&
-        pods["metadata"]["labels"]["pod-template-generation"].to_i == template_generation.to_i
+      latest_pods = all_pods.find_all do |pod|
+        next unless owners = pod.dig("metadata", "ownerReferences")
+        owners.any? { |ref| ref["uid"] == ds_data["metadata"]["uid"] } &&
+        pod["metadata"]["labels"]["pod-template-generation"].to_i == template_generation.to_i
       end
       return unless latest_pods.present?
 

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class DaemonSet < KubernetesResource
+    TIMEOUT = 5.minutes
+
+    def sync
+      raw_json, _err, st = kubectl.run("get", type, @name, "--output=json")
+      @found = st.success?
+
+      if @found
+        daemonset_data = JSON.parse(raw_json)
+        @current_generation = daemonset_data["metadata"]["generation"]
+        @observed_generation = daemonset_data["status"]["observedGeneration"]
+        @rollout_data = daemonset_data["status"]
+          .slice("currentNumberScheduled", "desiredNumberScheduled", "numberReady")
+        @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas}" }.join(", ")
+        @pods = find_pods(daemonset_data)
+      else # reset
+        @rollout_data = { "currentNumberScheduled" => 0 }
+        @current_generation = 1 # to make sure the current and observed generations are different
+        @observed_generation = 0
+        @status = nil
+        @pods = []
+      end
+    end
+
+    def deploy_succeeded?
+      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["currentNumberScheduled"].to_i &&
+      @rollout_data["desiredNumberScheduled"].to_i == @rollout_data["numberReady"].to_i &&
+      @current_generation == @observed_generation
+    end
+
+    def deploy_failed?
+      @pods.present? && @pods.any?(&:deploy_failed?)
+    end
+
+    def failure_message
+      @pods.map(&:failure_message).compact.uniq.join("\n")
+    end
+
+    def timeout_message
+      @pods.map(&:timeout_message).compact.uniq.join("\n")
+    end
+
+    def deploy_timed_out?
+      super || @pods.present? && @pods.any?(&:deploy_timed_out?)
+    end
+
+    def exists?
+      @found
+    end
+
+    def fetch_events
+      own_events = super
+      return own_events unless @pods.present?
+      most_useful_pod = @pods.find(&:deploy_failed?) || @pods.find(&:deploy_timed_out?) || @pods.first
+      own_events.merge(most_useful_pod.fetch_events)
+    end
+
+    def fetch_logs
+      most_useful_pod = @pods.find(&:deploy_failed?) || @pods.find(&:deploy_timed_out?) || @pods.first
+      most_useful_pod.fetch_logs
+    end
+
+    private
+
+    def find_pods(ds_data)
+      label_string = ds_data["spec"]["selector"]["matchLabels"].map { |k, v| "#{k}=#{v}" }.join(",")
+      raw_json, _err, st = kubectl.run("get", "pods", "-a", "--output=json", "--selector=#{label_string}")
+      return [] unless st.success?
+
+      all_pods = JSON.parse(raw_json)["items"]
+      template_generation = ds_data["spec"]["templateGeneration"]
+
+      latest_pods = all_pods.find_all do |pods|
+        pods["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == ds_data["metadata"]["uid"] } &&
+        pods["metadata"]["labels"]["pod-template-generation"].to_i == template_generation.to_i
+      end
+      return unless latest_pods.present?
+
+      latest_pods.each_with_object([]) do |pod_data, relevant_pods|
+        pod = Pod.new(
+          namespace: namespace,
+          context: context,
+          definition: pod_data,
+          logger: @logger,
+          parent: "#{@name.capitalize} daemon set",
+          deploy_started: @deploy_started
+        )
+        pod.sync(pod_data)
+        relevant_pods << pod
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -20,6 +20,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   pod_disruption_budget
   replica_set
   service_account
+  daemon_set
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
 end

--- a/test/fixtures/hello-cloud/daemon_set.yml
+++ b/test/fixtures/hello-cloud/daemon_set.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -130,5 +130,11 @@ module FixtureSetAssertions
       annotations = obj.metadata.annotations.to_h.stringify_keys
       assert annotations.key?(annotation), "Expected secret to have annotation #{annotation}, but it did not"
     end
+
+    def assert_daemon_set_present(name)
+      daemon_sets = v1beta1_kubeclient.get_daemon_sets(namespace: namespace)
+      desired = daemon_sets.find { |ds| ds.metadata.name == name }
+      assert desired.present?, "Daemon set #{name} does not exist"
+    end
   end
 end

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -15,6 +15,7 @@ module FixtureSetAssertions
       assert_poddisruptionbudget
       assert_bare_replicaset_up
       assert_all_service_accounts_up
+      assert_daemon_set_up
     end
 
     def assert_unmanaged_pod_statuses(status, count = 1)
@@ -83,6 +84,10 @@ module FixtureSetAssertions
 
     def assert_all_service_accounts_up
       assert_service_account_present("build-robot")
+    end
+
+    def assert_daemon_set_up
+      assert_daemon_set_present("nginx")
     end
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -11,13 +11,14 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Deploying ConfigMap/hello-cloud-configmap-data (timeout: 30s)",
       "Hello from Docker!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 13 resources"
+      "Successfully deployed 14 resources"
     ], in_order: true)
 
     assert_logs_match_all([
       %r{ReplicaSet/bare-replica-set\s+1 replica, 1 availableReplica, 1 readyReplica},
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
-      %r{Service/web\s+Selects at least 1 pod}
+      %r{Service/web\s+Selects at least 1 pod},
+      %r{DaemonSet/nginx\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady}
     ])
   end
 
@@ -49,9 +50,10 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       'pod "unmanaged-pod-',
       'service "web"',
       'deployment "web"',
-      'ingress "web"'
+      'ingress "web"',
+      'daemonset "nginx"'
     ] # not necessarily listed in this order
-    expected_msgs = [/Pruned 5 resources and successfully deployed 3 resources/]
+    expected_msgs = [/Pruned 6 resources and successfully deployed 3 resources/]
     expected_pruned.map do |resource|
       expected_msgs << /The following resources were pruned:.*#{resource}/
     end
@@ -630,6 +632,26 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_equal false, success, "Deploy succeeded when it was expected to fail"
     assert_logs_match("Unmanaged pods like Pod/oops-it-is-static must have unique names on every deploy")
+  end
+
+  def test_bad_container_on_daemon_sets_fails
+    success = deploy_fixtures("hello-cloud", subset: ["daemon_set.yml"]) do |fixtures|
+      daemon_set = fixtures['daemon_set.yml']['DaemonSet'].first
+      container = daemon_set['spec']['template']['spec']['containers'].first
+      container["image"] = "busybox"
+      container["command"] = ["ls", "/not-a-dir"]
+    end
+
+    refute success
+    assert_logs_match_all([
+      "DaemonSet/nginx: FAILED",
+      "nginx: Crashing repeatedly (exit 1). See logs for more information.",
+      "Final status: 1 currentNumberScheduled, 1 desiredNumberScheduled, 0 numberReady",
+      "Events (common success events excluded):",
+      "BackOff: Back-off restarting failed container",
+      "Logs from container 'nginx' (last 250 lines shown):",
+      "ls: /not-a-dir: No such file or directory"
+    ], in_order: true)
   end
 
   private


### PR DESCRIPTION
## What?
- Re-adds daemon set resource
- Notes/todos from investigating the failed deploys after previous attempt:

  - [x] We need to change the RollingUpdate strategy on a bunch of our DS before shipping this again. `maxUnavailable: 2` is unreasonable for huge numbers of nodes; it should be a percentage.
    - https://github.com/Shopify/k8s-cluster-services/pull/148
  - [ ] Some of our datadog DS seem to have actual stability issues. This is going to rightly interfere with deploys until we fix them. We have some ideas.
  - [x] I think we're looking at the wrong field when selecting pods. `DS#spec.Generation` matches up with `DS#status.observedGeneration` for making sure the status we're looking at is up to date, so that's fine. However, it seems to be `DS#spec.templateGeneration` that matches up with `Pod#metadata.labels.pod-template-generation`. We have a DS where Generation and templateGeneration are really different.
  - [x] We have one case where `numberAvailable` is down by one even though all the pods appear to have been ready for minutes (where min ready seconds is 5). I still think that `numberAvailable` is the most correct thing to look, but you're right that we'll have to switch if we can't figure out why this is / it seems unreliable.