### PR TITLE
Update CI Setup for k8s 1.7.x, 1.8.x

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,0 +1,24 @@
+  - name: 'Run Test Suite (:kubernetes: 1.9-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-v1.9-latest
+    env:
+      LOGGING_LEVEL: 4
+  - name: 'Run Test Suite (:kubernetes: 1.8-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-v1.8-latest
+    env:
+      LOGGING_LEVEL: 4
+  - name: 'Run Test Suite (:kubernetes: 1.7-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-v1.7-latest
+    env:
+      LOGGING_LEVEL: 4
+  - name: 'Run Test Suite (:kubernetes: 1.6.4)'
+    command: bin/ci
+    agents:
+      queue: minikube-v1.6.4
+    env:
+      LOGGING_LEVEL: 4

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,18 @@
-  - name: 'Run Test Suite (:kubernetes: 1.7.5)'
+  - name: 'Run Test Suite (:kubernetes: 1.8-latest)'
     command: bin/ci
     agents:
-      queue: pipa-production-minikube-v1.7.5
+      queue: minikube-v1.8-latest
+    env:
+      LOGGING_LEVEL: 4
+  - name: 'Run Test Suite (:kubernetes: 1.7-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-v1.7-latest
+    env:
+      LOGGING_LEVEL: 4
   - name: 'Run Test Suite (:kubernetes: 1.6.4)'
     command: bin/ci
     agents:
-      queue: pipa-production-minikube-v1.6.4
+      queue: minikube-v1.6.4
+    env:
+      LOGGING_LEVEL: 4

--- a/bin/ci
+++ b/bin/ci
@@ -6,11 +6,11 @@ if [[ -n "${DEBUG:+set}" ]]; then
 fi
 
 docker run --rm \
-	--net=host \
-	-v "$HOME/.kube":/"$HOME/.kube" \
-    -v "$HOME/.minikube":/"$HOME/.minikube" \
+    --net=host \
+    -v "$HOME/.kube":"/root/.kube" \
+    -v "$HOME/.minikube":"$HOME/.minikube" \
     -v "$PWD":/usr/src/app \
-    -v "/usr/bin/minikube/kubectl":"/usr/bin/kubectl" \
+    -v "/usr/bin/kubectl":"/usr/bin/kubectl" \
     -e CI=1 \
     -e CODECOV_TOKEN=$CODECOV_TOKEN \
     -e COVERAGE=1 \


### PR DESCRIPTION
Run CI on:
- k8s 1.6.4 (this is the latest version supported by this CI setup)
- k8s 1.7.x latest
- k8s 1.8.x latest
- k8s 1.9.x latest (nightly builds only)

Latest includes beta/alpha releases.

Requires https://github.com/Shopify/kubernetes-deploy/pull/198 for passing 1.8.x+ builds.