### PR TITLE
Add support for labels

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,7 +8,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured')
-      meet: minikube start --vm-driver=xhyve --kubernetes-version=v1.7.5
+      meet: minikube start --vm-driver=hyperkit --kubernetes-version=v1.7.5
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -10,6 +10,7 @@ allow_protected_ns = false
 prune = true
 bindings = {}
 verbose_log_prefix = false
+selector = nil
 
 ARGV.options do |opts|
   opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
@@ -23,6 +24,10 @@ ARGV.options do |opts|
   opts.on("--no-prune", "Disable deletion of resources that do not appear in the template dir") { prune = false }
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
   opts.on("--verbose-log-prefix", "Add [context][namespace] to the log prefix") { verbose_log_prefix = true }
+  opts.on("--selector=SELECTOR", "Ensure that all resources in your template dir match the given selector, " \
+    "and restrict pruning to deployed resources it selects.  (format: k1=v1,k2=v2 or JSON)") do |s|
+    selector = KubernetesDeploy::BindingsParser.parse(s)
+  end
 
   opts.on_tail("-h", "--help", "Print this help") do
     puts opts
@@ -60,7 +65,8 @@ runner = KubernetesDeploy::DeployTask.new(
   current_sha: revision,
   template_dir: template_dir,
   bindings: bindings,
-  logger: logger
+  logger: logger,
+  selector: selector
 )
 
 success = runner.run(

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -6,9 +6,13 @@ require 'optparse'
 require 'kubernetes-deploy'
 require 'kubernetes-deploy/restart_task'
 
-raw_deployments = nil
+deployments = nil
+selector = nil
 ARGV.options do |opts|
-  opts.on("--deployments=LIST") { |v| raw_deployments = v.split(",") }
+  opts.on("--deployments=LIST") { |v| deployments = v.split(",") }
+  opts.on("--selector=SELECTOR", "Restarts deployments matching selector (format: k1=v1,k2=v2 or JSON)") do |s|
+    selector = KubernetesDeploy::BindingsParser.parse(s)
+  end
   opts.parse!
 end
 
@@ -17,5 +21,5 @@ context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
-success = restart.perform(raw_deployments)
+success = restart.perform(deployments: deployments, selector: selector)
 exit 1 unless success

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -26,21 +26,27 @@ module KubernetesDeploy
       @logger = logger
     end
 
-    def perform(deployments_names = nil)
+    # Perform a restart of Kubernetes Deployments.
+    #
+    # deployments is a list of deployment names.
+    # selector is a kubernetes selector, as a hash.
+    # Only one of them can be specified.
+    def perform(deployments: nil, selector: nil)
       start = Time.now.utc
       @logger.reset
 
       @logger.phase_heading("Initializing restart")
       verify_namespace
-      deployments = identify_target_deployments(deployments_names)
+      kubernetes_deployments = identify_target_deployments(deployments, selector)
+
       if kubectl.server_version < Gem::Version.new(MIN_KUBE_VERSION)
         @logger.warn(KubernetesDeploy::Errors.server_version_warning(kubectl.server_version))
       end
       @logger.phase_heading("Triggering restart by touching ENV[RESTARTED_AT]")
-      patch_kubeclient_deployments(deployments)
+      patch_kubeclient_deployments(kubernetes_deployments)
 
       @logger.phase_heading("Waiting for rollout")
-      resources = build_watchables(deployments, start)
+      resources = build_watchables(kubernetes_deployments, start)
       ResourceWatcher.new(resources, logger: @logger, operation_name: "restart").run
       success = resources.all?(&:deploy_succeeded?)
     rescue FatalDeploymentError => error
@@ -55,17 +61,25 @@ module KubernetesDeploy
 
     private
 
-    def identify_target_deployments(deployment_names)
+    def identify_target_deployments(deployment_names, selector)
       if deployment_names.nil?
-        @logger.info("Configured to restart all deployments with the `#{ANNOTATION}` annotation")
-        deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace)
-          .select { |d| d.metadata.annotations[ANNOTATION] }
+        deployments = if selector.nil?
+          @logger.info("Configured to restart all deployments with the `#{ANNOTATION}` annotation")
+          v1beta1_kubeclient.get_deployments(namespace: @namespace)
+        else
+          selector_string = Utils.selector_to_string(selector)
+          @logger.info("Configured to restart all deployments with the `#{ANNOTATION}` annotation and #{selector_string} selector")
+          v1beta1_kubeclient.get_deployments(namespace: @namespace, label_selector: selector_string)
+        end
+        deployments.select! { |d| d.metadata.annotations[ANNOTATION] }
 
         if deployments.none?
           raise FatalRestartError, "no deployments with the `#{ANNOTATION}` annotation found in namespace #{@namespace}"
         end
       elsif deployment_names.empty?
         raise FatalRestartError, "Configured to restart deployments by name, but list of names was blank"
