### PR TITLE
required-rollout takes a percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ before the deployment is considered successful.
   In other words, the number of new pods that must be ready is equal to `spec.replicas` - `strategy.RollingUpdate.maxUnavailable`
   (converted from percentages by rounding up, if applicable). This option is only valid for deployments
   that use the `RollingUpdate` strategy.
-  - number or percent (10 or 10%): Same as `maxUnavailable` except the provided value is used instead of taken from
-  `strategy.RollingUpdate.maxUnavailable`.
+  - Percent (e.g. 90%): The deploy is successful when the number of new pods that must be ready is equal to
+  `spec.replicas` * Percent.
 
 
 ### Running tasks at the beginning of a deploy

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ before the deployment is considered successful.
   In other words, the number of new pods that must be ready is equal to `spec.replicas` - `strategy.RollingUpdate.maxUnavailable`
   (converted from percentages by rounding up, if applicable). This option is only valid for deployments
   that use the `RollingUpdate` strategy.
-  - Percent (e.g. 90%): The deploy is successful when the number of new pods that must be ready is equal to
+  - Percent (e.g. 90%): The deploy is successful when the number of new pods that are ready is equal to
   `spec.replicas` * Percent.
 
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ before the deployment is considered successful.
   In other words, the number of new pods that must be ready is equal to `spec.replicas` - `strategy.RollingUpdate.maxUnavailable`
   (converted from percentages by rounding up, if applicable). This option is only valid for deployments
   that use the `RollingUpdate` strategy.
+  - number or percent (10 or 10%): Same as `maxUnavailable` except the provided value is used instead of taken from
+  `strategy.RollingUpdate.maxUnavailable`.
 
 
 ### Running tasks at the beginning of a deploy

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -48,15 +48,14 @@ module KubernetesDeploy
     def deploy_succeeded?
       return false unless @latest_rs.present?
 
-      case required_rollout
-      when 'full'
+      if required_rollout == 'full'
         @latest_rs.deploy_succeeded? &&
         @latest_rs.desired_replicas == @desired_replicas && # latest RS fully scaled up
         @rollout_data["updatedReplicas"].to_i == @desired_replicas &&
         @rollout_data["updatedReplicas"].to_i == @rollout_data["availableReplicas"].to_i
-      when 'none'
+      elsif required_rollout == 'none'
         true
-      when 'maxUnavailable'
+      elsif required_rollout == 'maxUnavailable' || number_or_percent(required_rollout)
         minimum_needed = min_available_replicas
 
         @latest_rs.desired_replicas >= minimum_needed &&
@@ -102,7 +101,7 @@ module KubernetesDeploy
     def validate_definition
       super
 
-      unless REQUIRED_ROLLOUT_TYPES.include?(required_rollout)
+      unless REQUIRED_ROLLOUT_TYPES.include?(required_rollout) || number_or_percent(required_rollout)
         @validation_errors << rollout_annotation_err_msg
       end
 
@@ -168,16 +167,27 @@ module KubernetesDeploy
     end
 
     def min_available_replicas
-      if @max_unavailable =~ /%/
-        (@desired_replicas * (100 - @max_unavailable.to_i) / 100.0).ceil
+      if max_unavailable =~ /%/
+        (@desired_replicas * (100 - max_unavailable.to_i) / 100.0).ceil
       else
-        @desired_replicas - @max_unavailable.to_i
+        @desired_replicas - max_unavailable.to_i
+      end
+    end
+
+    def max_unavailable
+      if number_or_percent(required_rollout)
+        required_rollout
+      else
+        @max_unavailable
       end
     end
 
     def required_rollout
-      @definition.dig('metadata', 'annotations', REQUIRED_ROLLOUT_ANNOTATION).presence ||
-      DEFAULT_REQUIRED_ROLLOUT
+      @definition.dig('metadata', 'annotations', REQUIRED_ROLLOUT_ANNOTATION).presence || DEFAULT_REQUIRED_ROLLOUT
+    end
+
+    def number_or_percent(value)
+      value.to_i.to_s == value || value.to_s =~ /%/
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -181,7 +181,7 @@ module KubernetesDeploy
     end
 
     def percent?(value)
-      value =~ /%/
+      value =~ /\d+%/
     end
   end
 end


### PR DESCRIPTION
#208 added the `kubernetes-deploy.shopify.io/required-rollout` annotation. There is a corner case when  `maxUnavailable` is `0%` and the annotation becomes a no-op. This PR allows a user to specify a number or a percent (e.g. `10` or `15%` ) to the annotation instead of using the value from `maxUnavailable`. 

Previously there was a concern that allowing users to provide their own value would allow the user to  🔫 👣  . Would it be better if this feature required `maxUnavailable` to be `0%` / only took a `%`? That would limit the blast radius. 

cc: @dwradcliffe 
