### PR TITLE
Allow template rendering from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 * [Prerequisites](#prerequisites-1)
 * [Usage](#usage-2)
 
+**KUBERNETES-RENDER**
+* [Usage](#usage-3)
+
 **DEVELOPMENT**
 * [Setup](#setup)
 * [Running the test suite locally](#running-the-test-suite-locally)
@@ -352,6 +355,28 @@ Based on this specification `kubernetes-run` will create a new pod with the entr
 * `--template=TEMPLATE`:  Specifies the name of the PodTemplate to use (default is `task-runner-template` if this option is not set).
 * `--env-vars=ENV_VARS`: Accepts a comma separated list of environment variables to be added to the pod template. For example, `--env-vars="ENV=VAL,ENV2=VAL2"` will make `ENV` and `ENV2` available to the container.
 
+
+# kubernetes-render
+
+`kubernetes-render` is a tool to render ERB templates as `kubernetes-deploy` would.
+
+## Usage
+
+`kubernetes-render <options>`
+
+*Environment variables:*
+
+- `$REVISION` **(required)**: the SHA of the commit you are deploying. Will be exposed to your ERB templates as `current_sha`.
+- `$KUBECONFIG`  **(required)**: points to one or multiple valid kubeconfig files that include the context you want to deploy to. File names are separated by colon for Linux and Mac, and semi-colon for Windows.
+- `$ENVIRONMENT`: used to set the deploy directory to `config/deploy/$ENVIRONMENT`. You can use the `--template-dir=DIR` option instead if you prefer (**one or the other is required**).
+
+
+*Options:*
+
+Refer to `kubernetes-render --help` for the authoritative set of options.
+
+- `--template-dir=DIR`: Used to set the deploy directory. Set `$ENVIRONMENT` instead to use `config/deploy/$ENVIRONMENT`.
+- `--bindings=BINDINGS`: Makes additional variables available to your ERB templates. For example, `kubernetes-deploy my-app cluster1 --bindings=color=blue,size=large` will expose `color` and `size`.
 
 
 

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kubernetes-deploy'
+require 'optparse'
+
+template_dir = nil
+bindings = {}
+
+ARGV.options do |opts|
+  opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
+    "(format: k1=v1,k2=v2 or JSON)") do |binds|
+    bindings = KubernetesDeploy::BindingsParser.parse(binds)
+  end
+
+  opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
+
+  opts.on_tail("-h", "--help", "Print this help") do
+    puts opts
+    exit
+  end
+  opts.on_tail("-v", "--version", "Show version") do
+    puts "v#{KubernetesDeploy::VERSION}"
+    exit
+  end
+  opts.parse!
+end
+
+if !template_dir && ENV.key?("ENVIRONMENT")
+  template_dir = "config/deploy/#{ENV['ENVIRONMENT']}"
+end
+
+if !template_dir || template_dir.empty?
+  puts "Template directory is unknown. " \
+    "Either specify --template-dir argument or set $ENVIRONMENT to use config/deploy/$ENVIRONMENT as a default path."
+  exit 1
+end
+
+revision = ENV.fetch('REVISION') do
+  puts "ENV['REVISION'] is missing. Please specify the commit SHA"
+  exit 1
+end
+
+logger = KubernetesDeploy::FormattedLogger.build(nil, nil)
+
+renderer = KubernetesDeploy::Renderer.new(
+  current_sha: revision,
+  template_dir: template_dir,
+  bindings: bindings,
+  logger: logger
+)
+
+Dir.foreach(template_dir) do |filename|
+  next unless filename.end_with?(".yml.erb", ".yml", ".yaml", ".yaml.erb")
+
+  file_content = File.read(File.join(template_dir, filename))
+  puts renderer.render_template(filename, file_content)
+end


### PR DESCRIPTION
Hey!
Would it be acceptable to have a feature to only render templates and not applying them ? Similar to what can be done with Helm ?

This allows parsing the generated template to extract some information for other tools, like all the images involved.
