### PR TITLE
Kubernetes 1.7 upgrade

### DIFF
--- a/test/fixtures/hello-cloud/daemon_set.yml
+++ b/test/fixtures/hello-cloud/daemon_set.yml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: nginx:alpine
         ports:
         - containerPort: 80

--- a/test/fixtures/hello-cloud/template-runner.yml
+++ b/test/fixtures/hello-cloud/template-runner.yml
@@ -15,6 +15,7 @@ template:
     containers:
     - name: task-runner
       image: hello-world:latest
+      imagePullPolicy: IfNotPresent
       env:
       - name: CONFIG
         valueFrom:

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -60,4 +60,5 @@ spec:
               key: datapoint1
       - name: sidecar
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["sleep", "8000"]

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -25,6 +25,7 @@ spec:
           failureThreshold: 1
       - name: exec-probe
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["sleep", "8000"]
         readinessProbe:
           exec:
@@ -36,6 +37,7 @@ spec:
           failureThreshold: 1
       - name: sidecar
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["sleep", "8000"]
         readinessProbe:
           exec:

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -13,7 +13,9 @@ spec:
       initContainers:
       - name: successful-init
         image: hello-world:latest
+        imagePullPolicy: IfNotPresent
       containers:
       - name: container-cannot-run
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["/some/bad/path"]

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -13,6 +13,7 @@ spec:
       initContainers:
       - name: init-crash-loop-back-off
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["ls", "/not-a-dir"]
       containers:
       - name: app

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -32,6 +32,7 @@ spec:
       containers:
       - name: app
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["sleep", "40"]
         env:
         - name: GITHUB_REV

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,6 +64,20 @@ module KubernetesDeploy
       @logger_stream.close
     end
 
+    def assert_deploy_status(desired_status, result)
+      expected = case desired_status
+      when :failure then false
+      when :success then true
+      else raise "#{desired_status} is not a valid option for this test helper"
+      end
+
+      logging_assertion do |logs|
+        assert_equal expected, result, "Unexpected deploy result (wanted #{desired_status}). Logs:\n#{logs}"
+        expected_msg = expected ? "Result: SUCCESS" : "Result: FAILURE"
+        assert_match Regexp.new(expected_msg), logs, "'#{expected_msg}' not found in the following logs:\n#{logs}"
+      end
+    end
+
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|
         unless times

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,17 +64,17 @@ module KubernetesDeploy
       @logger_stream.close
     end
 
-    def assert_deploy_status(desired_status, result)
-      expected = case desired_status
-      when :failure then false
-      when :success then true
-      else raise "#{desired_status} is not a valid option for this test helper"
-      end
-
+    def assert_deploy_failure(result)
       logging_assertion do |logs|
-        assert_equal expected, result, "Unexpected deploy result (wanted #{desired_status}). Logs:\n#{logs}"
-        expected_msg = expected ? "Result: SUCCESS" : "Result: FAILURE"
-        assert_match Regexp.new(expected_msg), logs, "'#{expected_msg}' not found in the following logs:\n#{logs}"
+        assert_equal false, result, "Deploy succeeded when it was expected to fail. Logs:\n#{logs}"
+        assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
+      end
+    end
+
+    def assert_deploy_success(result)
+      logging_assertion do |logs|
+        assert_equal true, result, "Deploy failed when it was expected to succeed. Logs:\n#{logs}"
+        assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
       end
     end
 


### PR DESCRIPTION
## Purpose 

This PR prepares kubernetes-deploy for version 1.7. I've run the tests against v1.7.4 locally, which only revealed the following very minor issues:
- `activeDeadlineSeconds` doesn't make sense on a deployment, and k8s now validates this, preventing a test's setup from working. It was a regression test trying to simulate dead pods hanging around as a result of evictions. Performing an actual eviction against minikube does not seem to leave the pods around. The value of this test is very low (we now ignore the old replicaset completely, and there is a test for the ability to run multiple revisions at once) and it is not obvious how to make it work without the activeDeadlineSeconds hack, so I'm removing it.
- Unmanaged pods that die immediately with `ContainerCannotRun` have their termination data under `state.terminated` instead of `lastState.terminated`, so we need to check both places. I'm not certain whether a managed pod can also end up with `ContainerCannotRun` in `state.terminated`, but  if it does, using that info so seems acceptable (even desirable) to me. Without this fix, the result is still correct and all of the information is still logged, but the termination reason isn't surfaced at the top of the output as it should be.

![](https://screenshot.click/2017-09-11--180248_fhw0z-zqj5d.png)

I plan to upgrade CI to 1.7 once we're actually running that version. If you think I should do that sooner, LMK. (Maybe we should set up the ability to run CI against two versions for a period...)

## Incidentals

- Add a helper to assert the return value of `deploy_fixtures` in a consistent and more helpful way (inspired by one of the test failures I debugged here originally being `expected true, actual false`)
- Make sure ImagePullPolicy is explicitly set to IfNotPresent where that is not the default (i.e. when tag is `:latest` or unspecified). I noticed in passing that it was set to `Always` in some cases, which could theoretically be slowing down CI.

cc @Shopify/cloudplatform 