### PR TITLE
Use a new exit code for failures due to timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+### 0.17.1
+*Features*
+- kubernetes-restart and kubernetes-deploy use exit code 124 when a
+deploy fails due to one or more resources failing to deploy in time.
+([#244](https://github.com/Shopify/kubernetes-deploy/pull/244))
+
 ### 0.17.0
 *Enhancements*
 
-- Add the `--cascade` when we force replace a resource. ([#250](https://github.com/Shopify/kubernetes-deploy/pull/250))
+- Add the `--cascade` flag when we force replace a resource. ([#250](https://github.com/Shopify/kubernetes-deploy/pull/250))
 
 ### 0.16.0
 **Important:** This release changes the officially supported Kubernetes versions to v1.7 through v1.9. Other versions may continue to work, but we are no longer running our test suite against them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.17.1
 *Features*
-- kubernetes-restart and kubernetes-deploy use exit code 124 when a
+- kubernetes-restart and kubernetes-deploy use exit code 70 when a
 deploy fails due to one or more resources failing to deploy in time.
 ([#244](https://github.com/Shopify/kubernetes-deploy/pull/244))
 

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -63,9 +63,14 @@ runner = KubernetesDeploy::DeployTask.new(
   logger: logger
 )
 
-success = runner.run(
+success, err = runner.run(
   verify_result: !skip_wait,
   allow_protected_ns: allow_protected_ns,
   prune: prune
 )
-exit 1 unless success
+
+if err == :timeout
+  exit 2
+elsif !success
+  exit 1
+end

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -63,11 +63,14 @@ runner = KubernetesDeploy::DeployTask.new(
   logger: logger
 )
 
-success, error = runner.run(
-  verify_result: !skip_wait,
-  allow_protected_ns: allow_protected_ns,
-  prune: prune
-)
-
-exit 2 if error.is_a?(KubernetesDeploy::DeploymentTimeoutError)
-exit 1 unless success
+begin
+  runner.run!(
+    verify_result: !skip_wait,
+    allow_protected_ns: allow_protected_ns,
+    prune: prune
+  )
+rescue KubernetesDeploy::DeploymentTimeoutError
+  exit 124
+rescue KubernetesDeploy::FatalDeploymentError
+  exit 1
+end

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -69,8 +69,5 @@ success, error = runner.run(
   prune: prune
 )
 
-if error == :timeout
-  exit 2
-elsif !success
-  exit 1
-end
+exit 2 if error.is_a?(KubernetesDeploy::DeploymentTimeoutError)
+exit 1 unless success

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -70,7 +70,7 @@ begin
     prune: prune
   )
 rescue KubernetesDeploy::DeploymentTimeoutError
-  exit 124
+  exit 70
 rescue KubernetesDeploy::FatalDeploymentError
   exit 1
 end

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -63,13 +63,13 @@ runner = KubernetesDeploy::DeployTask.new(
   logger: logger
 )
 
-success, err = runner.run(
+success, error = runner.run(
   verify_result: !skip_wait,
   allow_protected_ns: allow_protected_ns,
   prune: prune
 )
 
-if err == :timeout
+if error == :timeout
   exit 2
 elsif !success
   exit 1

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -17,7 +17,10 @@ context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
-success, error = restart.perform(raw_deployments)
-
-exit 2 if error.is_a?(KubernetesDeploy::DeploymentTimeoutError)
-exit 1 unless success
+begin
+  restart.perform!(raw_deployments)
+rescue KubernetesDeploy::DeploymentTimeoutError
+  exit 124
+rescue KubernetesDeploy::FatalDeploymentError
+  exit 1
+end

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -19,8 +19,5 @@ logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
 success, error = restart.perform(raw_deployments)
 
-if error == :timeout
-  exit 2
-elsif !success
-  exit 1
-end
+exit 2 if error.is_a?(KubernetesDeploy::DeploymentTimeoutError)
+exit 1 unless success

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -20,7 +20,7 @@ restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: conte
 begin
   restart.perform!(raw_deployments)
 rescue KubernetesDeploy::DeploymentTimeoutError
-  exit 124
+  exit 70
 rescue KubernetesDeploy::FatalDeploymentError
   exit 1
 end

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -17,5 +17,10 @@ context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger)
-success = restart.perform(raw_deployments)
-exit 1 unless success
+success, error = restart.perform(raw_deployments)
+
+if error == :timeout
+  exit 2
+elsif !success
+  exit 1
+end

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -41,7 +41,7 @@ module KubernetesDeploy
         level = :info
       elsif status == :timed_out
         heading("Result: ", status_string, :yellow)
-        level = :warn
+        level = :fatal
       else
         heading("Result: ", status_string, :red)
         level = :fatal

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -39,6 +39,9 @@ module KubernetesDeploy
       if status == :success
         heading("Result: ", status_string, :green)
         level = :info
+      elsif status == :timed_out
+        heading("Result: ", status_string, :yellow)
+        level = :warn
       else
         heading("Result: ", status_string, :red)
         level = :fatal

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -34,12 +34,13 @@ module KubernetesDeploy
     end
 
     # Outputs the deferred summary information saved via @logger.summary.add_action and @logger.summary.add_paragraph
-    def print_summary(success)
-      if success
-        heading("Result: ", "SUCCESS", :green)
+    def print_summary(status)
+      status_string = status.to_s.humanize.upcase
+      if status == :success
+        heading("Result: ", status_string, :green)
         level = :info
       else
-        heading("Result: ", "FAILURE", :red)
+        heading("Result: ", status_string, :red)
         level = :fatal
       end
 

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -180,7 +180,7 @@ module KubernetesDeploy
       raise
     rescue FatalDeploymentError => error
       @logger.summary.add_action(error.message) if error.message.present?
-      ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:#{failed}")
+      ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
       success = false
       raise
     ensure

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -169,22 +169,19 @@ module KubernetesDeploy
           This means the desired changes were communicated to Kubernetes, but the deploy did not make sure they actually succeeded.
         MSG
         @logger.summary.add_paragraph(ColorizedString.new(warning).yellow)
-        success = true
       end
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:success")
-      success
+      @logger.print_summary(:success)
     rescue DeploymentTimeoutError => error
-      success = false
       @logger.summary.add_action(error.message)
+      @logger.print_summary(:timed_out)
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:timeout")
       raise
     rescue FatalDeploymentError => error
       @logger.summary.add_action(error.message) if error.message.present?
+      @logger.print_summary(:failure)
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
-      success = false
       raise
-    ensure
-      @logger.print_summary(success)
     end
 
     private

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -9,7 +9,7 @@ module KubernetesDeploy
     end
   end
 
-  class DeploymentTimeoutError < StandardError
+  class DeploymentTimeoutError < FatalDeploymentError
     attr_reader :resources
     def initialize(resources)
       @resources = resources

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -8,6 +8,15 @@ module KubernetesDeploy
       super("Namespace `#{name}` not found in context `#{context}`")
     end
   end
+
+  class DeploymentTimeoutError < StandardError
+    attr_reader :resources
+    def initialize(resources)
+      @resources = resources
+      super("Resources #{@resources.map(&:name).join(',')} failed due to timeouts.")
+    end
+  end
+
   module Errors
     extend self
     def server_version_warning(server_version)

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -13,7 +13,7 @@ module KubernetesDeploy
     attr_reader :resources
     def initialize(resources)
       @resources = resources
-      super("Resources #{@resources.map(&:name).join(',')} failed due to timeouts.")
+      super("Timed out waiting for #{@resources.count} resources.")
     end
   end
 

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -55,6 +55,7 @@ module KubernetesDeploy
       status = success ? "success" : "failed"
       tags = %W(namespace:#{@namespace} context:#{@context} status:#{status} deployments:#{deployments.to_a.length}})
       ::StatsD.measure('restart.duration', StatsD.duration(start), tags: tags)
+      [success, error]
     end
 
     private

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -56,7 +56,7 @@ module KubernetesDeploy
       end
       raise FatalDeploymentError unless success
       success
-    rescue DeploymentTimeoutError
+    rescue DeploymentTimeoutError => error
       success = false
       @logger.summary.add_action(error.message)
       raise

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -26,8 +26,8 @@ module FixtureDeployHelper
   #     pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
-  def deploy_fixtures(set, subset: nil, **args) # extra args are passed through to deploy_dir_without_profiling
-    success, _ = deploy_fixtures_with_error(set, subset: subset, **args)
+  def deploy_fixtures(set, subset: nil, **args, &block) # extra args are passed through to deploy_dir_without_profiling
+    success, _ = deploy_fixtures_with_error(set, subset: subset, **args, &block)
     success
   end
 

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -27,7 +27,8 @@ module FixtureDeployHelper
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
   def deploy_fixtures(set, subset: nil, **args, &block) # extra args are passed through to deploy_dir_without_profiling
-    success, _ = deploy_fixtures_with_error(set, subset: subset, **args, &block)
+    success, error = deploy_fixtures_with_error(set, subset: subset, **args, &block)
+    assert_nil error
     success
   end
 

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -27,8 +27,7 @@ module FixtureDeployHelper
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
   def deploy_fixtures(set, subset: nil, **args, &block) # extra args are passed through to deploy_dir_without_profiling
-    success, error = deploy_fixtures_with_error(set, subset: subset, **args, &block)
-    assert_nil error
+    success, _ = deploy_fixtures_with_error(set, subset: subset, **args, &block)
     success
   end
 

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -26,24 +26,18 @@ module FixtureDeployHelper
   #     pod = fixtures["unmanaged-pod.yml.erb"]["Pod"].first
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
-  def deploy_fixtures(set, subset: nil, **args, &block) # extra args are passed through to deploy_dir_without_profiling
-    success, _ = deploy_fixtures_with_error(set, subset: subset, **args, &block)
-    success
-  end
-
-  def deploy_fixtures_with_error(set, subset: nil, **args)
+  def deploy_fixtures(set, subset: nil, **args) # extra args are passed through to deploy_dir_without_profiling
     fixtures = load_fixtures(set, subset)
     raise "Cannot deploy empty template set" if fixtures.empty?
 
     yield fixtures if block_given?
 
     success = false
-    error = nil
     Dir.mktmpdir("fixture_dir") do |target_dir|
       write_fixtures_to_dir(fixtures, target_dir)
-      success, error = deploy_dir(target_dir, args)
+      success = deploy_dir(target_dir, args)
     end
-    [success, error]
+    success
   end
 
   def deploy_raw_fixtures(set, wait: true, bindings: {})

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -27,17 +27,23 @@ module FixtureDeployHelper
   #     pod["spec"]["containers"].first["image"] = "hello-world:thisImageIsBad"
   #   end
   def deploy_fixtures(set, subset: nil, **args) # extra args are passed through to deploy_dir_without_profiling
+    success, _ = deploy_fixtures_with_error(set, subset: subset, **args)
+    success
+  end
+
+  def deploy_fixtures_with_error(set, subset: nil, **args)
     fixtures = load_fixtures(set, subset)
     raise "Cannot deploy empty template set" if fixtures.empty?
 
     yield fixtures if block_given?
 
     success = false
+    error = nil
     Dir.mktmpdir("fixture_dir") do |target_dir|
       write_fixtures_to_dir(fixtures, target_dir)
-      success = deploy_dir(target_dir, args)
+      success, error = deploy_dir(target_dir, args)
     end
-    success
+    [success, error]
   end
 
   def deploy_raw_fixtures(set, wait: true, bindings: {})

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -382,7 +382,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       container = deployment['spec']['template']['spec']['containers'].first
       container['readinessProbe'] = { "exec" => { "command" => ['- ls'] } }
     end
-    assert_deploy_failure(result, :timeout)
+    assert_deploy_failure(result, :timed_out)
 
     assert_logs_match_all([
       'Deployment/undying: TIMED OUT (progress deadline: 10s)',
@@ -765,7 +765,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
   def test_resource_quotas_are_deployed_first
     result = deploy_fixtures("resource-quota")
-    assert_deploy_failure(result, :timeout)
+    assert_deploy_failure(result, :timed_out)
     assert_logs_match_all([
       "Predeploying priority resources",
       "Deploying ResourceQuota/resource-quotas (timeout: 30s)",

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -390,7 +390,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       container['readinessProbe'] = { "exec" => { "command" => ['- ls'] } }
     end
     assert_deploy_failure(result)
-    assert_equal error, :timeout
+    assert_kind_of KubernetesDeploy::DeploymentTimeoutError, error
 
     assert_logs_match_all([
       'Deployment/undying: TIMED OUT (progress deadline: 10s)',
@@ -404,7 +404,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       container["image"] = "some-invalid-image:badtag"
     end
     assert_deploy_failure(result)
-    refute_equal error, :timeout
+    assert_nil error
   end
 
   def test_wait_false_ignores_non_priority_resource_failures

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -143,7 +143,9 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_invalid_yaml_in_partial_prints_helpful_error
-    refute deploy_raw_fixtures("invalid-partials")
+    success, _ = deploy_raw_fixtures("invalid-partials")
+
+    refute success
     assert_logs_match_all([
       "Result: FAILURE",
       %r{Template '.*/partials/invalid.yml.erb' cannot be rendered \(included from: include-invalid-partial.yml.erb\)},
@@ -162,7 +164,9 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_missing_nested_partial_prints_helpful_error
-    refute deploy_raw_fixtures("missing-partials")
+    success, _ = deploy_raw_fixtures("missing-partials")
+
+    refute success
     assert_logs_match_all([
       "Result: FAILURE",
       %r{Could not find partial 'missing' in any of.*fixtures/missing-partials/partials:.*/fixtures/partials},
@@ -400,7 +404,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       container["image"] = "some-invalid-image:badtag"
     end
     assert_deploy_failure(result)
-    assert_equal error, nil
+    refute_equal error, :timeout
   end
 
   def test_wait_false_ignores_non_priority_resource_failures
@@ -818,7 +822,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_partials
-    result = deploy_raw_fixtures("test-partials", bindings: { 'supports_partials' => 'true' })
+    result, _ = deploy_raw_fixtures("test-partials", bindings: { 'supports_partials' => 'true' })
     assert_deploy_success(result)
     assert_logs_match_all([
       "log from pod1",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -100,14 +100,6 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       in_order: true)
   end
 
-  def test_restart_error_nil_when_not_timeout
-    restart = build_restart_task
-    success, error = restart.perform(["web"])
-
-    assert_equal success, false
-    refute_kind_of KubernetesDeploy::DeploymentTimeoutError, error
-  end
-
   def test_restart_one_not_existing_deployment
     assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
 
@@ -182,10 +174,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_deploy_success(success)
 
     restart = build_restart_task
-    status, error = restart.perform(%w(web))
+    assert_raises(KubernetesDeploy::DeploymentTimeoutError) { restart.perform!(%w(web)) }
 
-    assert_equal false, status
-    assert_kind_of KubernetesDeploy::DeploymentTimeoutError, error
     assert_logs_match_all([
       "Triggered `web` restart",
       "Deployment/web rollout timed out",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -105,7 +105,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     success, error = restart.perform(["web"])
 
     assert_equal success, false
-    refute_equal error, :timeout
+    assert_nil error
   end
 
   def test_restart_one_not_existing_deployment
@@ -185,7 +185,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     status, error = restart.perform(%w(web))
 
     assert_equal false, status
-    assert_equal :timeout, error
+    assert_kind_of KubernetesDeploy::DeploymentTimeoutError, error
     assert_logs_match_all([
       "Triggered `web` restart",
       "Deployment/web rollout timed out",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -100,6 +100,14 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       in_order: true)
   end
 
+  def test_restart_error_nil_when_not_timeout
+    restart = build_restart_task
+    success, error = restart.perform(["web"])
+
+    assert_equal success, false
+    refute_equal error, :timeout
+  end
+
   def test_restart_one_not_existing_deployment
     assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
 
@@ -174,7 +182,10 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_deploy_success(success)
 
     restart = build_restart_task
-    assert_restart_failure(restart.perform(%w(web)))
+    status, error = restart.perform(%w(web))
+
+    assert_equal false, status
+    assert_equal :timeout, error
     assert_logs_match_all([
       "Triggered `web` restart",
       "Deployment/web rollout timed out",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -105,7 +105,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     success, error = restart.perform(["web"])
 
     assert_equal success, false
-    assert_nil error
+    refute_kind_of KubernetesDeploy::DeploymentTimeoutError, error
   end
 
   def test_restart_one_not_existing_deployment

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -179,7 +179,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Triggered `web` restart",
       "Deployment/web rollout timed out",
-      "Result: FAILURE",
+      "Result: TIMED OUT",
       "Failed to restart 1 resource",
       "Deployment/web: TIMED OUT",
       "The following containers have not passed their readiness probes",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,9 +109,10 @@ module KubernetesDeploy
       end
 
       logging_assertion do |logs|
-        assert_match(/failed due to timeouts./, logs) if cause == :timeout
+        cause_string = cause == :timed_out ? "TIMED OUT" : "FAILURE"
+        assert_match Regexp.new("Result: #{cause_string}"), logs,
+          "'Result: #{cause_string}' not found in the following logs:\n#{logs}"
         assert_equal false, result, "Deploy succeeded when it was expected to fail. Logs:\n#{logs}"
-        assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
       end
     end
     alias_method :assert_restart_failure, :assert_deploy_failure

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,22 +102,19 @@ module KubernetesDeploy
       end
     end
 
-    def assert_deploy_failure(result)
+    def assert_deploy_failure(result, cause = nil)
       if ENV["PRINT_LOGS"]
         assert_equal false, result, "Deploy succeeded when it was expected to fail"
         return
       end
 
       logging_assertion do |logs|
+        assert_match(/failed due to timeouts./, logs) if cause == :timeout
         assert_equal false, result, "Deploy succeeded when it was expected to fail. Logs:\n#{logs}"
         assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
       end
     end
-
-    def assert_restart_failure(result)
-      success, _ = result
-      assert_deploy_failure(success)
-    end
+    alias_method :assert_restart_failure, :assert_deploy_failure
 
     def assert_deploy_success(result)
       if ENV["PRINT_LOGS"]
@@ -130,11 +127,7 @@ module KubernetesDeploy
         assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
       end
     end
-
-    def assert_restart_success(result)
-      success, _ = result
-      assert_deploy_success(success)
-    end
+    alias_method :assert_restart_success, :assert_deploy_success
 
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -113,7 +113,11 @@ module KubernetesDeploy
         assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
       end
     end
-    alias_method :assert_restart_failure, :assert_deploy_failure
+
+    def assert_restart_failure(result)
+      success, _ = result
+      assert_deploy_failure(success)
+    end
 
     def assert_deploy_success(result)
       if ENV["PRINT_LOGS"]
@@ -126,7 +130,11 @@ module KubernetesDeploy
         assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
       end
     end
-    alias_method :assert_restart_success, :assert_deploy_success
+
+    def assert_restart_success(result)
+      success, _ = result
+      assert_deploy_success(success)
+    end
 
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -42,7 +42,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
 
     watcher = KubernetesDeploy::ResourceWatcher.new([resource], logger: logger)
     watcher.run(delay_sync: 0.1)
-    logger.print_summary(false)
+    logger.print_summary(:failure)
 
     assert_logs_match_all([
       /web-pod failed to deploy after \d\.\ds/,


### PR DESCRIPTION
Pulled from https://github.com/Shopify/kubernetes-deploy/issues/229 `Different exit status for failures and timeouts`. This is technically a breaking change, but probably not one that will impact many people. 