### PR TITLE
Explicitly return empty array for no pods in Daemon Sets

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -77,7 +77,7 @@ module KubernetesDeploy
         owners.any? { |ref| ref["uid"] == ds_data["metadata"]["uid"] } &&
         pod["metadata"]["labels"]["pod-template-generation"].to_i == template_generation.to_i
       end
-      return unless latest_pods.present?
+      return [] unless latest_pods.present?
 
       latest_pods.each_with_object([]) do |pod_data, relevant_pods|
         pod = Pod.new(


### PR DESCRIPTION
## What?
- Resolves https://github.com/Shopify/kubernetes-deploy/issues/160
- `find_pods` was previously returning nil when no `latest_pods` were found
- This PR explicitly returns an empty array `[]`

cc/ @wvanbergen @KnVerey 