### PR TITLE
Enable per-resource timeout customization via an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ You can add additional variables using the `--bindings=BINDINGS` option. For exa
 
 ### Customizing behaviour with annotations
 
-- `kubernetes-deploy.shopify.io/timeout-override` (any resource): Override the tool's hard timeout for one specific resource. Both full ISO8601 durations and the time portion of ISO8601 durations are valid. Value must be between 1 second and 24 hours. Example values: 45s / 3m / 1h / PT0.25H
+- `kubernetes-deploy.shopify.io/timeout-override`: Override the tool's hard timeout for one specific resource. Both full ISO8601 durations and the time portion of ISO8601 durations are valid. Value must be between 1 second and 24 hours.
+  - _Example values_: 45s / 3m / 1h / PT0.25H
+  - _Compatibility_: all resource types (Note: `Deployment` timeouts are based on `spec.progressDeadlineSeconds` if present, and that field has a default value as of the `apps/v1beta1` group version. Using this annotation will have no effect on `Deployment`s that time out with "Timeout reason: ProgressDeadlineExceeded".)
 
 ### Running tasks at the beginning of a deploy
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 * [Installation](#installation)
 * [Usage](#usage)
   * [Using templates and variables](#using-templates-and-variables)
+  * [Customizing behaviour with annotations](#customizing-behaviour-with-annotations)
   * [Running tasks at the beginning of a deploy](#running-tasks-at-the-beginning-of-a-deploy)
   * [Deploying Kubernetes secrets (from EJSON)](#deploying-kubernetes-secrets-from-ejson)
 
@@ -120,6 +121,9 @@ All templates must be YAML formatted. You can also use ERB. The following local 
 You can add additional variables using the `--bindings=BINDINGS` option. For example, `kubernetes-deploy my-app cluster1 --bindings=color=blue,size=large` will expose `color` and `size` in your templates.
 
 
+### Customizing behaviour with annotations
+
+- `kubernetes-deploy.shopify.io/timeout-override-seconds` (any resource): Override the tool's hard timeout for one specific resource. Value must be a positive number of seconds (digits only).
 
 ### Running tasks at the beginning of a deploy
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can add additional variables using the `--bindings=BINDINGS` option. For exa
 
 ### Customizing behaviour with annotations
 
-- `kubernetes-deploy.shopify.io/timeout-override-seconds` (any resource): Override the tool's hard timeout for one specific resource. Value must be a positive number of seconds (digits only).
+- `kubernetes-deploy.shopify.io/timeout-override` (any resource): Override the tool's hard timeout for one specific resource. Both full ISO8601 durations and the time portion of ISO8601 durations are valid. Value must be between 1 second and 24 hours. Example values: 45s / 3m / 1h / PT0.25H
 
 ### Running tasks at the beginning of a deploy
 

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/array/conversions'
+require 'active_support/duration'
 require 'colorized_string'
 
 require 'kubernetes-deploy/version'
@@ -17,6 +18,7 @@ require 'kubernetes-deploy/deploy_task'
 require 'kubernetes-deploy/statsd'
 require 'kubernetes-deploy/concurrency'
 require 'kubernetes-deploy/bindings_parser'
+require 'kubernetes-deploy/duration_parser'
 
 module KubernetesDeploy
   KubernetesDeploy::StatsD.build

--- a/lib/kubernetes-deploy/duration_parser.rb
+++ b/lib/kubernetes-deploy/duration_parser.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module KubernetesDeploy
+  ##
+  # This class is a less strict extension of ActiveSupport::Duration::ISO8601Parser.
+  # In addition to full ISO8601 durations, it can parse unprefixed ISO8601 time components (e.g. '1H').
+  # It is also case-insensitive.
+  # For example, this class considers the values "1H", "1h" and "PT1H" to be valid and equivalent.
+
+  class DurationParser
+    class ParsingError < ArgumentError; end
+
+    def initialize(value)
+      @iso8601_str = value.to_s.strip.upcase
+    end
+
+    def parse!
+      if @iso8601_str.blank?
+        raise ParsingError, "Cannot parse blank value"
+      end
+
+      parser = ActiveSupport::Duration::ISO8601Parser.new(@iso8601_str)
+      parser.mode = :time unless @iso8601_str.start_with?("P")
+      parts = parser.parse!
+      ActiveSupport::Duration.new(calculate_total_seconds(parts), parts)
+    rescue ActiveSupport::Duration::ISO8601Parser::ParsingError => e
+      raise ParsingError, e.message
+    end
+
+    private
+
+    # https://github.com/rails/rails/blob/19c450d5d99275924254b2041b6ad470fdaa1f93/activesupport/lib/active_support/duration.rb#L79-L83
+    def calculate_total_seconds(parts)
+      parts.inject(0) do |total, (part, value)|
+        total + value * ActiveSupport::Duration::PARTS_IN_SECONDS[part]
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/duration_parser.rb
+++ b/lib/kubernetes-deploy/duration_parser.rb
@@ -15,24 +15,12 @@ module KubernetesDeploy
     end
 
     def parse!
-      if @iso8601_str.blank?
-        raise ParsingError, "Cannot parse blank value"
-      end
-
-      parser = ActiveSupport::Duration::ISO8601Parser.new(@iso8601_str)
-      parser.mode = :time unless @iso8601_str.start_with?("P")
-      parts = parser.parse!
-      ActiveSupport::Duration.new(calculate_total_seconds(parts), parts)
-    rescue ActiveSupport::Duration::ISO8601Parser::ParsingError => e
-      raise ParsingError, e.message
-    end
-
-    private
-
-    # https://github.com/rails/rails/blob/19c450d5d99275924254b2041b6ad470fdaa1f93/activesupport/lib/active_support/duration.rb#L79-L83
-    def calculate_total_seconds(parts)
-      parts.inject(0) do |total, (part, value)|
-        total + value * ActiveSupport::Duration::PARTS_IN_SECONDS[part]
+      ActiveSupport::Duration.parse("PT#{@iso8601_str}") # By default assume it is just a time component
+    rescue ActiveSupport::Duration::ISO8601Parser::ParsingError
+      begin
+        ActiveSupport::Duration.parse(@iso8601_str)
+      rescue ActiveSupport::Duration::ISO8601Parser::ParsingError => e
+        raise ParsingError, e.message
       end
     end
   end

--- a/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
+++ b/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: unmanaged-pod-<%= deployment_id %>
+  annotations:
+    kubernetes-deploy.shopify.io/timeout-override-seconds: "42"
   labels:
     type: unmanaged-pod
     name: unmanaged-pod-<%= deployment_id %>

--- a/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
+++ b/test/fixtures/hello-cloud/unmanaged-pod.yml.erb
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: unmanaged-pod-<%= deployment_id %>
   annotations:
-    kubernetes-deploy.shopify.io/timeout-override-seconds: "42"
+    kubernetes-deploy.shopify.io/timeout-override: "42s"
   labels:
     type: unmanaged-pod
     name: unmanaged-pod-<%= deployment_id %>

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -9,6 +9,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
     assert_logs_match_all([
       "Deploying ConfigMap/hello-cloud-configmap-data (timeout: 30s)",
+      %r{Deploying Pod/unmanaged-pod-[-\w]+ \(timeout: 42s\)}, # annotation timeout override
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
       "Successfully deployed 17 resources"

--- a/test/unit/kubernetes-deploy/duration_parser_test.rb
+++ b/test/unit/kubernetes-deploy/duration_parser_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class DurationParserTest < KubernetesDeploy::TestCase
+  def test_parses_correct_iso_durations_with_prefixes
+    assert_equal 300, new_parser("PT300S").parse!
+    assert_equal 300, new_parser("PT5M").parse!
+    assert_equal 900, new_parser("PT0.25H").parse!
+    assert_equal 110839937, new_parser("P3Y6M4DT12H30M5S").parse!
+  end
+
+  def test_parses_correct_iso_durations_without_prefixes
+    assert_equal 300, new_parser("300S").parse!
+    assert_equal 300, new_parser("5M").parse!
+    assert_equal 900, new_parser("0.25H").parse!
+    assert_equal(-60, new_parser("-1M").parse!)
+  end
+
+  def test_parse_is_case_insensitive
+    assert_equal 30, new_parser("30S").parse!
+    assert_equal 30, new_parser("30s").parse!
+  end
+
+  def test_parse_raises_expected_error_for_blank_values
+    ["", "   ", nil].each do |blank_value|
+      assert_raises_message(KubernetesDeploy::DurationParser::ParsingError, "Cannot parse blank value") do
+        new_parser(blank_value).parse!
+      end
+    end
+  end
+
+  def test_extra_whitespace_is_stripped_from_values
+    assert_equal 30, new_parser("  30S    ").parse!
+  end
+
+  def test_parse_raises_expected_error_when_value_is_invalid
+    assert_raises_message(KubernetesDeploy::DurationParser::ParsingError, 'Invalid ISO 8601 duration: "FOO"') do
+      new_parser("foo").parse!
+    end
+  end
+
+  private
+
+  def new_parser(value)
+    KubernetesDeploy::DurationParser.new(value)
+  end
+end

--- a/test/unit/kubernetes-deploy/duration_parser_test.rb
+++ b/test/unit/kubernetes-deploy/duration_parser_test.rb
@@ -19,11 +19,14 @@ class DurationParserTest < KubernetesDeploy::TestCase
   def test_parse_is_case_insensitive
     assert_equal 30, new_parser("30S").parse!
     assert_equal 30, new_parser("30s").parse!
+    assert_equal 30, new_parser("pt30s").parse!
+    assert_equal 110839937, new_parser("p3y6M4dT12H30M5s").parse!
   end
 
   def test_parse_raises_expected_error_for_blank_values
     ["", "   ", nil].each do |blank_value|
-      assert_raises_message(KubernetesDeploy::DurationParser::ParsingError, "Cannot parse blank value") do
+      expected_msg = 'Invalid ISO 8601 duration: "" is empty duration'
+      assert_raises_message(KubernetesDeploy::DurationParser::ParsingError, expected_msg) do
         new_parser(blank_value).parse!
       end
     end

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -92,7 +92,8 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata(""))
     customized_resource.validate_definition
     assert customized_resource.validation_failed?, "Blank annotation was valid"
-    assert_equal "#{timeout_override_err_prefix}: Cannot parse blank value", customized_resource.validation_error_msg
+    assert_equal "#{timeout_override_err_prefix}: Invalid ISO 8601 duration: \"\" is empty duration",
+      customized_resource.validation_error_msg
   end
 
   def test_lack_of_timeout_annotation_does_not_fail_validation
@@ -123,7 +124,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
   def test_timeout_override_upper_bound_validation
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("24H1S"))
     customized_resource.validate_definition
-    assert customized_resource.validation_failed?, "Annotation with '0' was valid"
+    assert customized_resource.validation_failed?, "Annotation with '24H1S' was valid"
     assert_equal "#{timeout_override_err_prefix}: Value must be less than 24h", customized_resource.validation_error_msg
 
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("24H"))

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -3,17 +3,34 @@ require 'test_helper'
 
 class KubernetesResourceTest < KubernetesDeploy::TestCase
   class DummyResource < KubernetesDeploy::KubernetesResource
+    attr_writer :succeeded
+
     def initialize(definition_extras: {})
       definition = { "kind" => "DummyResource", "metadata" => { "name" => "test" } }.merge(definition_extras)
-      super(namespace: 'test', context: 'test', definition: definition, logger: @logger)
+      super(namespace: 'test', context: 'test', definition: definition, logger: ::Logger.new($stderr))
+      @succeeded = false
     end
 
     def exists?
       true
     end
 
+    def deploy_succeeded?
+      @succeeded
+    end
+
     def file_path
       "/tmp/foo/bar"
+    end
+
+    def kubectl
+      @kubectl_stub ||= begin
+        kubectl_stub = super
+        def kubectl_stub.run(*)
+          ["", "", SystemExit.new(0)]
+        end
+        kubectl_stub
+      end
     end
   end
 
@@ -31,7 +48,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     tricky_events = dummy_events(start_time)
     assert tricky_events.first[:message].count("\n") > 1, "Sanity check failed: inadequate newlines in test events"
 
-    stub_kubectl_response("get", "events", anything, resp: build_event_jsonpath(tricky_events), json: false)
+    dummy.kubectl.expects(:run).returns([build_event_jsonpath(tricky_events), "", SystemExit.new(0)])
     events = dummy.fetch_events
     assert_includes_dummy_events(events, first: true, second: true)
   end
@@ -43,7 +60,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     mixed_time_events = dummy_events(start_time)
     mixed_time_events.first[:last_seen] = 1.hour.ago
 
-    stub_kubectl_response("get", "events", anything, resp: build_event_jsonpath(mixed_time_events), json: false)
+    dummy.kubectl.expects(:run).returns([build_event_jsonpath(mixed_time_events), "", SystemExit.new(0)])
     events = dummy.fetch_events
     assert_includes_dummy_events(events, first: false, second: true)
   end
@@ -52,81 +69,124 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     dummy = DummyResource.new
     dummy.deploy_started_at = Time.now.utc - 10.seconds
 
-    stub_kubectl_response("get", "events", anything, resp: "", json: false)
+    dummy.kubectl.expects(:run).returns(["", "", SystemExit.new(0)])
     events = dummy.fetch_events
     assert_operator events, :empty?
   end
 
   def test_can_override_hardcoded_timeout_via_an_annotation
     basic_resource = DummyResource.new
-    assert_equal 5.minutes, basic_resource.timeout
+    assert_equal 300, basic_resource.timeout
 
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("60"))
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("60S"))
     assert_equal 60, customized_resource.timeout
 
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata(" 60  "))
-    assert_equal 60, customized_resource.timeout
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("60M"))
+    assert_equal 3600, customized_resource.timeout
+
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("1H"))
+    assert_equal 3600, customized_resource.timeout
   end
 
