### PR TITLE
Fix insta-timeout bug

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -22,7 +22,7 @@ ARGV.options do |opts|
   end
 
   opts.on("--skip-wait", "Skip verification of non-priority-resource success (not recommended)") { skip_wait = true }
-  prot_ns = KubernetesDeploy::Runner::PROTECTED_NAMESPACES.join(', ')
+  prot_ns = KubernetesDeploy::DeployTask::PROTECTED_NAMESPACES.join(', ')
   opts.on("--allow-protected-ns", "Enable deploys to #{prot_ns}; requires --no-prune") { allow_protected_ns = true }
   opts.on("--no-prune", "Disable deletion of resources that do not appear in the template dir") { prune = false }
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
@@ -58,7 +58,7 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context, verbose_prefix: verbose_log_prefix)
 
-runner = KubernetesDeploy::Runner.new(
+runner = KubernetesDeploy::DeployTask.new(
   namespace: namespace,
   context: context,
   current_sha: revision,

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -13,7 +13,7 @@ require 'colorized_string'
 require 'kubernetes-deploy/version'
 require 'kubernetes-deploy/errors'
 require 'kubernetes-deploy/formatted_logger'
-require 'kubernetes-deploy/runner'
+require 'kubernetes-deploy/deploy_task'
 require 'kubernetes-deploy/statsd'
 require 'kubernetes-deploy/concurrency'
 

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
 require 'active_support/core_ext/object/blank'

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -37,7 +37,7 @@ require 'kubernetes-deploy/kubeclient_builder'
 require 'kubernetes-deploy/ejson_secret_provisioner'
 
 module KubernetesDeploy
-  class Runner
+  class DeployTask
     include KubeclientBuilder
 
     PREDEPLOY_SEQUENCE = %w(

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -326,14 +326,14 @@ module KubernetesDeploy
         @logger.info("Deploying resources:")
       else
         resource = resources.first
-        @logger.info("Deploying #{resource.id} (timeout: #{resource.timeout}s)")
+        @logger.info("Deploying #{resource.id} (#{resource.pretty_timeout_type})")
       end
 
       # Apply can be done in one large batch, the rest have to be done individually
       applyables, individuals = resources.partition { |r| r.deploy_method == :apply }
 
       individuals.each do |r|
-        @logger.info("- #{r.id} (timeout: #{r.timeout}s)") if resources.length > 1
+        @logger.info("- #{r.id} (#{r.pretty_timeout_type})") if resources.length > 1
         r.deploy_started_at = Time.now.utc
         case r.deploy_method
         when :replace
@@ -369,7 +369,7 @@ module KubernetesDeploy
 
       command = ["apply"]
       resources.each do |r|
-        @logger.info("- #{r.id} (timeout: #{r.timeout}s)") if resources.length > 1
+        @logger.info("- #{r.id} (#{r.pretty_timeout_type})") if resources.length > 1
         command.push("-f", r.file_path)
         r.deploy_started_at = Time.now.utc
       end

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -334,7 +334,7 @@ module KubernetesDeploy
 
       individuals.each do |r|
         @logger.info("- #{r.id} (timeout: #{r.timeout}s)") if resources.length > 1
-        r.deploy_started = Time.now.utc
+        r.deploy_started_at = Time.now.utc
         case r.deploy_method
         when :replace
           _, _, replace_st = kubectl.run("replace", "-f", r.file_path, log_failure: false)
@@ -371,7 +371,7 @@ module KubernetesDeploy
       resources.each do |r|
         @logger.info("- #{r.id} (timeout: #{r.timeout}s)") if resources.length > 1
         command.push("-f", r.file_path)
-        r.deploy_started = Time.now.utc
+        r.deploy_started_at = Time.now.utc
       end
 
       if prune

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -23,7 +23,13 @@ module KubernetesDeploy
       @ejson_file = "#{template_dir}/#{EJSON_SECRETS_FILE}"
       @logger = logger
       @prune = prune
-      @kubectl = Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: false)
+      @kubectl = Kubectl.new(
+        namespace: @namespace,
+        context: @context,
+        logger: @logger,
+        log_failure_by_default: false,
+        output_is_sensitive: true # output may contain ejson secrets
+      )
     end
 
     def secret_changes_required?

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -6,7 +6,7 @@ require 'kubernetes-deploy/kubectl'
 
 module KubernetesDeploy
   class KubernetesResource
-    attr_reader :name, :namespace, :file, :context, :validation_error_msg
+    attr_reader :name, :namespace, :context, :validation_error_msg
     attr_writer :type, :deploy_started_at
 
     TIMEOUT = 5.minutes

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -42,6 +42,10 @@ module KubernetesDeploy
       self.class.timeout
     end
 
+    def pretty_timeout_type
+      "timeout: #{timeout}s"
+    end
+
     def initialize(namespace:, context:, definition:, logger:)
       # subclasses must also set these if they define their own initializer
       @name = definition.dig("metadata", "name")
@@ -126,7 +130,7 @@ module KubernetesDeploy
         helpful_info << ColorizedString.new("#{id}: FAILED").red
         helpful_info << failure_message if failure_message.present?
       elsif deploy_timed_out?
-        helpful_info << ColorizedString.new("#{id}: TIMED OUT").yellow + " (limit: #{timeout}s)"
+        helpful_info << ColorizedString.new("#{id}: TIMED OUT (#{pretty_timeout_type})").yellow
         helpful_info << timeout_message if timeout_message.present?
       else
         # Arriving in debug_message when we neither failed nor timed out is very unexpected. Dump all available info.

--- a/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
@@ -7,7 +7,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      return false unless @deploy_started
+      return false unless deploy_started?
 
       unless @success_assumption_warning_shown
         @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -11,15 +11,21 @@ module KubernetesDeploy
         deployment_data = JSON.parse(raw_json)
         @desired_replicas = deployment_data["spec"]["replicas"].to_i
         @latest_rs = find_latest_rs(deployment_data)
+
         @rollout_data = { "replicas" => 0 }.merge(deployment_data["status"]
           .slice("replicas", "updatedReplicas", "availableReplicas", "unavailableReplicas"))
         @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
+
         conditions = deployment_data.fetch("status", {}).fetch("conditions", [])
-        @progress = conditions.find { |condition| condition['type'] == 'Progressing' }
+        @progress_condition = conditions.find { |condition| condition['type'] == 'Progressing' }
+        @progress_deadline = deployment_data['spec']['progressDeadlineSeconds']
       else # reset
         @latest_rs = nil
         @rollout_data = { "replicas" => 0 }
         @status = nil
+        @progress_condition = nil
+        @progress_deadline = @definition['spec']['progressDeadlineSeconds']
+        @desired_replicas = -1
       end
     end
 
@@ -35,7 +41,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      return false unless @latest_rs
+      return false unless @latest_rs.present?
 
       @latest_rs.deploy_succeeded? &&
       @latest_rs.desired_replicas == @desired_replicas && # latest RS fully scaled up
@@ -48,22 +54,27 @@ module KubernetesDeploy
     end
 
     def failure_message
-      @latest_rs&.failure_message
+      return unless @latest_rs.present?
+      "Latest ReplicaSet: #{@latest_rs.name}\n\n#{@latest_rs.failure_message}"
     end
 
     def timeout_message
-      progress_seconds = @definition['spec']['progressDeadlineSeconds']
-      if progress_seconds
-        "Deploy timed out due to progressDeadlineSeconds of #{progress_seconds} seconds, "\
-        " reason: #{@progress['reason']}\n"\
-        "#{@latest_rs&.timeout_message}"
+      reason_msg = if @progress_condition.present?
+        "Timeout reason: #{@progress_condition['reason']}"
       else
-        @latest_rs&.timeout_message
+        "Timeout reason: hard deadline for #{type}"
       end
+      return reason_msg unless @latest_rs.present?
+      "#{reason_msg}\nLatest ReplicaSet: #{@latest_rs.name}\n\n#{@latest_rs.timeout_message}"
+    end
+
+    def pretty_timeout_type
+      @progress_deadline.present? ? "progress deadline: #{@progress_deadline}s" : super
     end
 
     def deploy_timed_out?
-      @progress ? @progress["status"] == 'False' : super
+      # Do not use the hard timeout if progress deadline is set
+      @progress_condition.present? ? deploy_failing_to_progress? : super
     end
 
     def exists?
@@ -71,6 +82,21 @@ module KubernetesDeploy
     end
 
     private
+
+    def deploy_failing_to_progress?
+      return false unless @progress_condition.present?
+
+      if kubectl.server_version < Gem::Version.new("1.7.7")
+        # Deployments were being updated prematurely with incorrect progress information
+        # https://github.com/kubernetes/kubernetes/issues/49637
+        return false unless Time.now.utc - @deploy_started_at >= @progress_deadline.to_i
+      else
+        return false unless deploy_started?
+      end
+
+      @progress_condition["status"] == 'False' &&
+      Time.parse(@progress_condition["lastUpdateTime"]).to_i >= (@deploy_started_at - 5.seconds).to_i
+    end
 
     def find_latest_rs(deployment_data)
       label_string = deployment_data["spec"]["selector"]["matchLabels"].map { |k, v| "#{k}=#{v}" }.join(",")

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -44,7 +44,7 @@ module KubernetesDeploy
     end
 
     def deploy_failed?
-      @latest_rs && @latest_rs.deploy_failed?
+      @latest_rs&.deploy_failed?
     end
 
     def failure_message

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -92,7 +92,7 @@ module KubernetesDeploy
         definition: latest_rs_data,
         logger: @logger,
         parent: "#{@name.capitalize} deployment",
-        deploy_started: @deploy_started
+        deploy_started_at: @deploy_started_at
       )
       rs.sync(latest_rs_data)
       rs

--- a/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
@@ -7,7 +7,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      return false unless @deploy_started
+      return false unless deploy_started?
 
       unless @success_assumption_warning_shown
         @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -3,6 +3,8 @@ module KubernetesDeploy
   class Pod < KubernetesResource
     TIMEOUT = 10.minutes
 
+    FAILED_PHASE_NAME = "Failed"
+
     def initialize(namespace:, context:, definition:, logger:, parent: nil, deploy_started_at: nil)
       @parent = parent
       @deploy_started_at = deploy_started_at
@@ -46,8 +48,7 @@ module KubernetesDeploy
     end
 
     def deploy_failed?
-      return true if @phase == "Failed"
-      @containers.any?(&:doomed?)
+      failure_message.present?
     end
 
     def exists?
@@ -62,19 +63,23 @@ module KubernetesDeploy
     end
 
     def failure_message
-      doomed_containers = @containers.select(&:doomed?)
-      return unless doomed_containers.present?
-      container_messages = doomed_containers.map do |c|
-        red_name = ColorizedString.new(c.name).red
-        "> #{red_name}: #{c.doom_reason}"
+      if @phase == FAILED_PHASE_NAME
+        phase_problem = "Pod status: #{@status}. "
       end
 
-      intro = if unmanaged?
-        "The following containers encountered errors:"
-      else
-        "The following containers are in a state that is unlikely to be recoverable:"
+      doomed_containers = @containers.select(&:doomed?)
+      if doomed_containers.present?
+        container_problems = if unmanaged?
+          "The following containers encountered errors:\n"
+        else
+          "The following containers are in a state that is unlikely to be recoverable:\n"
+        end
+        doomed_containers.each do |c|
+          red_name = ColorizedString.new(c.name).red
+          container_problems += "> #{red_name}: #{c.doom_reason}\n"
+        end
       end
-      intro + "\n" + container_messages.join("\n") + "\n"
+      "#{phase_problem}#{container_problems}"
     end
 
     # Returns a hash in the following format:

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -79,7 +79,7 @@ module KubernetesDeploy
           container_problems += "> #{red_name}: #{c.doom_reason}\n"
         end
       end
-      "#{phase_problem}#{container_problems}"
+      "#{phase_problem}#{container_problems}".presence
     end
 
     # Returns a hash in the following format:

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -2,12 +2,10 @@
 module KubernetesDeploy
   class PodSetBase < KubernetesResource
     def failure_message
-      "Pods in #{name} #{self.class.name.demodulize} are failing. " +
       pods.map(&:failure_message).compact.uniq.join("\n")
     end
 
     def timeout_message
-      "Pods in #{name} #{self.class.name.demodulize} have timed out. " +
       pods.map(&:timeout_message).compact.uniq.join("\n")
     end
 
@@ -61,7 +59,7 @@ module KubernetesDeploy
           context: context,
           definition: pod_data,
           logger: @logger,
-          parent: "#{name.capitalize} #{self.class.name.demodulize}",
+          parent: "#{name.capitalize} #{type}",
           deploy_started_at: @deploy_started_at
         )
         pod.sync(pod_data)

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -2,10 +2,12 @@
 module KubernetesDeploy
   class PodSetBase < KubernetesResource
     def failure_message
