### PR TITLE
Don't blow up when no pods retrieved for DS

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -37,6 +37,7 @@ module KubernetesDeploy
     end
 
     def fetch_logs
+      return {} unless @pods.present?
       most_useful_pod = @pods.find(&:deploy_failed?) || @pods.find(&:deploy_timed_out?) || @pods.first
       most_useful_pod.fetch_logs
     end


### PR DESCRIPTION
As seen in a cluster-services deploy:

```ruby
lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb:41:in `fetch_logs': undefined method `fetch_logs' for nil:NilClass (NoMethodError)
	from lib/kubernetes-deploy/kubernetes_resource.rb:149:in `sync_debug_info'
	from lib/kubernetes-deploy/concurrency.rb:13:in `each'
	from lib/kubernetes-deploy/concurrency.rb:13:in `block (2 levels) in split_across_threads'
```