-  def test_blank_timeout_annotation_is_ignored
-    stub_kubectl_response("create", "-f", "/tmp/foo/bar", "--dry-run", "--output=name", anything, resp: "{}")
-
+  def test_blank_timeout_annotation_is_invalid
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata(""))
     customized_resource.validate_definition
-    refute customized_resource.validation_failed?, "Blank annotation with was invalid"
-    assert_equal 5.minutes, customized_resource.timeout
+    assert customized_resource.validation_failed?, "Blank annotation was valid"
+    assert_equal "#{timeout_override_err_prefix}: Cannot parse blank value", customized_resource.validation_error_msg
   end
 
-  def test_validation_of_timeout_annotation
-    expected_cmd = ["create", "-f", "/tmp/foo/bar", "--dry-run", "--output=name", anything]
-    error_msg = "kubernetes-deploy.shopify.io/timeout-override-seconds annotation " \
-      "must contain digits only and must be > 0"
+  def test_lack_of_timeout_annotation_does_not_fail_validation
+    basic_resource = DummyResource.new
+    assert_equal 300, basic_resource.timeout
+    basic_resource.validate_definition
+    refute basic_resource.validation_failed?
+  end
 
-    stub_kubectl_response(*expected_cmd, resp: "{}")
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("sixty"))
-    customized_resource.validate_definition
-    assert customized_resource.validation_failed?, "Annotation with 'sixty' was valid"
-    assert_equal error_msg, customized_resource.validation_error_msg
-
-    stub_kubectl_response(*expected_cmd, resp: "{}")
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("-1"))
+  def test_timeout_override_lower_bound_validation
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("-1S"))
     customized_resource.validate_definition
     assert customized_resource.validation_failed?, "Annotation with '-1' was valid"
