### PR TITLE
make sure current_sha in fixtures is always a string

### DIFF
--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -21,6 +21,6 @@ spec:
           name: http
         env:
         - name: GITHUB_REV
-          value: <%= current_sha %>
+          value: "<%= current_sha %>"
 ---
 <% end %>

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -55,7 +55,7 @@ spec:
           name: http
         env:
         - name: GITHUB_REV
-          value: <%= current_sha %>
+          value: "<%= current_sha %>"
         - name: CONFIG
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
If you don't don this, the kubernetes server will complain in the
following way:

Error from server (BadRequest): error when creating
"/var/folders/rf/.../T/Deployment-web-one20171210-42930-1xcb15.yml":
Deployment in version "v1beta1" cannot be handled as a Deployment:
[pos 999]: json: expect char '"' but got char '7'