### PR TITLE
Improve stability of a test

### DIFF
--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -307,10 +307,10 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Deployment/cannot-run: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
       %r{container-cannot-run: Failed to start \(exit 127\): .*/some/bad/path},
-      "Logs from container 'container-cannot-run'",
-      "no such file or directory",
+      "Logs from container 'successful-init'",
       "Hello from Docker!" # logs from successful init container
     ], in_order: true)
+    assert_logs_match("no such file or directory")
   end
 
   def test_wait_false_still_waits_for_priority_resources


### PR DESCRIPTION
Example failure: https://buildkite.com/shopify/kubernetes-deploy-gem/builds/69#673de254-f724-4bca-96d9-da3c1fd383b9

The specific log message from k8s seems unreliable here. The important thing is that this information is displayed SOMEWHERE in the deploy logs. As you can see in that build, it is actually displayed many times, just not in the logs section.