-    assert_equal error_msg, customized_resource.validation_error_msg
+    assert_equal "#{timeout_override_err_prefix}: Value must be greater than 0",
+      customized_resource.validation_error_msg
 
-    stub_kubectl_response(*expected_cmd, resp: "{}")
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("0"))
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("0S"))
     customized_resource.validate_definition
     assert customized_resource.validation_failed?, "Annotation with '0' was valid"
-    assert_equal error_msg, customized_resource.validation_error_msg
+    assert_equal "#{timeout_override_err_prefix}: Value must be greater than 0",
+      customized_resource.validation_error_msg
 
-    stub_kubectl_response(*expected_cmd, resp: "{}")
-    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("10m"))
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("1S"))
     customized_resource.validate_definition
-    assert customized_resource.validation_failed?, "Annotation with '10m' was valid"
-    assert_equal error_msg, customized_resource.validation_error_msg
+    refute customized_resource.validation_failed?, "Annotation with '1' was invalid"
+  end
+
+  def test_timeout_override_upper_bound_validation
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("24H1S"))
+    customized_resource.validate_definition
+    assert customized_resource.validation_failed?, "Annotation with '0' was valid"
+    assert_equal "#{timeout_override_err_prefix}: Value must be less than 24h", customized_resource.validation_error_msg
+
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("24H"))
+    customized_resource.validate_definition
+    refute customized_resource.validation_failed?, "Annotation with '24H' was invalid"
   end
 
   def test_annotation_and_kubectl_error_messages_are_combined
