### PR TITLE
 Simplify Deployment and ReplicaSet timeout condition 

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -61,11 +61,7 @@ module KubernetesDeploy
     end
 
     def deploy_timed_out?
-      if @progress
-        @progress["status"] == 'False'
-      else
-        super || @latest_rs && @latest_rs.deploy_timed_out?
-      end
+      @progress ? @progress["status"] == 'False' : super
     end
 
     def exists?

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -50,10 +50,6 @@ module KubernetesDeploy
       @pods.map(&:timeout_message).compact.uniq.join("\n")
     end
 
-    def deploy_timed_out?
-      super || @pods.present? && @pods.all?(&:deploy_timed_out?)
-    end
-
     def exists?
       @found
     end


### PR DESCRIPTION
There were two extra sources of Deployment timeout with the previous conditions:
- the ReplicaSet hard timeout, which should have matched but didn't
- the Pod hard timeout, which is higher, and which it doesn't even
really make sense to fail Deployments on

This was unnecessarily complex.