### PR TITLE
Fix test failures for various combinations of kubectl and Kubernetes versions

### DIFF
--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -36,10 +36,8 @@ module KubernetesDeploy
       @version_info ||=
         begin
           response, _, status = run("version", "--output=yaml", use_namespace: false, log_failure: true)
-          raise "Could not retrieve kubectl client info" unless status.success?
+          raise KubectlError, "Could not retrieve kubectl version info" unless status.success?
           YAML.load(response)
-        rescue => e
-          raise "Could not load kubectl client info: #{e}"
         end
     end
 

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -44,11 +44,11 @@ module KubernetesDeploy
     end
 
     def client_version
-      version_info["clientVersion"]["gitVersion"]
+      Gem::Version.new(version_info["clientVersion"]["gitVersion"].sub(/^v/, ''))
     end
 
     def server_version
-      version_info["serverVersion"]["gitVersion"]
+      Gem::Version.new(version_info["serverVersion"]["gitVersion"].sub(/^v/, ''))
     end
 
   end

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -35,18 +35,31 @@ module KubernetesDeploy
     def version_info
       @version_info ||=
         begin
-          response, _, status = run("version", "--output=yaml", use_namespace: false, log_failure: true)
+          response, _, status = run("version", use_namespace: false, log_failure: true)
           raise KubectlError, "Could not retrieve kubectl version info" unless status.success?
-          YAML.load(response)
+          extract_version_info_from_kubectl_response(response)
         end
     end
 
     def client_version
-      Gem::Version.new(version_info["clientVersion"]["gitVersion"].sub(/^v/, ''))
+      version_info[:client]
     end
 
     def server_version
-      Gem::Version.new(version_info["serverVersion"]["gitVersion"].sub(/^v/, ''))
+      version_info[:server]
+    end
+
+    private
+
+    def extract_version_info_from_kubectl_response(response)
+      info = {}
+      response.each_line do |l|
+        match = l.match(/^(?<kind>Client|Server).* GitVersion:"v(?<version>[0-9\.]+)"/)
+        if match
+          info[match[:kind].downcase.to_sym] = Gem::Version.new(match[:version])
+        end
+      end
+      info
     end
   end
 end

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -48,6 +48,5 @@ module KubernetesDeploy
     def server_version
       Gem::Version.new(version_info["serverVersion"]["gitVersion"].sub(/^v/, ''))
     end
-
   end
 end

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -31,5 +31,25 @@ module KubernetesDeploy
       end
       [out.chomp, err.chomp, st]
     end
+
+    def version_info
+      @version_info ||=
+        begin
+          response, _, status = run("version", "--output=yaml", use_namespace: false, log_failure: true)
+          raise "Could not retrieve kubectl client info" unless status.success?
+          YAML.load(response)
+        rescue => e
+          raise "Could not load kubectl client info: #{e}"
+        end
+    end
+
+    def client_version
+      version_info["clientVersion"]["gitVersion"]
+    end
+
+    def server_version
+      version_info["serverVersion"]["gitVersion"]
+    end
+
   end
 end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -411,7 +411,10 @@ module KubernetesDeploy
     def confirm_cluster_reachable
       success = false
       with_retries(2) do
-        success = kubectl.version_info rescue false
+        begin
+          success = kubectl.version_info
+        rescue KubectlError
+        end
       end
       raise FatalDeploymentError, "Failed to reach server for #{@context}" unless success
     end

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -414,6 +414,7 @@ module KubernetesDeploy
         begin
           success = kubectl.version_info
         rescue KubectlError
+          success = false
         end
       end
       raise FatalDeploymentError, "Failed to reach server for #{@context}" unless success

--- a/lib/kubernetes-deploy/runner.rb
+++ b/lib/kubernetes-deploy/runner.rb
@@ -410,23 +410,10 @@ module KubernetesDeploy
 
     def confirm_cluster_reachable
       success = false
-      response = nil
       with_retries(2) do
-        response, _, st = kubectl.run("version", "--output=yaml", use_namespace: false, log_failure: true)
-        success = st.success?
+        success = kubectl.version_info rescue false
       end
-
       raise FatalDeploymentError, "Failed to reach server for #{@context}" unless success
