### PR TITLE
Handle exec probes and fix container readiness check

### DIFF
--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -11,15 +11,36 @@ spec:
         app: crash-app
     spec:
       containers:
-      - name: app
+      - name: http-probe
         image: nginx:alpine
         ports:
-        - containerPort: 8000
-          name: http-alt
+        - containerPort: 80
+          name: http
         readinessProbe:
           httpGet:
             path: "/bad/ping/path"
-            port: 8000
+            port: 80
           initialDelaySeconds: 0
           timeoutSeconds: 1
-
+          failureThreshold: 1
+      - name: exec-probe
+        image: busybox
+        command: ["sleep", "8000"]
+        readinessProbe:
+          exec:
+            command:
+              - "ls"
+              - "/bad/path"
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+          failureThreshold: 1
+      - name: sidecar
+        image: busybox
+        command: ["sleep", "8000"]
+        readinessProbe:
+          exec:
+            command: ["ls", "/"]
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          failureThreshold: 100

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -476,7 +476,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_deploy_result_logging_for_mixed_result_deploy
-    forced_timeout = 12 # failure often takes 8s, and want both
+    forced_timeout = 20 # failure can take 10+s, which makes this test flake with shorter hard timeouts
     KubernetesDeploy::Deployment.any_instance.stubs(:timeout).returns(forced_timeout)
     refute deploy_fixtures("invalid", subset: ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml"])
     # Debug info for bad probe timeout


### PR DESCRIPTION
Fixes https://github.com/Shopify/kubernetes-deploy/issues/139

- Makes the timeout heading for readiness probe failures less confident, since it can surface when a huge deployment takes forever to roll out and one of its containers is still brand new (and could very well pass its probes)
- Makes the list of failed readiness probes support exec probes
- Fixes the readiness probe check to correctly detect success (was `if true == "true"` 😞 ), and adds a test assertion for this (I noticed in production that it was printing all the probes when I could see that one was passing)

cc @Shopify/cloudplatform 