+      "Pods in #{name} #{self.class.name.demodulize} are failing. " +
       pods.map(&:failure_message).compact.uniq.join("\n")
     end
 
     def timeout_message
+      "Pods in #{name} #{self.class.name.demodulize} have timed out. " +
       pods.map(&:timeout_message).compact.uniq.join("\n")
     end
 
@@ -59,7 +61,7 @@ module KubernetesDeploy
           context: context,
           definition: pod_data,
           logger: @logger,
-          parent: "#{name.capitalize} #{self.class.name}",
+          parent: "#{name.capitalize} #{self.class.name.demodulize}",
           deploy_started_at: @deploy_started_at
         )
         pod.sync(pod_data)

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -23,7 +23,7 @@ module KubernetesDeploy
           "logs",
           id,
           "--container=#{container_name}",
-          "--since-time=#{@deploy_started.to_datetime.rfc3339}",
+          "--since-time=#{@deploy_started_at.to_datetime.rfc3339}",
           "--tail=#{LOG_LINE_COUNT}"
         )
         container_logs[container_name] = out.split("\n")
@@ -60,7 +60,7 @@ module KubernetesDeploy
           definition: pod_data,
           logger: @logger,
           parent: "#{name.capitalize} #{self.class.name}",
-          deploy_started: @deploy_started
+          deploy_started_at: @deploy_started_at
         )
         pod.sync(pod_data)
         relevant_pods << pod

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -5,9 +5,9 @@ module KubernetesDeploy
     TIMEOUT = 5.minutes
     attr_reader :desired_replicas, :pods
 
