### PR TITLE
Fetch debug info in parallel

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -142,7 +142,7 @@ module KubernetesDeploy
 
     def sync_debug_info
       @events = fetch_events
-      @logs = fetch_logs if type_supports_logs?
+      @logs = fetch_logs if supports_logs?
       @debug_info_synced = true
     end
 
@@ -173,7 +173,7 @@ module KubernetesDeploy
         helpful_info << "  - Events: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
       end
 
-      if type_supports_logs?
+      if supports_logs?
         if @logs.blank? || @logs.values.all?(&:blank?)
           helpful_info << "  - Logs: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
         else
@@ -328,7 +328,7 @@ module KubernetesDeploy
       file&.close
     end
 
-    def type_supports_logs?
+    def supports_logs?
       respond_to?(:fetch_logs)
     end
 

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -82,6 +82,7 @@ module KubernetesDeploy
 
       if fail_count > 0
         @logger.summary.add_action("failed to #{@operation_name} #{fail_count} #{'resource'.pluralize(fail_count)}")
+        KubernetesDeploy::Concurrency.split_across_threads(failed_resources, &:sync_debug_info)
         failed_resources.each { |r| @logger.summary.add_paragraph(r.debug_message) }
       end
     end

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -42,8 +42,14 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
 
     watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger)
     watcher.run(delay_sync: 0.1)
+    logger.print_summary(false)
 
-    assert_logs_match(/web-pod failed to deploy after \d\.\ds/)
+    assert_logs_match_all([
+      /web-pod failed to deploy after \d\.\ds/,
+      "Result: FAILURE",
+      "Failed to deploy 1 resource",
+      "Something went wrong"
+    ], in_order: true)
   end
 
   def test_timeout_from_resource
@@ -94,6 +100,8 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
   private
 
   MockResource = Struct.new(:id, :hits_to_complete, :status) do
+    attr_reader :debug_message
+
     def sync
       @hits ||= 0
       @hits += 1
@@ -115,8 +123,8 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       hits_to_complete
     end
 
-    def debug_message
-      "Something went wrong"
+    def sync_debug_info
+      @debug_message = "Something went wrong"
     end
 
     def pretty_status


### PR DESCRIPTION
Problem: We noticed that when a bunch (~10) of core's large deployments fail, there can be a 5+ minute delay between the polling loop completing and the statsd metric for completion being emitted. The only interesting thing that happens in that period is the fetching of the debug information (i.e. logs and events). Unlike all the other API call points (validation, syncing), we're still doing this one in serial. We may also want to introduce an option to skip this altogether (or automatically disable it in some circumstance?), but I think not parallelizing here was an oversight to begin with.

@dturn @stefanmb 
cc @Shopify/cloudplatform 