### PR TITLE
Make statefulset shut down faster to speed up test

### DIFF
--- a/test/fixtures/hello-cloud/stateful_set.yml
+++ b/test/fixtures/hello-cloud/stateful_set.yml
@@ -11,9 +11,9 @@ spec:
         app: hello-cloud
         name: nginx-ss
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
-        command: ["sleep", "40"]
+        image: nginx:alpine
         ports:
         - containerPort: 80


### PR DESCRIPTION
Fixes https://github.com/Shopify/kubernetes-deploy/issues/214. `test_pruning` sometimes takes over a minute because `apply` blocks on the statefulset scaling down for some reason. A few recent results:

`KubernetesDeployTest#test_pruning_works = 89.72 s`
`KubernetesDeployTest#test_pruning_works = 93.05 s`
`KubernetesDeployTest#test_pruning_works = 106.93 s`

After this change, `apply` waits for ~6s, and the test runs in ~25s.