-    def initialize(namespace:, context:, definition:, logger:, parent: nil, deploy_started: nil)
+    def initialize(namespace:, context:, definition:, logger:, parent: nil, deploy_started_at: nil)
       @parent = parent
-      @deploy_started = deploy_started
+      @deploy_started_at = deploy_started_at
       @rollout_data = { "replicas" => 0 }
       @pods = []
       super(namespace: namespace, context: context, definition: definition, logger: logger)

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -9,6 +9,7 @@ module KubernetesDeploy
       @parent = parent
       @deploy_started_at = deploy_started_at
       @rollout_data = { "replicas" => 0 }
+      @desired_replicas = -1
       @pods = []
       super(namespace: namespace, context: context, definition: definition, logger: logger)
     end
@@ -22,8 +23,9 @@ module KubernetesDeploy
       if rs_data.present?
         @found = true
         @desired_replicas = rs_data["spec"]["replicas"].to_i
-        @rollout_data = { "replicas" => 0 }.merge(rs_data["status"]
-          .slice("replicas", "availableReplicas", "readyReplicas"))
+        @rollout_data = { "replicas" => 0 }.merge(
+          rs_data["status"].slice("replicas", "availableReplicas", "readyReplicas")
+        )
         @status = @rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
         @pods = find_pods(rs_data)
       else # reset
