### PR TITLE
Use busybox in all fixtures

### DIFF
--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -13,7 +13,9 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80
           name: http

--- a/test/fixtures/ejson-cloud/web.yaml
+++ b/test/fixtures/ejson-cloud/web.yaml
@@ -14,7 +14,9 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80
           name: http

--- a/test/fixtures/hello-cloud/bare_replica_set.yml
+++ b/test/fixtures/hello-cloud/bare_replica_set.yml
@@ -19,8 +19,10 @@ spec:
         name: bare-replica-set
     spec:
       containers:
-      - image: nginx:alpine
-        name: app
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80
           name: http

--- a/test/fixtures/hello-cloud/daemon_set.yml
+++ b/test/fixtures/hello-cloud/daemon_set.yml
@@ -1,16 +1,18 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: nginx
+  name: ds-app
 spec:
   template:
     metadata:
       labels:
         app: hello-cloud
-        name: nginx
+        name: ds-app
     spec:
       containers:
-      - name: nginx
-        image: nginx:alpine
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -41,7 +41,9 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis:3.2.6-alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 6379
           name: redis

--- a/test/fixtures/hello-cloud/stateful_set.yml
+++ b/test/fixtures/hello-cloud/stateful_set.yml
@@ -1,19 +1,21 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: nginx-ss
+  name: stateful-busybox
 spec:
-  serviceName: "nginx-ss"
+  serviceName: "stateful-busybox"
   replicas: 2
   template:
     metadata:
       labels:
         app: hello-cloud
-        name: nginx-ss
+        name: stateful-busybox
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: nginx
-        image: nginx:alpine
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80

--- a/test/fixtures/hello-cloud/template-runner.yml
+++ b/test/fixtures/hello-cloud/template-runner.yml
@@ -14,8 +14,9 @@ template:
   spec:
     containers:
     - name: task-runner
-      image: hello-world:latest
+      image: busybox
       imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "echo 'Hello from the command runner!' && test 1 -eq 1"]
       env:
       - name: CONFIG
         valueFrom:

--- a/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
+++ b/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
@@ -11,8 +11,9 @@ spec:
   restartPolicy: Never
   containers:
     - name: hello-cloud
-      image: hello-world:latest
+      image: busybox
       imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "echo 'Hello from the command runner!' && test 1 -eq 1"]
       env:
       - name: CONFIG
         valueFrom:

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -47,7 +47,9 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80
           name: http
@@ -62,4 +64,4 @@ spec:
       - name: sidecar
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["sleep", "8000"]
+        command: ["tail", "-f", "/dev/null"]

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -13,7 +13,9 @@ spec:
     spec:
       containers:
       - name: http-probe
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         ports:
         - containerPort: 80
           name: http
@@ -28,12 +30,10 @@ spec:
       - name: exec-probe
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["sleep", "8000"]
+        command: ["tail", "-f", "/dev/null"]
         readinessProbe:
           exec:
-            command:
-              - "ls"
-              - "/bad/path"
+            command: ["test", "0", "-eq", "1"]
           initialDelaySeconds: 0
           periodSeconds: 1
           timeoutSeconds: 1
@@ -41,10 +41,10 @@ spec:
       - name: sidecar
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["sleep", "8000"]
+        command: ["tail", "-f", "/dev/null"]
         readinessProbe:
           exec:
-            command: ["ls", "/"]
+            command: ["test", "0", "-eq", "0"]
           initialDelaySeconds: 1
           periodSeconds: 1
           successThreshold: 1

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -13,8 +13,9 @@ spec:
     spec:
       initContainers:
       - name: successful-init
-        image: hello-world:latest
+        image: busybox
         imagePullPolicy: IfNotPresent
+        command: ["sh", "-c", "echo 'Log from successful init container' && test 1 -eq 1"]
       containers:
       - name: container-cannot-run
         image: busybox

--- a/test/fixtures/invalid/crash_loop.yml
+++ b/test/fixtures/invalid/crash_loop.yml
@@ -12,14 +12,14 @@ spec:
         app: crash-app
     spec:
       containers:
-      - name: crash-loop-back-off
-        image: nginx:alpine
-        command: ["/usr/sbin/nginx", "-s", "stop"]
-        readinessProbe:
-          exec:
-            command:
-            - "test -d /etc/nginx/nginx.conf" # it isn't a directory
-          initialDelaySeconds: 0
-          periodSeconds: 1
-          timeoutSeconds: 1
-          failureThreshold: 1
+        - name: crash-loop-back-off
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "echo 'this is a log from the crashing container' && test 0 -eq 1"]
+          readinessProbe:
+            exec:
+              command: ["test", "-d", "/not/a/directory"]
+            initialDelaySeconds: 0
+            periodSeconds: 1
+            timeoutSeconds: 1
+            failureThreshold: 1

--- a/test/fixtures/invalid/crash_loop_daemon_set.yml
+++ b/test/fixtures/invalid/crash_loop_daemon_set.yml
@@ -11,12 +11,13 @@ spec:
     spec:
       containers:
       - name: crash-loop-back-off
-        image: nginx:alpine
-        command: ["/usr/sbin/nginx", "-s", "stop"]
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c", "echo 'this is a log from the crashing container' && test 0 -eq 1"]
         readinessProbe:
           exec:
             command:
-            - "test -d /etc/nginx/nginx.conf" # it isn't a directory
+            - "test -d /not/a/directory"
           initialDelaySeconds: 0
           periodSeconds: 1
           timeoutSeconds: 1

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -15,7 +15,9 @@ spec:
       - name: init-crash-loop-back-off
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["ls", "/not-a-dir"]
+        command: ["sh", "-c", "echo 'this is a log from the crashing init container' && test 0 -eq 1"]
       containers:
       - name: app
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]

--- a/test/fixtures/invalid/missing_volumes.yml
+++ b/test/fixtures/invalid/missing_volumes.yml
@@ -13,7 +13,9 @@ spec:
     spec:
       containers:
       - name: mounts-missing-volumes
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         volumeMounts:
         - mountPath: /server-cert
           name: server-cert

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -34,7 +34,7 @@ spec:
       - name: app
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["sleep", "40"]
+        command: ["tail", "-f", "/dev/null"]
         lifecycle:
           preStop:
             exec:

--- a/test/fixtures/resource-quota/web.yml
+++ b/test/fixtures/resource-quota/web.yml
@@ -15,7 +15,9 @@ spec:
     spec:
       containers:
       - name: app
-        image: nginx:alpine
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
         resources:
           requests:
             cpu: 1
@@ -29,4 +31,4 @@ spec:
       - name: sidecar
         image: busybox
         imagePullPolicy: IfNotPresent
-        command: ["sleep", "8000"]
+        command: ["tail", "-f", "/dev/null"]

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -88,11 +88,11 @@ module FixtureSetAssertions
     end
 
     def assert_daemon_set_up
-      assert_daemon_set_present("nginx")
+      assert_daemon_set_present("ds-app")
     end
 
     def assert_stateful_set_up
-      assert_stateful_set_present("nginx-ss")
+      assert_stateful_set_present("stateful-busybox")
     end
   end
 end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -19,7 +19,7 @@ class PodTest < KubernetesDeploy::TestCase
 
     expected_msg = <<~STRING
       The following containers encountered errors:
-      > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
+      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
     assert_equal expected_msg, pod.failure_message
   end
@@ -42,7 +42,7 @@ class PodTest < KubernetesDeploy::TestCase
 
     expected_msg = <<~STRING
       The following containers encountered errors:
-      > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
+      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
     assert_equal expected_msg, pod.failure_message
   end
@@ -81,7 +81,7 @@ class PodTest < KubernetesDeploy::TestCase
 
     expected_msg = <<~STRING
       The following containers encountered errors:
-      > hello-cloud: Failed to pull image hello-world:latest. Did you wait for it to be built and pushed to the registry before deploying?
+      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
     assert_equal expected_msg, pod.failure_message
   end


### PR DESCRIPTION
- Changes all fixtures to use the `busybox` image. Now the whole suite should only pull one tiny image a single time.
- Gets rid of all uses of `sleep` to simulate long-running processes. `sleep` doesn't handle SIGTERM, impeding pod shutdown.
- Switches to `test 0 -eq 1` as the mechanism for simulating crashing containers, and manually `echo`s log messages we want to assert on.

It's hard to say if this actually makes a speed difference for CI, since the run times vary by a pretty big margin. 