### PR TITLE
More powerful bindings parser

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -12,13 +12,8 @@ bindings = {}
 verbose_log_prefix = false
 
 ARGV.options do |opts|
-  opts.on("--bindings=BINDINGS", Array, "Expose additional variables to ERB templates (format: k1=v1,k2=v2)") do |binds|
-    bindings = binds.each_with_object({}) do |bind, acc|
-      k, v = bind.split('=')
-      raise "key for value #{v} is blank!" if k.blank?
-      raise "value for key #{k} is blank!" if v.blank?
-      acc[k] = v
-    end
+  opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates (format: k1=v1,k2=v2 or JSON)") do |binds|
+    bindings = KubernetesDeploy::BindingsParser.parse(binds)
   end
 
   opts.on("--skip-wait", "Skip verification of non-priority-resource success (not recommended)") { skip_wait = true }

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -16,6 +16,7 @@ require 'kubernetes-deploy/formatted_logger'
 require 'kubernetes-deploy/deploy_task'
 require 'kubernetes-deploy/statsd'
 require 'kubernetes-deploy/concurrency'
+require 'kubernetes-deploy/bindings_parser'
 
 module KubernetesDeploy
   KubernetesDeploy::StatsD.build

--- a/lib/kubernetes-deploy/bindings_parser.rb
+++ b/lib/kubernetes-deploy/bindings_parser.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'json'
+require 'csv'
+
+module KubernetesDeploy
+  module BindingsParser
+    extend self
+
+    def parse(string)
+      bindings = parse_json(string) || parse_csv(string)
+
+      unless bindings
+        raise ArgumentError, "Failed to parse bindings."
+      end
+
+      bindings
+    end
+
+    private
+
+    def parse_json(string)
+      bindings = JSON.parse(string)
+
+      unless bindings.is_a?(Hash)
+        raise ArgumentError, "Expected JSON data to be a hash."
+      end
+
+      bindings
+    rescue JSON::ParserError
+      nil
+    end
+
+    def parse_csv(string)
+      lines = CSV.parse(string)
+      bindings = {}
+
+      lines.each do |line|
+        line.each do |binding|
+          key, value = binding.split('=', 2)
+
+          if key.blank?
+            raise ArgumentError, "key is blank"
+          end
+
+          bindings[key] = value
+        end
+      end
+
+      bindings
+    rescue CSV::MalformedCSVError
+      nil
+    end
+  end
+end

--- a/test/unit/kubernetes-deploy/bindings_parser_test.rb
+++ b/test/unit/kubernetes-deploy/bindings_parser_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'json'
+
+class BindingsParserTest < ::Minitest::Test
+  def test_parse_json
+    expected = { "foo" => 42, "bar" => "hello" }
+    assert_equal expected, parse(expected.to_json)
+  end
+
+  def test_parse_complex_json
+    expected = { "foo" => 42, "bar" => [1, 2, 3], "bla" => { "hello" => 17 } }
+    assert_equal expected, parse(expected.to_json)
+  end
+
+  def test_parse_json_not_hash
+    assert_raises(ArgumentError) do
+      parse([1, 2, 3].to_json)
+    end
+  end
+
+  def test_parse_csv
+    expected = { "foo" => "42", "bar" => "17" }
+    assert_equal expected, parse("foo=42,bar=17")
+  end
+
+  def test_parse_csv_with_comma_in_values
+    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
+    assert_equal expected, parse('"foo=a,b,c",bar=d,"bla=e,f"')
+  end
+
+  def test_parse_csv_with_equality_sign
+    expected = { "foo" => "1=2=3", "bar" => "3", "bla" => "4=7" }
+    assert_equal expected, parse("foo=1=2=3,bar=3,bla=4=7")
+  end
+
+  def test_parse_csv_with_no_value
+    expected = { "bla" => nil, "foo" => "" }
+    assert_equal expected, parse("bla,foo=")
+  end
+
+  def test_parse_csv_with_no_key
+    assert_raises(ArgumentError) do
+      parse("=17,foo=42")
+    end
+  end
+
+  private
+
+  def parse(string)
+    KubernetesDeploy::BindingsParser.parse(string)
+  end
+end


### PR DESCRIPTION
* Fix a bug in the `kubernetes-deploy --bindings` parser. Previously, it was not possible to pass bindings for which the value contains commas (because the comma was interpreted as a separator). This is now possible via something like `--bindings='"foo=bar,42",bla=42'`.
* Add possibility to pass a JSON encoded hash, e.g. `--bindings='{ "foo": 42, "bar": 17 }'`.
* Add some tests for the parser.