### PR TITLE
Return empty hash for logs if no pods present

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -66,6 +66,7 @@ module KubernetesDeploy
     end
 
     def fetch_logs
+      return {} unless @pods.present? # the kubectl command times out if no pods exist
       container_names.each_with_object({}) do |container_name, container_logs|
         out, _err, _st = kubectl.run(
           "logs",


### PR DESCRIPTION
## What?
- Seems like `kubectl get logs rs/#{name}` times out after 30s when the replica set has no pods
- This was causing a simple test to take much longer
- This unblocks the test by speeding it up but requires some investigation as to whether this is a bug or feature in k8s