-    stub_kubectl_response(
-      "create", "-f", "/tmp/foo/bar", "--dry-run", "--output=name", anything,
-      resp: "{}",
-      err: "Error from kubectl: Something else in this template was not valid",
-      success: false
-    )
-
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("bad"))
+    customized_resource.kubectl.expects(:run).returns([
+      "{}",
+      "Error from kubectl: Something else in this template was not valid",
+      stub(success?: false)
+    ])
+
     customized_resource.validate_definition
     assert customized_resource.validation_failed?, "Expected resource to be invalid"
-
     expected = <<~STRING.strip
-      kubernetes-deploy.shopify.io/timeout-override-seconds annotation must contain digits only and must be > 0
+      #{timeout_override_err_prefix}: Invalid ISO 8601 duration: "BAD"
       Error from kubectl: Something else in this template was not valid
     STRING
     assert_equal expected, customized_resource.validation_error_msg
   end
 
+  def test_calling_timeout_before_validation_with_invalid_annotation_does_not_raise
+    customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("bad"))
+    assert_equal 300, customized_resource.timeout
+    assert_nil customized_resource.timeout_override
+  end
+
+  def test_deploy_timed_out_respects_hardcoded_timeouts
+    Timecop.freeze do
+      dummy = DummyResource.new
+      refute dummy.deploy_timed_out?
+      assert_equal 300, dummy.timeout
+
+      dummy.deploy_started_at = Time.now.utc - 300
+      refute dummy.deploy_timed_out?
+
+      dummy.deploy_started_at = Time.now.utc - 301
+      assert dummy.deploy_timed_out?
+    end
+  end
+
+  def test_deploy_timed_out_respects_annotation_based_timeouts
+    Timecop.freeze do
+      custom_dummy = DummyResource.new(definition_extras: build_timeout_metadata("3s"))
+      refute custom_dummy.deploy_timed_out?
+      assert_equal 3, custom_dummy.timeout
+
+      custom_dummy.deploy_started_at = Time.now.utc - 3
+      refute custom_dummy.deploy_timed_out?
+
+      custom_dummy.deploy_started_at = Time.now.utc - 4
+      assert custom_dummy.deploy_timed_out?
+    end
+  end
+
   private