@@ -31,6 +33,7 @@ module KubernetesDeploy
         @rollout_data = { "replicas" => 0 }
         @status = nil
         @pods = []
+        @desired_replicas = -1
       end
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
@@ -7,7 +7,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      return false unless @deploy_started
+      return false unless deploy_started?
 
       unless @success_assumption_warning_shown
         @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")

--- a/lib/kubernetes-deploy/kubernetes_resource/topic.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/topic.rb
@@ -7,7 +7,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      return false unless @deploy_started
+      return false unless deploy_started?
 
       unless @success_assumption_warning_shown
         @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -80,7 +80,7 @@ module KubernetesDeploy
       kubeclient_resources.map do |d|
         definition = d.to_h.deep_stringify_keys
         r = Deployment.new(namespace: @namespace, context: @context, definition: definition, logger: @logger)
-        r.deploy_started = started # we don't care what happened to the resource before the restart cmd ran
+        r.deploy_started_at = started # we don't care what happened to the resource before the restart cmd ran
         r
       end
     end

--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -1,5 +1,5 @@
 <% %w(one two three).each do |name| %>
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: <%= "web-#{name}" %>

--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -5,6 +5,7 @@ metadata:
   name: <%= "web-#{name}" %>
 spec:
   replicas: 1
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -5,7 +5,7 @@ metadata:
   name: <%= "web-#{name}" %>
 spec:
   replicas: 1
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/ejson-cloud/web.yaml
+++ b/test/fixtures/ejson-cloud/web.yaml
@@ -5,7 +5,7 @@ metadata:
   name: web
 spec:
   replicas: 1
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/ejson-cloud/web.yaml
+++ b/test/fixtures/ejson-cloud/web.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web

