### PR TITLE
Improve restart command

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 4.2"
-  spec.add_dependency "kubeclient", "~> 2.3"
+  spec.add_dependency "kubeclient", "~> 2.4"
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -5,7 +5,7 @@ module KubernetesDeploy
 
   class NamespaceNotFoundError < FatalDeploymentError
     def initialize(name, context)
-      super("Namespace `#{name}` not found in context `#{context}`. Aborting the task.")
+      super("Namespace `#{name}` not found in context `#{context}`")
     end
   end
 end

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -6,8 +6,7 @@ module KubernetesDeploy
   module KubeclientBuilder
     class ContextMissingError < FatalDeploymentError
       def initialize(context_name)
-        super("`#{context_name}` context must be configured in your KUBECONFIG (#{ENV['KUBECONFIG']}). " \
-          "Please see the README.")
+        super("`#{context_name}` context must be configured in your KUBECONFIG (#{ENV['KUBECONFIG']}).")
       end
     end
 

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class ResourceWatcher
-    def initialize(resources, logger:, deploy_started_at: Time.now.utc)
+    def initialize(resources, logger:, deploy_started_at: Time.now.utc, operation_name: "deploy")
       unless resources.is_a?(Enumerable)
         raise ArgumentError, <<~MSG
           ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead
@@ -10,30 +10,33 @@ module KubernetesDeploy
       @resources = resources
       @logger = logger
       @deploy_started_at = deploy_started_at
+      @operation_name = operation_name
     end
 
-    def run(delay_sync: 3.seconds, reminder_interval: 30.seconds)
+    def run(delay_sync: 3.seconds, reminder_interval: 30.seconds, record_summary: true)
       delay_sync_until = last_message_logged_at = Time.now.utc
+      remainder = @resources.dup
 
-      while @resources.present?
+      while remainder.present?
         if Time.now.utc < delay_sync_until
           sleep(delay_sync_until - Time.now.utc)
         end
         delay_sync_until = Time.now.utc + delay_sync # don't pummel the API if the sync is fast
 
-        KubernetesDeploy::Concurrency.split_across_threads(@resources, &:sync)
-        newly_finished_resources, @resources = @resources.partition(&:deploy_finished?)
+        KubernetesDeploy::Concurrency.split_across_threads(remainder, &:sync)
+        newly_finished_resources, remainder = remainder.partition(&:deploy_finished?)
 
         if newly_finished_resources.present?
           watch_time = (Time.now.utc - @deploy_started_at).round(1)
           report_what_just_happened(newly_finished_resources, watch_time)
-          report_what_is_left(reminder: false)
+          report_what_is_left(remainder, reminder: false)
           last_message_logged_at = Time.now.utc
         elsif due_for_reminder?(last_message_logged_at, reminder_interval)
-          report_what_is_left(reminder: true)
+          report_what_is_left(remainder, reminder: true)
           last_message_logged_at = Time.now.utc
         end
       end
+      record_statuses_for_summary(@resources) if record_summary
     end
 
     private
@@ -44,23 +47,41 @@ module KubernetesDeploy
       new_successes, new_failures = resources.partition(&:deploy_succeeded?)
       new_failures.each do |resource|
         if resource.deploy_failed?
-          @logger.error("#{resource.id} failed to deploy after #{watch_time}s")
+          @logger.error("#{resource.id} failed to #{@operation_name} after #{watch_time}s")
         else
-          @logger.error("#{resource.id} deployment timed out")
+          @logger.error("#{resource.id} rollout timed out")
         end
       end
 
       if new_successes.present?
-        success_string = ColorizedString.new("Successfully deployed in #{watch_time}s:").green
+        success_string = ColorizedString.new("Successfully #{@operation_name}ed in #{watch_time}s:").green
         @logger.info("#{success_string} #{new_successes.map(&:id).join(', ')}")
       end
     end
 
