### PR TITLE
Skip collecting logs and events on failure via env var

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -168,35 +168,37 @@ module KubernetesDeploy
 
       if ENV['NO_DEBUG_INFO']
         helpful_info << NO_DEBUG_INFO_MESSAGE
-      else
-        if @events.present?
-          helpful_info << "  - Events (common success events excluded):"
-          @events.each do |identifier, event_hashes|
-            event_hashes.each { |event| helpful_info << "      [#{identifier}]\t#{event}" }
-          end
-        else
-          helpful_info << "  - Events: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
+        return helpful_info.join("\n")
+      end
+
+      if @events.present?
+        helpful_info << "  - Events (common success events excluded):"
+        @events.each do |identifier, event_hashes|
+          event_hashes.each { |event| helpful_info << "      [#{identifier}]\t#{event}" }
         end
+      else
+        helpful_info << "  - Events: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
+      end
 
-        if supports_logs?
-          elsif @logs.blank? || @logs.values.all?(&:blank?)
-            helpful_info << "  - Logs: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
-          else
-            sorted_logs = @logs.sort_by { |_, log_lines| log_lines.length }
-            sorted_logs.each do |identifier, log_lines|
-              if log_lines.empty?
-                helpful_info << "  - Logs from container '#{identifier}': #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
-                next
-              end
+      if supports_logs?
+        if @logs.blank? || @logs.values.all?(&:blank?)
+          helpful_info << "  - Logs: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
+        else
+          sorted_logs = @logs.sort_by { |_, log_lines| log_lines.length }
+          sorted_logs.each do |identifier, log_lines|
+            if log_lines.empty?
+              helpful_info << "  - Logs from container '#{identifier}': #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
+              next
+            end
 
-              helpful_info << "  - Logs from container '#{identifier}' (last #{LOG_LINE_COUNT} lines shown):"
-              log_lines.each do |line|
-                helpful_info << "      #{line}"
-              end
+            helpful_info << "  - Logs from container '#{identifier}' (last #{LOG_LINE_COUNT} lines shown):"
+            log_lines.each do |line|
+              helpful_info << "      #{line}"
             end
           end
         end
       end
+
       helpful_info.join("\n")
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -147,8 +147,6 @@ module KubernetesDeploy
     end
 
     def debug_message
-      sync_debug_info unless @debug_info_synced
-
       helpful_info = []
       if deploy_failed?
         helpful_info << ColorizedString.new("#{id}: FAILED").red
@@ -163,6 +161,9 @@ module KubernetesDeploy
         helpful_info << timeout_message if timeout_message.present? && timeout_message != STANDARD_TIMEOUT_MESSAGE
       end
       helpful_info << "  - Final status: #{status}"
+
+      return helpful_info.join("\n") if ENV['NO_DEBUG_MESSAGES']
+      sync_debug_info unless @debug_info_synced
 
       if @events.present?
         helpful_info << "  - Events (common success events excluded):"

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -14,8 +14,8 @@ module KubernetesDeploy
 
     DISABLE_FETCHING_LOG_INFO = 'DISABLE_FETCHING_LOG_INFO'
     DISABLE_FETCHING_EVENT_INFO = 'DISABLE_FETCHING_EVENT_INFO'
-    DISABLED_LOG_INFO_MESSAGE = "Log collection is disabled by the #{DISABLE_FETCHING_LOG_INFO} env var."
-    DISABLED_EVENT_INFO_MESSAGE = "Event collection is disabled by the #{DISABLE_FETCHING_EVENT_INFO} env var."
+    DISABLED_LOG_INFO_MESSAGE = "collection is disabled by the #{DISABLE_FETCHING_LOG_INFO} env var."
+    DISABLED_EVENT_INFO_MESSAGE = "collection is disabled by the #{DISABLE_FETCHING_EVENT_INFO} env var."
     DEBUG_RESOURCE_NOT_FOUND_MESSAGE = "None found. Please check your usual logging service (e.g. Splunk)."
     UNUSUAL_FAILURE_MESSAGE = <<~MSG
       It is very unusual for this resource type to fail to deploy. Please try the deploy again.
@@ -174,14 +174,14 @@ module KubernetesDeploy
           event_hashes.each { |event| helpful_info << "      [#{identifier}]\t#{event}" }
         end
       elsif ENV[DISABLE_FETCHING_EVENT_INFO]
-        helpful_info << DISABLED_EVENT_INFO_MESSAGE
+        helpful_info << "  - Events: #{DISABLED_EVENT_INFO_MESSAGE}"
       else
         helpful_info << "  - Events: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
       end
 
       if supports_logs?
         if ENV[DISABLE_FETCHING_LOG_INFO]
-          helpful_info << DISABLED_LOG_INFO_MESSAGE
+          helpful_info << "  - Logs: #{DISABLED_LOG_INFO_MESSAGE}"
         elsif @logs.blank? || @logs.values.all?(&:blank?)
           helpful_info << "  - Logs: #{DEBUG_RESOURCE_NOT_FOUND_MESSAGE}"
         else

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -202,7 +202,6 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
       assert_includes dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Unknown\n"
       assert_includes dummy.debug_message, KubernetesDeploy::KubernetesResource::DISABLED_LOG_INFO_MESSAGE
-      refute_includes dummy.debug_message, "- Logs"
     end
   end
 
@@ -213,7 +212,6 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
       assert_includes dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Unknown\n"
       assert_includes dummy.debug_message, KubernetesDeploy::KubernetesResource::DISABLED_EVENT_INFO_MESSAGE
-      refute_includes dummy.debug_message, "- Events"
     end
   end
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -189,8 +189,8 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     dummy.expects(:deploy_failed?).returns(true)
 
     assert_match dummy.debug_message,
-    "DummyResource/test: FAILED\n  - Final status: Unknown\n" +
-    KubernetesDeploy::KubernetesResource::NO_DEBUG_INFO_MESSAGE
+      "DummyResource/test: FAILED\n  - Final status: Unknown\n" +
+      KubernetesDeploy::KubernetesResource::NO_DEBUG_INFO_MESSAGE
   ensure
     ENV['NO_DEBUG_INFO'] = nil
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -183,6 +183,18 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     end
   end
 
+  def test_debug_message_with_no_debug_info
+    ENV['NO_DEBUG_INFO'] = 'true'
+    dummy = DummyResource.new
+    dummy.expects(:deploy_failed?).returns(true)
+
+    assert_match dummy.debug_message,
+    "DummyResource/test: FAILED\n  - Final status: Unknown\n" +
+    KubernetesDeploy::KubernetesResource::NO_DEBUG_INFO_MESSAGE
+  ensure
+    ENV['NO_DEBUG_INFO'] = nil
+  end
+
   private
 
   def timeout_override_err_prefix


### PR DESCRIPTION
When a bunch (~10) of deployments fail, there can be a 5+ minute delay between the polling loop completing and the statsd metric for completion being emitted.  https://github.com/Shopify/kubernetes-deploy/pull/238 sped this up by collecting logs and events in parallel. This PR goes one more step and provides a way to skip this altogether.

Open question: Should this be an env var?

