### PR TITLE
Service account deployed before pod

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -48,6 +48,7 @@ module KubernetesDeploy
       Bugsnag
       ConfigMap
       PersistentVolumeClaim
+      ServiceAccount
       Pod
     )
     PROTECTED_NAMESPACES = %w(

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -116,6 +116,7 @@ module KubernetesDeploy
 
       secret_yaml = generate_secret_yaml(secret_name, secret_type, data)
       file = Tempfile.new(secret_name)
+
       file.write(secret_yaml)
       file.close
 

--- a/test/fixtures/ejson-cloud/secrets.ejson
+++ b/test/fixtures/ejson-cloud/secrets.ejson
@@ -18,6 +18,12 @@
         "api-token": "EJ[1:N0RQ6a1BcGJ7w/1ABQUC3C2DQMP+qWuc10LoNUQOiUg=:yiXxO6D4W5/wtYNoOoxzllkTrw+XZ8Bx:gXL/hMM2JNlTJ1stmrHCGXQqWsELg5j9i5Mfmlz7ww21p2mUfQ==]",
         "_service": "Datadog"
       }
+    },
+    "image-pull-secret": {
+      "_type": "kubernetes.io/dockerconfigjson",
+      "data": {
+        ".dockerconfigjson": "EJ[1:65bOUCxxoSY95UrdKMR6C/bNQI35kp9RZTxMquudtRU=:NNCOhiHhbmGNl0f4glkDhiMO2LSuBimU:AFz/rvS00V2sMM9poOe79r/UvL4A1ZP4TUJB5LMJdcMEvXk+dhdJazU2t9uEFx3j4RYG96tKT5mTYRKO9A/fpB5eyiRIJleQ3sqwYrf+/xb/UWRSzYVeQeY2Oij/QG34+Oa6t2Ha+K3qaZU51kWV/vA5bVJlArwcWcT98xzlkvEGchbz]"
+        }
     }
   }
 }

--- a/test/fixtures/ejson-cloud/service-account.yml
+++ b/test/fixtures/ejson-cloud/service-account.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+imagePullSecrets:
+- name: image-pull-secret
+automountServiceAccountToken: false

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -34,6 +34,18 @@ module FixtureSetAssertions
       "this-is-the-key"
     end
 
+    def image_pull_secret_key_value
+      {
+        "sample.docker.com":
+        {
+          "username": "johndoe",
+          "password": "foo",
+          "email": "johndoe@sample.com",
+          "auth": "am9obmRvZTpmb28="
+        }
+      }.to_json
+    end
+
     def assert_all_secrets_present
       assert_secret_present("ejson-keys")
       cert_data = { "tls.crt" => "this-is-the-certificate", "tls.key" => catphotoscom_key_value }
@@ -43,6 +55,10 @@ module FixtureSetAssertions
       assert_secret_present("monitoring-token", token_data, managed: true)
 
       assert_secret_present("unused-secret", { "this-is-for-testing-deletion" => "true" }, managed: true)
+
+      assert_secret_present("image-pull-secret",
+        { ".dockerconfigjson" => image_pull_secret_key_value },
+        type: "kubernetes.io/dockerconfigjson", managed: true)
     end
 
     def assert_web_resources_up

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -67,7 +67,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.assert_all_service_accounts_up
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
     assert_logs_match_all([
-      %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot/},
+      %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
       %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*}
     ], in_order: true)
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -67,8 +67,8 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.assert_all_service_accounts_up
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
     assert_logs_match_all([
-      %r{ServiceAccount/build-robot\s+Created},
-      %r{Pod/unmanaged-pod-.*\s+Succeeded}
+      %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot/},
+      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*}
     ], in_order: true)
   end
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -28,9 +28,9 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_service_account_predeployed_before_unmanaged_pod
-    # Add an undefined service account in unmanaged pod 
+    # Add an undefined service account in unmanaged pod
     service_account_name = "unknown-service-account"
