### PR TITLE
Better error message when $KUBECONFIG not set

### DIFF
--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -264,7 +264,9 @@ module KubernetesDeploy
 
     def validate_configuration(allow_protected_ns:, prune:)
       errors = []
-      if ENV["KUBECONFIG"].blank? || !File.file?(ENV["KUBECONFIG"])
+      if ENV["KUBECONFIG"].blank?
+        errors << "$KUBECONFIG not set"
+      elsif !File.file?(ENV["KUBECONFIG"])
         errors << "Kube config not found at #{ENV['KUBECONFIG']}"
       end
 

--- a/test/unit/kubernetes-deploy/runner_test.rb
+++ b/test/unit/kubernetes-deploy/runner_test.rb
@@ -6,11 +6,33 @@ class RunnerTest < KubernetesDeploy::TestCase
     refute_nil ::KubernetesDeploy::VERSION
   end
 
+  def test_error_message_when_kubeconfig_not_set
+    runner_with_env(nil)
+    assert_logs_match("Configuration invalid")
+    assert_logs_match("$KUBECONFIG not set")
+    assert_logs_match("Current SHA must be specified")
+    assert_logs_match("Namespace must be specified")
+    assert_logs_match("Context must be specified")
+    assert_logs_match(/Template directory (\S+) doesn't exist/)
+  end
+
   def test_initializer
+    runner_with_env("/this-really-should/not-exist")
+    assert_logs_match("Configuration invalid")
+    assert_logs_match("Kube config not found at /this-really-should/not-exist")
+    assert_logs_match("Current SHA must be specified")
+    assert_logs_match("Namespace must be specified")
+    assert_logs_match("Context must be specified")
+    assert_logs_match(/Template directory (\S+) doesn't exist/)
+  end
+
+  private
+
+  def runner_with_env(value)
     # TODO: Switch to --kubeconfig for kubectl shell out and pass env var as arg to Runner init
     # Then fix this crappy env manipulation
     original_env = ENV["KUBECONFIG"]
-    ENV["KUBECONFIG"] = "/this-really-should/not-exist"
+    ENV["KUBECONFIG"] = value
 
     runner = KubernetesDeploy::Runner.new(
       namespace: "",
@@ -20,14 +42,6 @@ class RunnerTest < KubernetesDeploy::TestCase
       template_dir: "unknown",
     )
     runner.run
-
-    assert_logs_match("Configuration invalid")
-    assert_logs_match("Kube config not found at /this-really-should/not-exist")
-    assert_logs_match("Current SHA must be specified")
-    assert_logs_match("Namespace must be specified")
-    assert_logs_match("Context must be specified")
-    assert_logs_match(/Template directory (\S+) doesn't exist/)
-
   ensure
     ENV["KUBECONFIG"] = original_env
   end


### PR DESCRIPTION
Currently if $KUBECONFIG is not get you get an error message like:
```
[localhost][err] [FATAL][2017-09-26 09:39:15 -0400][context][namespace]    Configuration invalid
[localhost][err] [FATAL][2017-09-26 09:39:15 -0400][context][namespace]    - Kube config not found at
```

This will change the second line to `"$KUBECONFIG not set"` which should be easier to understand. 