### PR TITLE
Avoid creating base64 encodings with embedded newlines

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -128,7 +128,7 @@ module KubernetesDeploy
         # Leading underscores in ejson keys are used to skip encryption of the associated value
         # To support this ejson feature, we need to exclude these leading underscores from the secret's keys
         secret_key = key.sub(/\A_/, '')
-        encoded[secret_key] = Base64.encode64(value)
+        encoded[secret_key] = Base64.strict_encode64(value)
       end
 
       secret = {

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -120,7 +120,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def dummy_secret_hash(name: SecureRandom.hex(4), data: {}, managed: true)
     encoded_data = data.each_with_object({}) do |(key, value), encoded|
-      encoded[key] = Base64.encode64(value)
+      encoded[key] = Base64.strict_encode64(value)
     end
 
     secret = {


### PR DESCRIPTION
Ruby's Base64.encode method adds newlines to the encoded string after
every 60 characters and also adds one at the end. Kubernetes documentation
clearly states that base64 encoded secrets must not contain newlines (see 
https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually).
Also, Kubernetes 1.8 will now reject creating any secrets with embedded
newline characters.

The problem is solved by using Base64.strict_encode64, which does not embed
newline characters in the encoded string.