+      elsif !selector.nil?
+        raise FatalRestartError, "Can't specify deployment names and selector at the same time"
       else
         deployment_names = deployment_names.uniq
         list = deployment_names.join(', ')

--- a/lib/kubernetes-deploy/utils.rb
+++ b/lib/kubernetes-deploy/utils.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module KubernetesDeploy
+  module Utils
+    def self.selector_to_string(selector)
+      return "" if selector.nil?
+      selector.map { |k, v| "#{k}=#{v}" }.join(",")
+    end
+  end
+end

--- a/test/fixtures/branched/web.yml.erb
+++ b/test/fixtures/branched/web.yml.erb
@@ -1,0 +1,33 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: <%= branch %>-web
+  labels:
+    app: branched
+    branch: <%= branch %>
+    name: web
+  annotations:
+    shipit.shopify.io/restart: "true"
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 20
+  selector:
+    matchLabels:
+      app: branched
+      branch: <%= branch %>
+      name: web
+  template:
+    metadata:
+      labels:
+        app: branched
+        branch: <%= branch %>
+        name: web
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        env:
+        - name: GITHUB_REV
+          value: "<%= current_sha %>"

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -63,6 +63,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: redis
+  labels:
+    name: redis
+    app: hello-cloud
 spec:
   replicas: 1
   progressDeadlineSeconds: 60

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -34,6 +34,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: hello-cloud
   annotations:
     shipit.shopify.io/restart: "true"
 spec:

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -45,7 +45,7 @@ module FixtureDeployHelper
   end
 
   def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {},
-    sha: nil, kubectl_instance: nil)
+    sha: nil, kubectl_instance: nil, selector: nil)
     current_sha = sha || "k#{SecureRandom.hex(6)}"
     kubectl_instance ||= build_kubectl
 
@@ -56,7 +56,8 @@ module FixtureDeployHelper
       template_dir: dir,
       logger: logger,
       kubectl_instance: kubectl_instance,
-      bindings: bindings
+      bindings: bindings,
+      selector: selector
     )
     deploy.run(
       verify_result: wait,

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -87,6 +87,67 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.assert_poddisruptionbudget
   end
 
+  def test_selector
+    # Deploy the same thing twice with a different selector
+    assert_deploy_success(deploy_fixtures("branched",
+      bindings: { "branch" => "master" },
+      selector: { "branch" => "master" }))
+    assert_deploy_success(deploy_fixtures("branched",
+      bindings: { "branch" => "staging" },
+      selector: { "branch" => "staging" }))
+    deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace, label_selector: "app=branched")
+
+    assert_equal 2, deployments.size
+    assert_equal %w(master staging), deployments.map { |d| d.metadata.labels.branch }.sort
+
+    # Run again without selector to verify pruning works
+    assert_deploy_success(deploy_fixtures("branched", bindings: { "branch" => "master" }))
+    deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace, label_selector: "app=branched")
+
+    assert_equal 1, deployments.size
+    assert_equal "master", deployments.first.metadata.labels.branch
+  end
+
+  def test_mismatched_selector
+    assert_deploy_failure(deploy_fixtures("branched",
+      bindings: { "branch" => "master" },
+      selector: { "branch" => "staging" }))
+    assert_logs_match_all([
+      /Template validation failed/,
+      /Invalid template: Deployment/,
+      /selector branch=staging does not match labels app=branched,branch=master/,
+      /Rendered template content:/,
+    ], in_order: true)
+  end
+
+  def test_mismatched_selector_on_replace_resource_without_labels
+    assert_deploy_failure(deploy_fixtures("hello-cloud",
+      subset: %w(disruption-budgets.yml),
+      selector: { "branch" => "staging" }))
+    assert_logs_match_all([
+      /Template validation failed/,
+      /Invalid template: PodDisruptionBudget/,
+      /selector branch=staging passed in, but no labels were defined/,
+      /Rendered template content:/,
+    ], in_order: true)
+  end
+
+  def test_deploying_to_protected_namespace_with_override_does_not_prune
+    KubernetesDeploy::DeployTask.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do
+      assert_deploy_success(deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: false))
+      hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+      hello_cloud.assert_all_up
+      assert_logs_match_all([
+        /cannot be pruned/,
+        /Please do not deploy to #{@namespace} unless you really know what you are doing/
+      ])
+
+      result = deploy_fixtures("hello-cloud", subset: ["redis.yml"], allow_protected_ns: true, prune: false)
+      assert_deploy_success(result)
+      hello_cloud.assert_all_up
+    end
+  end
+
   def test_refuses_deploy_to_protected_namespace_with_override_if_pruning_enabled
     generated_ns = @namespace
     @namespace = 'default'