+
+  def timeout_override_err_prefix
+    "kubernetes-deploy.shopify.io/timeout-override annotation is invalid"
+  end
 
   def build_timeout_metadata(value)
     {


### PR DESCRIPTION
@Shopify/cloudplatform @Shopify/redis-memcached @psycotica0-shopify @kirs 

## What this does

This PR makes it possible to add a `kubernetes-deploy.shopify.io/timeout-override-seconds` annotation to any individual resource. If that annotation is present and valid, its value will be used in place of the global hard timeout for that resource type.

I think this is a reasonable feature even though it may let people shoot themselves/Shipit in the foot with reeeeeaaaaaly long timeouts because:
- We've tinkered with the global timeout on Deployment in the past just for core.
- #225 requested a timeout override for StatefulSets (and the same thing was raised internally for kafka)
- #231 is asking to bump the timout for Redis because of a single instance.
- This gem is open-source, and different organizations may be using it in very different contexts and for deploying very different things.


## Alternatives

* The various pod controllers are the main use case for this override (even Redis is actually watching a deployment), and for those using something like ProgressDeadlineSeconds (which only exists on Deployment) would be ideal. I've seen issues in k8s core about bringing all the workload controllers in line with each other before v1, so presumably this will be an option eventually. But last I checked StatefulSets (for example) still don't have a Progressing condition on k8s core master.
* Make Redis use ProgressDeadlineSeconds (since as mentioned above it is watching a Deployment), and set that value really high on the offending deployment. This isn't crazy... in fact the Redis controller should probably use that strategy when we switch to controller-reported statuses for CRs.
* Implement ProgressDeadlineSeconds-like behaviour for StatefulSets (and possibly other pod controller classes) client-side. I'm hesitant to do this since it would not be straightforward, and the feature is eventually coming upstream (where it belongs). 