-    result = deploy_fixtures("hello-cloud", 
+    result = deploy_fixtures("hello-cloud",
       subset: ["configmap-data.yml", "unmanaged-pod.yml.erb"]) do |fixtures|
       pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
       pod["spec"]["serviceAccountName"] = service_account_name
@@ -38,11 +38,11 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     end
     # Expect deploying the unmanaged pod fails due to missing service account
     assert_deploy_failure(result)
-    #if KUBE_CLIENT_VERSION < Gem::Version.new("1.8.0")
+    # if KUBE_CLIENT_VERSION < Gem::Version.new("1.8.0")
     assert_logs_match_all([
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error below were likely created/updated.",
-      %r{Invalid template: Pod-unmanaged-pod.*\.yml},
+      /Invalid template: Pod-unmanaged-pod.*\.yml/,
       "> Error from kubectl:",
       "Error from server (Forbidden): error when creating",
       "service account #{@namespace}/#{service_account_name} was not found, retry after the "\
@@ -52,9 +52,9 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "automountServiceAccountToken: false"
     ], in_order: true)
 
-    # Add a valid service account in unmanaged pod 
+    # Add a valid service account in unmanaged pod
     service_account_name = "build-robot"
-    result = deploy_fixtures("hello-cloud", 
+    result = deploy_fixtures("hello-cloud",
       subset: ["configmap-data.yml", "unmanaged-pod.yml.erb", "service-account.yml"]) do |fixtures|
       pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
       pod["spec"]["serviceAccountName"] = service_account_name
@@ -488,7 +488,8 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
     assert_logs_match_all([
       /Creating secret catphotoscom/,
       /Creating secret unused-secret/,
-      /Creating secret monitoring-token/
+      /Creating secret monitoring-token/,
+      /Creating secret image-pull-secret/
     ])
 
     refute_logs_match(ejson_cloud.test_private_key)

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -27,6 +27,51 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(%r{ConfigMap/hello-cloud-configmap-data\s+Available}, 1)
   end
 
+  def test_service_account_predeployed_before_unmanaged_pod
+    # Add an undefined service account in unmanaged pod 
+    service_account_name = "unknown-service-account"
+    result = deploy_fixtures("hello-cloud", 
+      subset: ["configmap-data.yml", "unmanaged-pod.yml.erb"]) do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["spec"]["serviceAccountName"] = service_account_name
+      pod["spec"]["automountServiceAccountToken"] = false
+    end
+    # Expect deploying the unmanaged pod fails due to missing service account
+    assert_deploy_failure(result)
+    #if KUBE_CLIENT_VERSION < Gem::Version.new("1.8.0")
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      "WARNING: Any resources not mentioned in the error below were likely created/updated.",
+      %r{Invalid template: Pod-unmanaged-pod.*\.yml},
+      "> Error from kubectl:",
+      "Error from server (Forbidden): error when creating",
+      "service account #{@namespace}/#{service_account_name} was not found, retry after the "\
+      "service account is created",
+      "> Rendered template content:",
+      "serviceAccountName: #{service_account_name}",
+      "automountServiceAccountToken: false"
+    ], in_order: true)
+
+    # Add a valid service account in unmanaged pod 
+    service_account_name = "build-robot"
+    result = deploy_fixtures("hello-cloud", 
+      subset: ["configmap-data.yml", "unmanaged-pod.yml.erb", "service-account.yml"]) do |fixtures|
+      pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
+      pod["spec"]["serviceAccountName"] = service_account_name
+      pod["spec"]["automountServiceAccountToken"] = false
+    end
+    # Expect the service account is deployed before the unmanaged pod
+    assert_deploy_success(result)
+    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+    hello_cloud.assert_configmap_data_present
+    hello_cloud.assert_all_service_accounts_up
+    hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
+    assert_logs_match_all([
+      %r{ServiceAccount/build-robot\s+Created},
+      %r{Pod/unmanaged-pod-.*\s+Succeeded}
+    ], in_order: true)
+  end
+
   def test_partial_deploy_followed_by_full_deploy
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "redis.yml"]))
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)


### PR DESCRIPTION
Force deploy service accounts before unmanaged pods in redeployment.
Tested a service account is deployed before a pod that refers to it.
Tested that an image pull secret that a service account refers is deployed before all redeployed resources.