-
-      begin
-        @kubectl_version_info = YAML.load(response)
-      rescue => e
-        raise FatalDeploymentError, "Could not load kubectl client info: #{e}"
-      end
-    end
-
-    def kubectl_version_info
-      @kubectl_version_info ||= confirm_cluster_reachable
     end
 
     def confirm_namespace_exists

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -161,7 +161,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
         "> Error from kubectl:",
-        "error validating data: ValidationError(ConfigMap.metadata): unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+        "error validating data: ValidationError(ConfigMap.metadata): \
+unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
         "> Rendered template content:",
         "      myKey: uhOh"
       ], in_order: true)
@@ -203,7 +204,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
         "> Error from kubectl:",
-        "error validating data: ValidationError(ConfigMap.metadata.labels.name): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
+        "error validating data: ValidationError(ConfigMap.metadata.labels.name): \
+invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
         "> Rendered template content:",
         "          not_a_name:",
       ], in_order: true)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -147,7 +147,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_failure(result)
 
-    if KUBE_CLIENT_VERSION < "v1.8.0"
+    if KUBE_CLIENT_VERSION < Gem::Version.new("1.8.0")
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
@@ -188,7 +188,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       }
     end
     assert_deploy_failure(result)
-    if KUBE_CLIENT_VERSION < "v1.8.0"
+    if KUBE_CLIENT_VERSION < Gem::Version.new("1.8.0")
       assert_logs_match_all([
         "Command failed: apply -f",
         "WARNING: Any resources not mentioned in the error below were likely created/updated.",
@@ -265,7 +265,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.refute_web_resources_exist
   end
 
-  if KUBE_SERVER_VERSION < "v1.8.0"
+  if KUBE_SERVER_VERSION < Gem::Version.new("1.8.0")
     # behavior in 1.8 has changed: kubernetes now times out instead of failing quickly
     def test_deployment_container_mounting_secret_that_does_not_exist_as_env_var_fails_quickly
       result = deploy_fixtures("ejson-cloud", subset: ["web.yaml"]) do |fixtures| # exclude secret ejson

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -147,14 +147,25 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_failure(result)
 
-    assert_logs_match_all([
-      "Template validation failed",
-      /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
-      "> Error from kubectl:",
-      "error validating data: found invalid field myKey for v1.ObjectMeta",
-      "> Rendered template content:",
-      "      myKey: uhOh"
-    ], in_order: true)
+    if KUBE_CLIENT_VERSION < "v1.8.0"
+      assert_logs_match_all([
+        "Template validation failed",
+        /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
+        "> Error from kubectl:",
+        "error validating data: found invalid field myKey for v1.ObjectMeta",
+        "> Rendered template content:",
+        "      myKey: uhOh"
+      ], in_order: true)
+    else
+      assert_logs_match_all([
+        "Template validation failed",
+        /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
+        "> Error from kubectl:",
+        "error validating data: ValidationError(ConfigMap.metadata): unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+        "> Rendered template content:",
+        "      myKey: uhOh"
+      ], in_order: true)
+    end
   end
 
   def test_dynamic_erb_collection_works
@@ -177,15 +188,26 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       }
     end
     assert_deploy_failure(result)
-    assert_logs_match_all([
-      "Command failed: apply -f",
-      "WARNING: Any resources not mentioned in the error below were likely created/updated.",
-      /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
-      "> Error from kubectl:",
-      "    Error from server (BadRequest): error when creating",
-      "> Rendered template content:",
-      "          not_a_name:",
-    ], in_order: true)
+    if KUBE_CLIENT_VERSION < "v1.8.0"
+      assert_logs_match_all([
+        "Command failed: apply -f",
+        "WARNING: Any resources not mentioned in the error below were likely created/updated.",
+        /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
+        "> Error from kubectl:",
+        "    Error from server (BadRequest): error when creating",
+        "> Rendered template content:",
+        "          not_a_name:",
+      ], in_order: true)
+    else
+      assert_logs_match_all([
+        "Template validation failed",
+        /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
+        "> Error from kubectl:",
+        "error validating data: ValidationError(ConfigMap.metadata.labels.name): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
+        "> Rendered template content:",
+        "          not_a_name:",
+      ], in_order: true)
+    end
   end
 
   def test_multiple_invalid_k8s_specs_fails_on_apply_and_prints_template
@@ -243,25 +265,28 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.refute_web_resources_exist
   end
 
-  def test_deployment_container_mounting_secret_that_does_not_exist_as_env_var_fails_quickly
-    result = deploy_fixtures("ejson-cloud", subset: ["web.yaml"]) do |fixtures| # exclude secret ejson
-      # Remove the volumes. Right now Kubernetes does not expose a useful status when mounting fails. :(
-      deploy = fixtures["web.yaml"]["Deployment"].first
-      deploy["spec"]["replicas"] = 3
-      pod_spec = deploy["spec"]["template"]["spec"]
-      pod_spec["volumes"] = []
-      pod_spec["containers"].first["volumeMounts"] = []
+  if KUBE_SERVER_VERSION < "v1.8.0"
+    # behavior in 1.8 has changed: kubernetes now times out instead of failing quickly
+    def test_deployment_container_mounting_secret_that_does_not_exist_as_env_var_fails_quickly
+      result = deploy_fixtures("ejson-cloud", subset: ["web.yaml"]) do |fixtures| # exclude secret ejson
+        # Remove the volumes. Right now Kubernetes does not expose a useful status when mounting fails. :(
+        deploy = fixtures["web.yaml"]["Deployment"].first
+        deploy["spec"]["replicas"] = 3
+        pod_spec = deploy["spec"]["template"]["spec"]
+        pod_spec["volumes"] = []
+        pod_spec["containers"].first["volumeMounts"] = []
+      end
+      assert_deploy_failure(result)
+
+      assert_logs_match_all([
+        "Deployment/web: FAILED",
+        "The following containers are in a state that is unlikely to be recoverable:",
+        "app: Failed to generate container configuration: secrets \"monitoring-token\" not found",
+        "Final status: 3 replicas, 3 updatedReplicas, 3 unavailableReplicas"
+      ], in_order: true)
+
+      assert_logs_match("The following containers are in a state that is unlikely to be recoverable", 1) # no duplicates
     end
-    assert_deploy_failure(result)
-
-    assert_logs_match_all([
-      "Deployment/web: FAILED",
-      "The following containers are in a state that is unlikely to be recoverable:",
-      "app: Failed to generate container configuration: secrets \"monitoring-token\" not found",
-      "Final status: 3 replicas, 3 updatedReplicas, 3 unavailableReplicas"
-    ], in_order: true)
-
-    assert_logs_match("The following containers are in a state that is unlikely to be recoverable", 1) # no duplicates
   end
 
   def test_bad_container_image_on_deployment_pod_fails_quickly

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -15,7 +15,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       "Configured to restart deployments by name: web",
       "Triggered `web` restart",
       "Waiting for rollout",
-      %r{Successfully restarted in \d\.\ds: Deployment/web},
+      %r{Successfully restarted in \d+\.\d+s: Deployment/web},
       "Result: SUCCESS",
       "Successfully restarted 1 resource",
       %r{Deployment/web.*1 availableReplica}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -180,6 +180,13 @@ module KubernetesDeploy
       TestProvisioner.delete_namespace(@namespace)
       WebMock.disable_net_connect!
     end
+
+    logger = KubernetesDeploy::FormattedLogger.build("default", MINIKUBE_CONTEXT, $stderr)
+    kubectl = KubernetesDeploy::Kubectl.new(namespace: "default", context: MINIKUBE_CONTEXT, logger: logger,
+                                            log_failure_by_default: true, default_timeout: '5s')
+
+    KUBE_CLIENT_VERSION = kubectl.client_version
+    KUBE_SERVER_VERSION = kubectl.server_version
   end
 
   module TestProvisioner


### PR DESCRIPTION
This patch fixes two different problems:

1. Kubernetes 1.8 has changed the behavior when secrets cannot be found.
   Instead of aborting a deployment quickly, Kubernetes retries quite a
   few times before it gives up. Removed the test case which checks for
   a quick exit.

2. kubectl 1.8 produces slighty different log output for some of the test
   cases. Made the matches version dependent. Another option would be to
   only check the parts which are identical in both versions.