### PR TITLE
version_info support for GKE versions

### DIFF
--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -54,7 +54,7 @@ module KubernetesDeploy
     def extract_version_info_from_kubectl_response(response)
       info = {}
       response.each_line do |l|
-        match = l.match(/^(?<kind>Client|Server).* GitVersion:"v(?<version>[0-9\.]+)"/)
+        match = l.match(/^(?<kind>Client|Server).* GitVersion:"v(?<version>\d+\.\d+\.\d+)/)
         if match
           info[match[:kind].downcase.to_sym] = Gem::Version.new(match[:version])
         end


### PR DESCRIPTION
On GKE, you can have intermediate versions in the format `v1.7.6-gke.1`. This changes the regex used by `version_info` to support that and adds unit tests.

@Shopify/cloudplatform 