### PR TITLE
Ejson secret base64 encoding issue

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -128,7 +128,7 @@ module KubernetesDeploy
         # Leading underscores in ejson keys are used to skip encryption of the associated value
         # To support this ejson feature, we need to exclude these leading underscores from the secret's keys
         secret_key = key.sub(/\A_/, '')
-        encoded[secret_key] = Base64.encode64(value)
+        encoded[secret_key] = Base64.strict_encode64(value)
       end
 
       secret = {

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -120,7 +120,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def dummy_secret_hash(name: SecureRandom.hex(4), data: {}, managed: true)
     encoded_data = data.each_with_object({}) do |(key, value), encoded|
-      encoded[key] = Base64.encode64(value)
+      encoded[key] = Base64.strict_encode64(value)
     end
 
     secret = {


### PR DESCRIPTION
This PR is to address issue https://github.com/Shopify/kubernetes-deploy/issues/192 .

As Kubernetes >= 1.8 requires the yaml to no longer have a `\n` in it, we'll need to utilize Ruby's `Base64.strict_encode64()` to encode with no new lines. @KnVerey 

```
# irb
:007 > str = "aooajsdjadad"
 => "aooajsdjadad"
 :008 > Base64.encode64(str)
 => "YW9vYWpzZGphZGFk\n"
 :009 > Base64.strict_encode64(str)
 => "YW9vYWpzZGphZGFk"
```

Docs: http://ruby-doc.org/stdlib-2.4.2/libdoc/base64/rdoc/Base64.html#method-i-strict_encode64