@@ -152,7 +213,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
-        "> Error from kubectl:",
+        "> Error:",
         "error validating data: found invalid field myKey for v1.ObjectMeta",
         "> Rendered template content:",
         "      myKey: uhOh"
@@ -161,7 +222,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
-        "> Error from kubectl:",
+        "> Error:",
         "error validating data: ValidationError(ConfigMap.metadata): \
 unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
         "> Rendered template content:",
@@ -195,7 +256,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
         "Command failed: apply -f",
         "WARNING: Any resources not mentioned in the error below were likely created/updated.",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
-        "> Error from kubectl:",
+        "> Error:",
         "    Error from server (BadRequest): error when creating",
         "> Rendered template content:",
         "          not_a_name:",
@@ -204,7 +265,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*\.yml/,
-        "> Error from kubectl:",
+        "> Error:",
         "error validating data: ValidationError(ConfigMap.metadata.labels.name): \
 invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
         "> Rendered template content:",
@@ -245,7 +306,7 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error below were likely created/updated.",
       "Invalid templates: See error message",
-      "> Error from kubectl:",
+      "> Error:",
       '    The Service "web" is invalid:',
       'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"'
     ], in_order: true)
@@ -569,7 +630,7 @@ invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels:",
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error below were likely created/updated.",
       "Invalid templates: See error message",
-      "> Error from kubectl:",
+      "> Error:",
       /The Deployment "web" is invalid.*`selector` does not match template `labels`/
     ], in_order: true)
   end

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -3,6 +3,28 @@ require 'test_helper'
 require 'kubernetes-deploy/restart_task'
 
 class RestartTaskTest < KubernetesDeploy::IntegrationTest
+  def test_restart
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
+
+    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+
+    restart = build_restart_task
+    assert_restart_success(restart.perform(deployments: ["web"]))
+
+    assert_logs_match_all([
+      "Configured to restart deployments by name: web",
+      "Triggered `web` restart",
+      "Waiting for rollout",
+      %r{Successfully restarted in \d+\.\d+s: Deployment/web},
+      "Result: SUCCESS",
+      "Successfully restarted 1 resource",
+      %r{Deployment/web.*1 availableReplica}
+    ],
+      in_order: true)
+
+    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
+  end
+
   def test_restart_by_annotation
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
 
@@ -27,6 +49,35 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     refute fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment"
   end
 
+  def test_restart_by_selector
+    assert_deploy_success(deploy_fixtures("branched",
+      bindings: { "branch" => "master" },
+      selector: { "branch" => "master" }))
+    assert_deploy_success(deploy_fixtures("branched",
+      bindings: { "branch" => "staging" },
+      selector: { "branch" => "staging" }))
+
+    refute fetch_restarted_at("master-web"), "no RESTARTED_AT env on fresh deployment"
+    refute fetch_restarted_at("staging-web"), "no RESTARTED_AT env on fresh deployment"
+
+    restart = build_restart_task
+    assert_restart_success(restart.perform(selector: {name: 'web', branch: 'staging'}))
+
+    assert_logs_match_all([
+      "Configured to restart all deployments with the `shipit.shopify.io/restart` annotation and name=web,branch=staging selector",
+      "Triggered `staging-web` restart",
+      "Waiting for rollout",
+      %r{Successfully restarted in \d\.\ds: Deployment/staging-web},
+      "Result: SUCCESS",
+      "Successfully restarted 1 resource",
+      %r{Deployment/staging-web.*1 availableReplica}
+    ],
+      in_order: true)
+
+    assert fetch_restarted_at("staging-web"), "RESTARTED_AT is present after the restart"
+    refute fetch_restarted_at("master-web"), "no RESTARTED_AT env on fresh deployment"
+  end
+
   def test_restart_by_annotation_none_found
     restart = build_restart_task
     assert_restart_failure(restart.perform)
@@ -44,7 +95,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
 
     restart = build_restart_task
