### PR TITLE
Fix crashes with Service of type ExternalName

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -48,7 +48,12 @@ module KubernetesDeploy
     end
 
     def requires_endpoints?
-      return false if external_name_svc? || @related_deployment_replicas.blank?
+      # Service of type External don't have endpoints
+      return false if external_name_svc?
+
+      # problem counting replicas - by default, assume endpoints are required
+      return true if @related_deployment_replicas.blank?
+
       @related_deployment_replicas > 0
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -18,7 +18,7 @@ module KubernetesDeploy
       elsif selects_some_pods?
         "Selects at least 1 pod"
       else
-        "Unknown"
+        "Selects 0 pods"
       end
     end
 
@@ -48,7 +48,7 @@ module KubernetesDeploy
     end
 
     def requires_endpoints?
-      # Service of type External don't have endpoints
+      # service of type External don't have endpoints
       return false if external_name_svc?
 
       # problem counting replicas - by default, assume endpoints are required

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -11,16 +11,19 @@ module KubernetesDeploy
     end
 
     def status
-      if @num_pods_selected.blank?
+      if !requires_endpoints?
+        "Doesn't require any endpoint"
+      elsif @num_pods_selected.blank?
         "Failed to count related pods"
       elsif selects_some_pods?
         "Selects at least 1 pod"
       else
-        "Selects 0 pods"
+        "Unknown"
       end
     end
 
     def deploy_succeeded?
+      return exists? unless requires_endpoints?
       # We can't use endpoints if we want the service to be able to fail fast when the pods are down
       exposes_zero_replica_deployment? || selects_some_pods?
     end
@@ -44,28 +47,39 @@ module KubernetesDeploy
       @related_deployment_replicas == 0
     end
 
+    def requires_endpoints?
+      return false if external_name_svc? || @related_deployment_replicas.blank?
+      @related_deployment_replicas > 0
+    end
+
     def selects_some_pods?
       return false unless @num_pods_selected
       @num_pods_selected > 0
     end
 
     def selector
-      @selector ||= @definition["spec"]["selector"].map { |k, v| "#{k}=#{v}" }.join(",")
+      @selector ||= @definition["spec"].fetch("selector", []).map { |k, v| "#{k}=#{v}" }.join(",")
     end
 
     def fetch_related_pod_count
+      return 0 unless selector.present?
       raw_json, _err, st = kubectl.run("get", "pods", "--selector=#{selector}", "--output=json")
       return unless st.success?
       JSON.parse(raw_json)["items"].length
     end
 
     def fetch_related_replica_count
+      return 0 unless selector.present?
       raw_json, _err, st = kubectl.run("get", "deployments", "--selector=#{selector}", "--output=json")
       return unless st.success?
 
       deployments = JSON.parse(raw_json)["items"]
       return unless deployments.length == 1
       deployments.first["spec"]["replicas"].to_i
+    end
+
+    def external_name_svc?
+      @definition["spec"]["type"] == "ExternalName"
     end
   end
 end

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -12,6 +12,17 @@ spec:
   selector:
     name: redis
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-external
+  labels:
+    name: redis-external
+    app: hello-cloud
+spec:
+  externalName: external-redis.shopify
+  type: ExternalName
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -23,6 +23,28 @@ spec:
   externalName: external-redis.shopify
   type: ExternalName
 ---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: redis-endpoints
+subsets:
+  - addresses:
+      - ip: 10.1.1.1
+      - ip: 10.1.1.2
+    ports:
+      - name: redis
+        port: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-endpoints
+spec:
+  clusterIP: None
+  ports:
+    - name: redis
+      port: 6379
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -11,7 +11,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Deploying ConfigMap/hello-cloud-configmap-data (timeout: 30s)",
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 14 resources"
+      "Successfully deployed 15 resources"
     ], in_order: true)
 
     assert_logs_match_all([
@@ -59,7 +59,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       'daemonset "ds-app"',
       'statefulset "stateful-busybox"'
     ] # not necessarily listed in this order
-    expected_msgs = [/Pruned 7 resources and successfully deployed 3 resources/]
+    expected_msgs = [/Pruned 7 resources and successfully deployed 4 resources/]
     expected_pruned.map do |resource|
       expected_msgs << /The following resources were pruned:.*#{resource}/
     end
@@ -627,7 +627,7 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
     assert_equal 0, pods.length, "Pods were running from zero-replica deployment"
 
     assert_logs_match_all([
-      %r{Service/web\s+Selects 0 pods},
+      %r{Service/web\s+Doesn't require any endpoint},
       %r{Deployment/web\s+0 replicas}
     ])
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -19,7 +19,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
       %r{Service/web\s+Selects at least 1 pod},
       %r{DaemonSet/ds-app\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady},
-      %r{StatefulSet/stateful-busybox}
+      %r{StatefulSet/stateful-busybox},
+      %r{Service/redis-external\s+Doesn't require any endpoint}
     ])
 
     # Verify that success section isn't duplicated for predeployed resources

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -11,7 +11,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Deploying ConfigMap/hello-cloud-configmap-data (timeout: 30s)",
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 15 resources"
+      "Successfully deployed 17 resources"
     ], in_order: true)
 
     assert_logs_match_all([
@@ -60,7 +60,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       'daemonset "ds-app"',
       'statefulset "stateful-busybox"'
     ] # not necessarily listed in this order
-    expected_msgs = [/Pruned 7 resources and successfully deployed 4 resources/]
+    expected_msgs = [/Pruned 7 resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|
       expected_msgs << /The following resources were pruned:.*#{resource}/
     end


### PR DESCRIPTION
`Service` of type `ClusterIP` have a `selector` field but those of type `ExternalName` don't.
Trying to deploy such s service with `kubernetes-deploy` leads to a crash:

```
[FATAL][2017-11-24 16:53:19 +0100]	No actions taken
.../lib/kubernetes-deploy/kubernetes_resource/service.rb:62:in `selector': undefined method `map' for nil:NilClass (NoMethodError)
	from .../lib/kubernetes-deploy/kubernetes_resource/service.rb:72:in `fetch_related_replica_count'
	from .../lib/kubernetes-deploy/kubernetes_resource/service.rb:15:in `sync'
	from .../lib/kubernetes-deploy/concurrency.rb:13:in `each'
```

This PR modifies the behavior of the `kubernetes-deploy` service resources to succeed automatically by not searching to look at inexistent corresponding pods.
