### PR TITLE
Remove support for Kubernetes v1.5

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -101,14 +101,9 @@ module KubernetesDeploy
       !deploy_succeeded? && !deploy_failed? && (Time.now.utc - @deploy_started > timeout)
     end
 
-    def tpr?
-      false
-    end
-
     # Expected values: :apply, :replace, :replace_force
     def deploy_method
-      # TPRs must use update for now: https://github.com/kubernetes/kubernetes/issues/39906
-      tpr? ? :replace : :apply
+      :apply
     end
 
     def debug_message

--- a/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bugsnag.rb
@@ -25,9 +25,5 @@ module KubernetesDeploy
     def exists?
       @found
     end
-
-    def tpr?
-      true
-    end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -23,10 +23,6 @@ module KubernetesDeploy
       false
     end
 
-    def tpr?
-      true
-    end
-
     def exists?
       @found
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -25,10 +25,6 @@ module KubernetesDeploy
       false
     end
 
-    def tpr?
-      true
-    end
-
     def exists?
       @found
     end


### PR DESCRIPTION
Closes https://github.com/Shopify/kubernetes-deploy/issues/83

- Removes code we added to support 1.5 and 1.6 at the same time
- Removes special handling of TPR creation/update, which is no longer required as of 1.6. This will also make it possible to prune TPRs if we want to go that route.