--- a/test/fixtures/ejson-cloud/web.yaml
+++ b/test/fixtures/ejson-cloud/web.yaml
@@ -5,6 +5,7 @@ metadata:
   name: web
 spec:
   replicas: 1
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -32,6 +32,7 @@ metadata:
   name: redis
 spec:
   replicas: 1
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -26,7 +26,7 @@ spec:
     requests:
       storage: 100M
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: redis

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -32,7 +32,7 @@ metadata:
   name: redis
 spec:
   replicas: 1
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -30,7 +30,7 @@ spec:
     name: web
     app: hello-cloud
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -38,6 +38,7 @@ metadata:
     shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -38,7 +38,7 @@ metadata:
     shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: bad-probe

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -1,9 +1,10 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1 # keep as long as this group is valid
 kind: Deployment
 metadata:
   name: bad-probe
 spec:
   replicas: 1
+  # progressDeadlineSeconds: 10 -- do not add: this is used to test the hard deadline
   template:
     metadata:
       labels:
@@ -21,6 +22,7 @@ spec:
             path: "/bad/ping/path"
             port: 80
           initialDelaySeconds: 0
+          periodSeconds: 1
           timeoutSeconds: 1
           failureThreshold: 1
       - name: exec-probe
@@ -33,6 +35,7 @@ spec:
               - "ls"
               - "/bad/path"
           initialDelaySeconds: 0
+          periodSeconds: 1
           timeoutSeconds: 1
           failureThreshold: 1
       - name: sidecar

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -4,6 +4,7 @@ metadata:
   name: cannot-run
 spec:
   replicas: 3
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cannot-run

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -4,7 +4,7 @@ metadata:
   name: cannot-run
 spec:
   replicas: 3
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/crash_loop.yml
+++ b/test/fixtures/invalid/crash_loop.yml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   name: crash-loop
 spec:
