### PR TITLE
It is possible for ownerReferences to be nil

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -97,7 +97,8 @@ module KubernetesDeploy
 
       all_pods = JSON.parse(raw_json)["items"]
       all_pods.each_with_object([]) do |pod_data, relevant_pods|
-        next unless pod_data["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == rs_data["metadata"]["uid"] }
+        next unless owners = pod_data.dig("metadata", "ownerReferences")
+        next unless owners.any? { |ref| ref["uid"] == rs_data["metadata"]["uid"] }
         pod = Pod.new(
           namespace: namespace,
           context: context,


### PR DESCRIPTION
We saw this on a rollback of a deployment that is externally autoscaled

```
kubernetes-deploy-0.11.0/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb:100:in `block in find_pods': undefined method `any?' for nil:NilClass (NoMethodError)
```

I don't know under what circumstances this can happen, but it's definitely not on all pods in the affected RS. The RS success condition doesn't depend on finding relevant pods, so not being able to identify them isn't a big deal in the happy path. If something is wrong and we can't identify _any_ pods, the deploy will eventually time out (the doom detection won't work). The worst case I can think of is a case where there are many pods in the RS and we only select one, and that one happens to be in a bad state, we'll fail the deploy unnecessarily. That seems super unlikely, but I'll keep an eye out for it.

@stefanmb 