-    def report_what_is_left(reminder:)
-      return unless @resources.present?
-      resource_list = @resources.map(&:id).join(', ')
+    def report_what_is_left(resources, reminder:)
+      return unless resources.present?
+      resource_list = resources.map(&:id).join(', ')
       msg = reminder ? "Still waiting for: #{resource_list}" : "Continuing to wait for: #{resource_list}"
       @logger.info(msg)
+    end
+
+    def record_statuses_for_summary(resources)
+      successful_resources, failed_resources = resources.partition(&:deploy_succeeded?)
+      fail_count = failed_resources.length
+      success_count = successful_resources.length
+
+      if success_count > 0
+        @logger.summary.add_action("successfully #{@operation_name}ed #{success_count} "\
+          "#{'resource'.pluralize(success_count)}")
+        final_statuses = successful_resources.map(&:pretty_status).join("\n")
+        @logger.summary.add_paragraph("#{ColorizedString.new('Successful resources').green}\n#{final_statuses}")
+      end
+
+      if fail_count > 0
+        @logger.summary.add_action("failed to #{@operation_name} #{fail_count} #{'resource'.pluralize(fail_count)}")
+        failed_resources.each { |r| @logger.summary.add_paragraph(r.debug_message) }
+      end
     end
 
     def due_for_reminder?(last_message_logged_at, reminder_interval)

--- a/lib/kubernetes-deploy/statsd.rb
+++ b/lib/kubernetes-deploy/statsd.rb
@@ -4,6 +4,10 @@ require 'logger'
 
 module KubernetesDeploy
   class StatsD
+    def self.duration(start_time)
+      (Time.now.utc - start_time).round(1)
+    end
+
     def self.build
       ::StatsD.default_sample_rate = 1.0
       ::StatsD.prefix = "KubernetesDeploy"

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -20,6 +20,10 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{Service/web\s+Selects at least 1 pod},
       %r{DaemonSet/nginx\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady}
     ])
+
+    # Verify that success section isn't duplicated for predeployed resources
+    assert_logs_match("Successful resources", 1)
+    assert_logs_match(%r{ConfigMap/hello-cloud-configmap-data\s+Available}, 1)
   end
 
   def test_partial_deploy_followed_by_full_deploy

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,18 +65,30 @@ module KubernetesDeploy
     end
 
     def assert_deploy_failure(result)
+      if ENV["PRINT_LOGS"]
+        assert_equal false, result, "Deploy succeeded when it was expected to fail"
+        return
+      end
+
       logging_assertion do |logs|
         assert_equal false, result, "Deploy succeeded when it was expected to fail. Logs:\n#{logs}"
         assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
       end
     end
+    alias_method :assert_restart_failure, :assert_deploy_failure
 
     def assert_deploy_success(result)
+      if ENV["PRINT_LOGS"]
+        assert_equal true, result, "Deploy failed when it was expected to succeed"
+        return
+      end
+
       logging_assertion do |logs|
         assert_equal true, result, "Deploy failed when it was expected to succeed. Logs:\n#{logs}"
         assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
       end
     end
+    alias_method :assert_restart_success, :assert_deploy_success
 
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|


### PR DESCRIPTION
Fixes https://github.com/Shopify/cloudplatform/issues/562
@Shopify/cloudplatform 


## Goals

- Make the restart command's exit status accurate (see [this deploy](https://shipit.shopify.io/shopify/facebook-commerce/staging/tasks/478249) for an example of the problem)
- Bring the restart command's output behaviour in line with the deploy command's
  - Task failures and user errors should generate friendly messages and exit cleanly
  - Final status/debug information should always be printed in a summary section
- Output statsd duration metrics for the restart task too


## Sample output

### Successful restart

![screenshot](https://screenshot.click/2017-09-19--181933_e6i84-30ph5.png)

![screenshot](https://screenshot.click/2017-09-19--182100_fbm3c-f61e4.png)

### Bad configuration

![screenshot](https://screenshot.click/2017-09-19--182000_k6ucw-i52iz.png)

![screenshot](https://screenshot.click/2017-09-19--182239_oegcy-tsrzz.png)

### Failed restart

![screenshot](https://screenshot.click/2017-09-19--182212_b1jl2-xhfg5.png)