### PR TITLE
Ensure ejson secrets respect the no-prune flag

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -32,11 +32,7 @@ module KubernetesDeploy
 
     def run
       create_secrets
-      if @prune
-        prune_managed_secrets
-      else
-        @logger.summary.add_action("no secrets were pruned")
-      end
+      prune_managed_secrets if @prune
     end
 
     private

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -17,11 +17,12 @@ module KubernetesDeploy
     EJSON_SECRETS_FILE = "secrets.ejson"
     EJSON_KEYS_SECRET = "ejson-keys"
 
-    def initialize(namespace:, context:, template_dir:, logger:)
+    def initialize(namespace:, context:, template_dir:, logger:, prune: true)
       @namespace = namespace
       @context = context
       @ejson_file = "#{template_dir}/#{EJSON_SECRETS_FILE}"
       @logger = logger
+      @prune = prune
       @kubectl = Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: false)
     end
 
@@ -31,7 +32,7 @@ module KubernetesDeploy
 
     def run
       create_secrets
-      prune_managed_secrets
+      prune_managed_secrets if @prune
     end
 
     private

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -32,7 +32,11 @@ module KubernetesDeploy
 
     def run
       create_secrets
-      prune_managed_secrets if @prune
+      if @prune
+        prune_managed_secrets
+      else
+        @logger.summary.add_action("no secrets were pruned")
+      end
     end
 
     private

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -100,7 +100,8 @@ module KubernetesDeploy
         namespace: @namespace,
         context: @context,
         template_dir: @template_dir,
-        logger: @logger
+        logger: @logger,
+        prune: prune,
       )
       if ejson.secret_changes_required?
         @logger.phase_heading("Deploying kubernetes secrets from #{EjsonSecretProvisioner::EJSON_SECRETS_FILE}")

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -668,7 +668,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert rq["spec"].present?
   end
 
-  def test_ejson_secrets_respect_no_prune_flag
+  def test_ejson_secrets_respects_no_prune_flag
     ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
     ejson_cloud.create_ejson_keys_secret
     assert_deploy_success(deploy_fixtures("ejson-cloud"))
@@ -678,6 +678,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       fixtures["secrets.ejson"]["kubernetes_secrets"].delete("unused-secret")
     end
     assert_deploy_success(result)
+
+    assert_logs_match(/no secrets were pruned/)
 
     # The removed secret was not pruned
     ejson_cloud.assert_secret_present('unused-secret', managed: true)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -679,8 +679,6 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_success(result)
 
-    assert_logs_match(/no secrets were pruned/)
-
     # The removed secret was not pruned
     ejson_cloud.assert_secret_present('unused-secret', managed: true)
     # The remaining secrets also exist

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -667,4 +667,23 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_equal "resource-quotas", rq["metadata"]["name"]
     assert rq["spec"].present?
   end
+
+  def test_ejson_secrets_respect_no_prune_flag
+    ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
+    ejson_cloud.create_ejson_keys_secret
+    assert_deploy_success(deploy_fixtures("ejson-cloud"))
+    ejson_cloud.assert_secret_present('unused-secret', managed: true)
+
+    result = deploy_fixtures("ejson-cloud", prune: false) do |fixtures|
+      fixtures["secrets.ejson"]["kubernetes_secrets"].delete("unused-secret")
+    end
+    assert_deploy_success(result)
+
+    # The removed secret was not pruned
+    ejson_cloud.assert_secret_present('unused-secret', managed: true)
+    # The remaining secrets also exist
+    ejson_cloud.assert_secret_present('monitoring-token', managed: true)
+    ejson_cloud.assert_secret_present('catphotoscom', type: 'kubernetes.io/tls', managed: true)
+    ejson_cloud.assert_secret_present('ejson-keys', managed: false)
+  end
 end


### PR DESCRIPTION
## What?
- Currently the ejson secret provisioner does not respect the no-prune flag
  - This can be a huge pain since the deploy can delete secrets from an apps namespace
- This PR adds a prune variable to the provisioner and respects the `--no-prune` flag passed to the runner

cc/ @Shopify/cloudplatform 