-  replicas: 3
-  progressDeadlineSeconds: 15
+  replicas: 2
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/crash_loop.yml
+++ b/test/fixtures/invalid/crash_loop.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: crash-loop

--- a/test/fixtures/invalid/crash_loop_daemon_set.yml
+++ b/test/fixtures/invalid/crash_loop_daemon_set.yml
@@ -1,10 +1,8 @@
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: extensions/v1beta1
+kind: DaemonSet
 metadata:
   name: crash-loop
 spec:
-  replicas: 3
-  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: init-crash

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -4,7 +4,7 @@ metadata:
   name: init-crash
 spec:
   replicas: 2
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -4,6 +4,7 @@ metadata:
   name: init-crash
 spec:
   replicas: 2
+  progressDeadlineSeconds: 15
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/missing_volumes.yml
+++ b/test/fixtures/invalid/missing_volumes.yml
@@ -4,6 +4,7 @@ metadata:
   name: missing-volumes
 spec:
   replicas: 1
+  progressDeadlineSeconds: 10
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/missing_volumes.yml
+++ b/test/fixtures/invalid/missing_volumes.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: missing-volumes

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -17,6 +17,7 @@ metadata:
   name: undying
 spec:
   replicas: 2
+  progressDeadlineSeconds: 15
   revisionHistoryLimit: 1
   strategy:
     type: RollingUpdate

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -17,7 +17,7 @@ metadata:
   name: undying
 spec:
   replicas: 2
-  progressDeadlineSeconds: 15
+  progressDeadlineSeconds: 20
   revisionHistoryLimit: 1
   strategy:
     type: RollingUpdate

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -11,7 +11,7 @@ spec:
     name: undying
     app: fixtures
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: undying

--- a/test/fixtures/resource-quota/web.yml
+++ b/test/fixtures/resource-quota/web.yml
@@ -6,7 +6,7 @@ metadata:
     shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
-  progressDeadlineSeconds: 10
+  progressDeadlineSeconds: 20
   template:
     metadata:
       labels:

--- a/test/fixtures/resource-quota/web.yml
+++ b/test/fixtures/resource-quota/web.yml
@@ -6,6 +6,7 @@ metadata:
     shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
+  progressDeadlineSeconds: 10
   template:
     metadata:
       labels:

--- a/test/fixtures/resource-quota/web.yml
+++ b/test/fixtures/resource-quota/web.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 module FixtureDeployHelper
   EJSON_FILENAME = KubernetesDeploy::EjsonSecretProvisioner::EJSON_SECRETS_FILE
 
-  # Deploys the specified set of fixtures via KubernetesDeploy::Runner.
+  # Deploys the specified set of fixtures via KubernetesDeploy::DeployTask.
   #
   # Optionally takes an array of filenames belonging to the fixture, and deploys that subset only.
   # Example:
@@ -47,7 +47,7 @@ module FixtureDeployHelper
 
   def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {}, sha: nil)
     current_sha = sha || SecureRandom.hex(6)
