### PR TITLE
Switch to Minikube Pipa CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,8 @@
+  - name: 'Run Test Suite (:kubernetes: 1.7.5)'
+    command: bin/ci
+    agents:
+      queue: pipa-production-minikube-v1.7.5
+  - name: 'Run Test Suite (:kubernetes: 1.6.4)'
+    command: bin/ci
+    agents:
+      queue: pipa-production-minikube-v1.6.4

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 * [Setup](#setup)
 * [Running the test suite locally](#running-the-test-suite-locally)
 * [Releasing a new version (Shopify employees)](#releasing-a-new-version-shopify-employees)
-* [CI (Shopify employees)](#ci-shopify-employees)
 * [CI (External contributors)](#ci-external-contributors)
 
 **CONTRIBUTING**
@@ -294,20 +293,11 @@ To make StatsD log what it would have emitted, run a test with `STATSD_DEV=1`.
 If you push your commit and the tag separately, Shipit usually fails with `You need to create the v0.7.9 tag first.`. To make it find your tag, go to `Settings` > `Resynchronize this stack` > `Clear git cache`.
 
 
-
-## CI (Shopify employees)
-
-Buildkite will build branches as you're working on them, but as soon as you create a PR it will stop building new commits from that branch because we disabled PR builds for security reasons. You can manually trigger the PR build from the [Buildkite UI](https://buildkite.com/shopify/kubernetes-deploy-gem) (just specify the branch; SHA is not required).
-
-<img width="464" alt="screen shot 2017-02-21 at 10 55 33" src="https://cloud.githubusercontent.com/assets/522155/23172610/52771a3a-f824-11e6-8c8e-3d59c45e7ff8.png">
-
-
-
 ## CI (External contributors)
 
-Please make sure you run the tests locally before submitting your PR (see [Running the test suite locally](#running-the-test-suite-locally)). A Shopify employee will trigger CI for you after reviewing your PR.
+Please make sure you run the tests locally before submitting your PR (see [Running the test suite locally](#running-the-test-suite-locally)). After reviewing your PR, a Shopify employee will trigger CI for you from the [Buildkite UI](https://buildkite.com/shopify/kubernetes-deploy-gem) (just specify the branch; SHA is not required).
 
-
+<img width="464" alt="screen shot 2017-02-21 at 10 55 33" src="https://cloud.githubusercontent.com/assets/522155/23172610/52771a3a-f824-11e6-8c8e-3d59c45e7ff8.png">
 
 # Contributing
 

--- a/bin/ci
+++ b/bin/ci
@@ -1,13 +1,19 @@
 #!/bin/bash
-set -eox pipefail
+set -euo pipefail
 
-KUBERNETES_VER=1.6.0
+if [[ -n "${DEBUG:+set}" ]]; then
+  set -x
+fi
 
-echo "--- Installing dependencies"
-bundle install --jobs 4
-
-echo "--- Starting minikube"
-minikube start --cpus 2 --memory 2048 --disk-size=2gb --kubernetes-version=$KUBERNETES_VER --logtostderr
-
-echo "--- Running tests"
-bundle exec rake test
+docker run --rm \
+	--net=host \
+	-v "$HOME/.kube":/"$HOME/.kube" \
+    -v "$HOME/.minikube":/"$HOME/.minikube" \
+    -v "$PWD":/usr/src/app \
+    -v "/usr/local/google-cloud-sdk/bin/kubectl":"/usr/bin/kubectl" \
+    -e CI=1 \
+    -e CODECOV_TOKEN=$CODECOV_TOKEN \
+    -e COVERAGE=1 \
+    -w /usr/src/app \
+    ruby:2.3 \
+    bin/test

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- :ruby: Bundle Install"
+bundle install --jobs 4 
+echo "+++ :kubernetes: Run Tests"
+bundle exec rake test TESTOPTS='-v'

--- a/test/fixtures/hello-cloud/disruption-budgets.yml
+++ b/test/fixtures/hello-cloud/disruption-budgets.yml
@@ -1,15 +1,3 @@
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: test
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      name: web
-      app: hello-cloud
----
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -34,6 +34,10 @@ spec:
         image: busybox
         imagePullPolicy: IfNotPresent
         command: ["sleep", "40"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "40"]
         env:
         - name: GITHUB_REV
           value: <%= current_sha %>

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -26,7 +26,7 @@ module FixtureDeployHelper
   #     pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
-  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false, prune: true, bindings: {})
+  def deploy_fixtures(set, subset: nil, wait: true, allow_protected_ns: false, prune: true, bindings: {}, sha: nil)
     fixtures = load_fixtures(set, subset)
     raise "Cannot deploy empty template set" if fixtures.empty?
 
@@ -36,7 +36,7 @@ module FixtureDeployHelper
     Dir.mktmpdir("fixture_dir") do |target_dir|
       write_fixtures_to_dir(fixtures, target_dir)
       success = deploy_dir(target_dir, wait: wait, allow_protected_ns: allow_protected_ns,
-        prune: prune, bindings: bindings)
+        prune: prune, bindings: bindings, sha: sha)
     end
     success
   end
@@ -45,10 +45,11 @@ module FixtureDeployHelper
     deploy_dir(fixture_path(set), wait: wait, bindings: bindings)
   end
 
-  def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {})
+  def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {}, sha: nil)
+    current_sha = sha || SecureRandom.hex(6)
     runner = KubernetesDeploy::Runner.new(
       namespace: @namespace,
-      current_sha: SecureRandom.hex(6),
+      current_sha: current_sha,
       context: KubeclientHelper::MINIKUBE_CONTEXT,
       template_dir: dir,
       logger: logger,

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -138,3 +138,5 @@ module FixtureSetAssertions
     end
   end
 end
+
+Dir.glob(File.expand_path("../fixture_sets/*.rb", __FILE__)).each { |file| require file }

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -74,7 +74,7 @@ module FixtureSetAssertions
     def assert_poddisruptionbudget
       budgets = policy_v1beta1_kubeclient.get_pod_disruption_budgets(namespace: namespace)
       assert_equal 1, budgets.size, "Expected 1 PodDisruptionBudget"
-      assert_equal 2, budgets[0].spec.minAvailable, "Expected PodDisruptionBudget to be overridden"
+      assert_equal 2, budgets[0].spec.minAvailable, "Unexpected value in PodDisruptionBudget spec"
     end
 
     def assert_bare_replicaset_up

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ require 'minitest/stub/const'
 require 'webmock/minitest'
 require 'mocha/mini_test'
 
-Dir.glob(File.expand_path("../helpers/**/*.rb", __FILE__)).each { |file| require file }
+Dir.glob(File.expand_path("../helpers/*.rb", __FILE__)).each { |file| require file }
 ENV["KUBECONFIG"] ||= "#{Dir.home}/.kube/config"
 
 Mocha::Configuration.prevent(:stubbing_method_unnecessarily)


### PR DESCRIPTION
**What**
* Added a separate pipeline: https://buildkite.com/shopify/kubernetes-deploy-gem-pipa
   - Note it's limited to `pipa` branch until we merge.
   - Builds branches but not PRs.
* Simultaneous k8s 1.6.4 and 1.7.5 CI

Todo: 

- [x] make the tests pass as reliably as on the old pipeline
- [x] fix the pipeline branch filter and make sure it correctly skips PRs
- [x] Update the readme if Shopify contributors no longer need to build manually
- [x] Disable the old CI pipeline
- [x] Update the repo's required statuses