### PR TITLE
Fix external contrib CI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ If you push your commit and the tag separately, Shipit usually fails with `You n
 
 ## CI (External contributors)
 
-Please make sure you run the tests locally before submitting your PR (see [Running the test suite locally](#running-the-test-suite-locally)). After reviewing your PR, a Shopify employee will trigger CI for you from the [Buildkite UI](https://buildkite.com/shopify/kubernetes-deploy-gem).
+Please make sure you run the tests locally before submitting your PR (see [Running the test suite locally](#running-the-test-suite-locally)). After reviewing your PR, a Shopify employee will trigger CI for you.
 
 #### Employees: Triggering CI for a contributed PR
 
-Use branch `external_contrib_ci` and the specific sha of the commit you want to build. Add `BUILDKITE_REFSPEC="refs/pull/${PR_NUM}/head"` in the Environment Variables section.
+Go to the [kubernetes-deploy-gem pipeline](https://buildkite.com/shopify/kubernetes-deploy-gem) and click "New Build". Use branch `external_contrib_ci` and the specific sha of the commit you want to build. Add `BUILDKITE_REFSPEC="refs/pull/${PR_NUM}/head"` in the Environment Variables section.
 
 <img width="350" alt="build external contrib PR" src="https://screenshot.click/2017-11-07--163728_7ovek-wrpwq.png">
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ Please make sure you run the tests locally before submitting your PR (see [Runni
 
 #### Employees: Triggering CI for a contributed PR
 
-Use branch `master` and add `BUILDKITE_REFSPEC="refs/pull/${PR_NUM}/head"` and `BUILDKITE_COMMIT=${SHA}` in the Environment Variables section.
+Use branch `external_contrib_ci` and the specific sha of the commit you want to build. Add `BUILDKITE_REFSPEC="refs/pull/${PR_NUM}/head"` in the Environment Variables section.
 
-<img width="350" alt="build external contrib PR" src="https://screenshot.click/2017-10-31--162431_2y8rn-0axc4.png">
+<img width="350" alt="build external contrib PR" src="https://screenshot.click/2017-11-07--163728_7ovek-wrpwq.png">
 
 # Contributing
 


### PR DESCRIPTION
@stefanmb I just had to use the external contrib CI instructions I merged the other day, and they didn't work... the BUILDKITE_COMMIT var was being overridden by the master sha, so it built the wrong thing. As long as the referenced branch exists, putting the sha in the main "Commit" field seems to work fine. Another issue I noticed is that if we use `master`, then the build affects the repo's status badge. I made a new protected branch called external_contrib_ci for this purpose. Example build that clearly shows (because of the failure) that it has built the right thing: https://buildkite.com/shopify/kubernetes-deploy-gem/builds/219#565ffa03-6aa3-4375-bb26-1ae61384063f