-    assert_restart_success(restart.perform(["web"]))
+    assert_restart_success(restart.perform(deployments: ["web"]))
 
     assert_logs_match_all([
       "Configured to restart deployments by name: web",
@@ -61,7 +112,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert first_restarted_at, "RESTARTED_AT is present after first restart"
 
     Timecop.freeze(1.second.from_now) do
-      assert_restart_success(restart.perform(["web"]))
+      assert_restart_success(restart.perform(deployments: ["web"]))
     end
 
     second_restarted_at = fetch_restarted_at("web")
@@ -75,7 +126,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
 
     restart = build_restart_task
-    assert_restart_success(restart.perform(%w(web web)))
+    assert_restart_success(restart.perform(deployments: %w(web web)))
 
     assert_logs_match_all([
       "Configured to restart deployments by name: web",
@@ -91,7 +142,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
 
   def test_restart_not_existing_deployment
     restart = build_restart_task
-    assert_restart_failure(restart.perform(["web"]))
+    assert_restart_failure(restart.perform(deployments: ["web"]))
     assert_logs_match_all([
       "Configured to restart deployments by name: web",
       "Result: FAILURE",
@@ -104,7 +155,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
 
     restart = build_restart_task
-    assert_restart_failure(restart.perform(%w(walrus web)))
+    assert_restart_failure(restart.perform(deployments: %w(walrus web)))
 
     refute fetch_restarted_at("web"), "no RESTARTED_AT env after failed restart task"
     assert_logs_match_all([
@@ -117,10 +168,20 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
 
   def test_restart_none
     restart = build_restart_task
-    assert_restart_failure(restart.perform([]))
+    assert_restart_failure(restart.perform(deployments: []))
     assert_logs_match_all([
       "Result: FAILURE",
       "Configured to restart deployments by name, but list of names was blank"
+    ],
+      in_order: true)
+  end
+
+  def test_restart_deployments_and_selector
+    restart = build_restart_task
+    assert_restart_failure(restart.perform(deployments: ["web"], selector: {app: 'web'}))
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Can't specify deployment names and selector at the same time"
     ],
       in_order: true)
   end
@@ -131,7 +192,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       namespace: @namespace,
       logger: logger
     )
-    assert_restart_failure(restart.perform(["web"]))
+    assert_restart_failure(restart.perform(deployments: ["web"]))
     assert_logs_match_all([
       "Result: FAILURE",
       "`walrus` context must be configured in your kubeconfig file(s)"
@@ -145,7 +206,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       namespace: "walrus",
       logger: logger
     )
-    assert_restart_failure(restart.perform(["web"]))
+    assert_restart_failure(restart.perform(deployments: ["web"]))
     assert_logs_match_all([
       "Result: FAILURE",
       "Namespace `walrus` not found in context `minikube`"
@@ -174,7 +235,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_deploy_success(success)
 
     restart = build_restart_task
-    assert_restart_failure(restart.perform(%w(web)))
+    assert_restart_failure(restart.perform(deployments: %w(web)))
     assert_logs_match_all([
       "Triggered `web` restart",
       "Deployment/web rollout timed out",

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -163,7 +163,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("bad"))
     customized_resource.kubectl.expects(:run).returns([
       "{}",
-      "Error from kubectl: Something else in this template was not valid",
+      "Error: Something else in this template was not valid",
       stub(success?: false)
     ])
 
@@ -171,7 +171,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     assert customized_resource.validation_failed?, "Expected resource to be invalid"
     expected = <<~STRING.strip
       #{timeout_override_err_prefix}: Invalid ISO 8601 duration: "BAD"
-      Error from kubectl: Something else in this template was not valid
+      Error: Something else in this template was not valid
     STRING
     assert_equal expected, customized_resource.validation_error_msg
   end


### PR DESCRIPTION
This PR adds support for the `--selector` flag, which makes it possible to restrict what resources get pruned on a deployment. It takes in a label selector which is then passed onto `kubectl apply --prune` to restrict which things to delete.

Some unanswered questions:

1. Right now I'm just using the BindingsParser, but I might have to do something else because conceivably you'd also want to be able to do something like `key!=value`.
2. Care needs to be taken when writing a deployment config that uses this feature, because it needs to make sure names don't overlap when deploying the same template multiple times in the same namespace. This gets worse for ejson values, because the names might get overwritten by subsequent deployments without you realizing. Should it maybe fail for ejson if it's going to overwrite a secret that doesn't match the selector?

### Use-case

I want to deploy multiple branches of an application within the same namespace, sharing some resources. The project layout would be something like this:

```
config/
  deploy/
    staging/
      database.yml.erb
      secrets.ejson
      service.yml.erb
    staging-branch/
      service.yml.erb
```

Where I'd run `ENVIRONMENT=staging kubernetes-deploy --selector=shared-resource=true ...` to deploy the shared resources, and then `ENVIRONMENT=staging-branch kubernetes-deploy --selector=branch=name --bindings=branch=name ...` to deploy a single branch. All the resources in the staging folder would have a `shared-resource: 'true'` label defined, and the things in the staging-branch folder would have `branch: <%= branch %>` in their labels.

Right now this isn't possible because the pruning would delete things from the other deployments. After this PR it should be possible.