### PR TITLE
Provide reason on deploy timeout

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -54,7 +54,8 @@ module KubernetesDeploy
     def timeout_message
       progress_seconds = @definition['spec']['progressDeadlineSeconds']
       if progress_seconds
-        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, reason: #{@progress['reason']} #{@latest_rs&.timeout_message}"
+        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, "\
+        " reason: #{@progress['reason']} #{@latest_rs&.timeout_message}"
       else
         @latest_rs&.timeout_message
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -54,7 +54,7 @@ module KubernetesDeploy
     def timeout_message
       progress_seconds = @definition['spec']['progressDeadlineSeconds']
       if progress_seconds
-        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, reason: #{@progress["reason"]} #{@latest_rs&.timeout_message}"
+        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, reason: #{@progress['reason']} #{@latest_rs&.timeout_message}"
       else
         @latest_rs&.timeout_message
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -54,7 +54,7 @@ module KubernetesDeploy
     def timeout_message
       progress_seconds = @definition['spec']['progressDeadlineSeconds']
       if progress_seconds
-        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds. #{@latest_rs&.timeout_message}"
+        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, reason: #{@progress["reason"]} #{@latest_rs&.timeout_message}"
       else
         @latest_rs&.timeout_message
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -55,7 +55,8 @@ module KubernetesDeploy
       progress_seconds = @definition['spec']['progressDeadlineSeconds']
       if progress_seconds
         "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, "\
-        " reason: #{@progress['reason']} #{@latest_rs&.timeout_message}"
+        " reason: #{@progress['reason']}\n"\
+        "#{@latest_rs&.timeout_message}"
       else
         @latest_rs&.timeout_message
       end


### PR DESCRIPTION
**What**
Print k8s reason for progressing status == false on deploy timeouts.

**Why**
Seeing sporadic failures in an app where deploys fail with:

```
[FATAL][2017-10-27 17:15:10 +0000]	Deployment/web: TIMED OUT (limit: 420s)
[FATAL][2017-10-27 17:15:10 +0000]	Deploy timed out due to progressDeadlineSeconds of 90 seconds. Kubernetes will continue to attempt to deploy this resource in the cluster, but at this point it is considered unlikely that it will succeed.
[FATAL][2017-10-27 17:15:10 +0000]	If you have reason to believe it will succeed, retry the deploy to continue to monitor the rollout.
```

The generic part of this error ("Kubernetes will continue...") indicates none of the pods failed Readiness Probes. The only other reason to fail would be the progress status being `false`, in which case printing the reason from k8s may help to debug.