### PR TITLE
Specify minimum rest-client version

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "kubeclient", "~> 2.4"
+  spec.add_dependency "rest-client", ">= 1.7" # Minimum required by kubeclient. Remove when kubeclient releases v3.0.
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"


### PR DESCRIPTION
Closes https://github.com/Shopify/kubernetes-deploy/issues/157

Kubeclient did bump the dependency themselves but they have no specific plans to release a version that includes the fix: https://github.com/abonas/kubeclient/issues/264#issuecomment-340734890