-    runner = KubernetesDeploy::Runner.new(
+    deploy = KubernetesDeploy::DeployTask.new(
       namespace: @namespace,
       current_sha: current_sha,
       context: KubeclientHelper::MINIKUBE_CONTEXT,
@@ -56,14 +56,14 @@ module FixtureDeployHelper
       kubectl_instance: build_kubectl,
       bindings: bindings
     )
-    runner.run(
+    deploy.run(
       verify_result: wait,
       allow_protected_ns: allow_protected_ns,
       prune: prune
     )
   end
 
-  # Deploys all fixtures in the given directory via KubernetesDeploy::Runner
+  # Deploys all fixtures in the given directory via KubernetesDeploy::DeployTask
   # Exposed for direct use only when deploy_fixtures cannot be used because the template cannot be loaded pre-deploy,
   # for example because it contains an intentional syntax error
   def deploy_dir(*args)

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -17,17 +17,26 @@ module FixtureSetAssertions
         namespace: namespace,
         labels: { name: 'ejson-keys' }
       }
-      encoded_data = {
-        "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a" =>
-          "ZmVkY2M5NTEzMmU5YjM5OWVlMWY0MDQzNjRmZGJjODFiZGJlNGZlYjViODI5MmIwNjFmMTAyMjQ4MTE1N2Q1YQ=="
-      }
+      encoded_data = { test_public_key => test_private_key }
       secret = Kubeclient::Secret.new(type: 'Opaque', metadata: metadata, data: encoded_data)
       kubeclient.create_secret(secret)
     end
 
+    def test_private_key
+      "ZmVkY2M5NTEzMmU5YjM5OWVlMWY0MDQzNjRmZGJjODFiZGJlNGZlYjViODI5MmIwNjFmMTAyMjQ4MTE1N2Q1YQ=="
+    end
+
+    def test_public_key
+      "65f79806388144edf800bf9fa683c98d3bc9484768448a275a35d398729c892a"
+    end
+
+    def catphotoscom_key_value
+      "this-is-the-key"
+    end
+
     def assert_all_secrets_present
       assert_secret_present("ejson-keys")
-      cert_data = { "tls.crt" => "this-is-the-certificate", "tls.key" => "this-is-the-key" }
+      cert_data = { "tls.crt" => "this-is-the-certificate", "tls.key" => catphotoscom_key_value }
       assert_secret_present("catphotoscom", cert_data, type: "kubernetes.io/tls", managed: true)
 
       token_data = { "api-token" => "this-is-the-api-token", "service" => "Datadog" } # Impt: it isn't _service: Datadog

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -542,7 +542,7 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
 
     # Debug info for missing volume timeout
     assert_logs_match_all([
-      "Deployment/missing-volumes: TIMED OUT (progress deadline: 10s)",
+      %r{Deployment/missing-volumes: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
       /Latest ReplicaSet: missing-volumes-\w+/,
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
@@ -758,7 +758,7 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
       "Deployment/web rollout timed out",
       "Successful resources",
       "ResourceQuota/resource-quotas",
-      "Deployment/web: TIMED OUT (progress deadline: 10s)",
+      %r{Deployment/web: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
       "failed quota: resource-quotas" # from an event
     ], in_order: true)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -77,7 +77,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_deploying_to_protected_namespace_with_override_does_not_prune
-    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+    KubernetesDeploy::DeployTask.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
       assert_deploy_success(deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: false))
       hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
       hello_cloud.assert_all_up
@@ -93,14 +93,14 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
-    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+    KubernetesDeploy::DeployTask.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
       assert_deploy_failure(deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true))
     end
     assert_logs_match(/Refusing to deploy to protected namespace .* pruning enabled/)
   end
 
   def test_refuses_deploy_to_protected_namespace_without_override
-    KubernetesDeploy::Runner.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+    KubernetesDeploy::DeployTask.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
       assert_deploy_failure(deploy_fixtures("hello-cloud", prune: false))
     end
     assert_logs_match(/Refusing to deploy to protected namespace/)

--- a/test/unit/kubernetes-deploy/deploy_task_test.rb
+++ b/test/unit/kubernetes-deploy/deploy_task_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 
-class RunnerTest < KubernetesDeploy::TestCase
+class DeployTaskTest < KubernetesDeploy::TestCase
   def test_that_it_has_a_version_number
     refute_nil ::KubernetesDeploy::VERSION
   end
@@ -29,19 +29,19 @@ class RunnerTest < KubernetesDeploy::TestCase
   private
 
   def runner_with_env(value)
-    # TODO: Switch to --kubeconfig for kubectl shell out and pass env var as arg to Runner init
+    # TODO: Switch to --kubeconfig for kubectl shell out and pass env var as arg to DeployTask init
     # Then fix this crappy env manipulation
     original_env = ENV["KUBECONFIG"]
     ENV["KUBECONFIG"] = value
 
-    runner = KubernetesDeploy::Runner.new(
+    deploy = KubernetesDeploy::DeployTask.new(
       namespace: "",
       context: "",
       logger: logger,
       current_sha: "",
       template_dir: "unknown",
     )
-    runner.run
+    deploy.run
   ensure
     ENV["KUBECONFIG"] = original_env
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -114,7 +114,7 @@ class PodTest < KubernetesDeploy::TestCase
       context: 'minikube',
       definition: spec,
       logger: @logger,
-      deploy_started: Time.now.utc
+      deploy_started_at: Time.now.utc
     )
   end
 end

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -22,7 +22,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
   def test_fetch_events_parses_tricky_events_correctly
     start_time = Time.now.utc - 10.seconds
     dummy = DummyResource.new
-    dummy.deploy_started = start_time
+    dummy.deploy_started_at = start_time
 
     tricky_events = dummy_events(start_time)
     assert tricky_events.first[:message].count("\n") > 1, "Sanity check failed: inadequate newlines in test events"
@@ -35,7 +35,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
   def test_fetch_events_excludes_events_from_previous_deploys
     start_time = Time.now.utc - 10.seconds
     dummy = DummyResource.new
-    dummy.deploy_started = start_time
+    dummy.deploy_started_at = start_time
     mixed_time_events = dummy_events(start_time)
     mixed_time_events.first[:last_seen] = 1.hour.ago
 
@@ -46,7 +46,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
   def test_fetch_events_returns_empty_hash_when_kubectl_results_empty
     dummy = DummyResource.new
-    dummy.deploy_started = Time.now.utc - 10.seconds
+    dummy.deploy_started_at = Time.now.utc - 10.seconds
 
     stub_kubectl_response("get", "events", anything, resp: "", json: false)
     events = dummy.fetch_events

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -99,10 +99,6 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       @hits += 1
     end
 
-    def deploy_finished?
-      deploy_succeeded? || deploy_failed? || deploy_timed_out?
-    end
-
     def deploy_succeeded?
       status == "success" && hits_complete?
     end


### PR DESCRIPTION
This PR has a bunch of changes related to fixing the "status: Recreate bug" (which turned out to a progress deadline problem) and making stuff like that easier to debug in the future (or now, if the workaround doesn't work 😄 ). I believe this may be the same bug we've seen when doing a rollback on core. I've added test cases for `type: Recreate` and rollbacks, though unfortunately I wasn't able to figure out how to make them true regression tests (the buggy k8s behaviour seems to be inconsistent, and these tests do not fail on master).

Highlights:
- Work around [this k8s bug](https://github.com/kubernetes/kubernetes/issues/49637) in versions < 1.7.7 by refusing to declare a failure to progress within 10 seconds of the resource being deployed.
- Make sure Deployment failures and timeouts always log _something_ about why they happened, and include the name of the replicaset we looked at (if applicable)
- Make the resets used when a particular poll cycle fails more robust.
- Make `deploy_timed_out?` more explicit (it was sometimes a fallback `else` after the other two checks)
- Make it possible to use debug-level logging in production by disabling kubectl output logs for the EjsonSecretProvisioner (previously, the debug-level logging would have logged everything we got back from the server, including base64-encoded secret data).

It also does two renames to fix frequent sources of confusion: `Runner` (often confused with `RunnerTask`) -> `DeployTask`, and `@deploy_started` -> `@deploy_started_at`/`deploy_started?` (it's a timestamp). These admittedly aren't necessary for this PR, so I can extract them (they're separate commits) if they're making it hard to review. Same goes for the `apps/v1beta` change in the fixtures.

@Shopify/cloudplatform 