### PR TITLE
Support deploying identical images during a single deployment.

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -19,6 +19,7 @@ require 'kubernetes-deploy/statsd'
 require 'kubernetes-deploy/concurrency'
 require 'kubernetes-deploy/bindings_parser'
 require 'kubernetes-deploy/duration_parser'
+require 'kubernetes-deploy/docker_registry'
 
 module KubernetesDeploy
   MIN_KUBE_VERSION = '1.7.0'

--- a/lib/kubernetes-deploy/docker_registry.rb
+++ b/lib/kubernetes-deploy/docker_registry.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'net/https'
+require 'json'
+
+module KubernetesDeploy
+  module DockerRegistry
+    extend self
+
+    def image_digest(image_url)
+      response = authenticated_request(manifest_url(image_url))
+      response["docker-content-digest"]
+    end
+
+    def image_with_digest(image_url, digest = nil)
+      info = url_info(image_url)
+      digest ||= image_digest(image_url)
+      iwd = String.new
+      if (host = info[:registry]) && host != DOCKER_HUB_HOST
+        iwd << host << "/"
+      end
+      if (user = info[:user]) && (user != "library" || iwd != "")
+        iwd << user << "/"
+      end
+      "#{iwd}#{info[:image]}@#{digest}"
+    end
+
+    private
+
+    DOCKER_HUB_HOST = "registry.hub.docker.com"
+    IMAGE_SPEC = %r{\A(((?<registry>[^:/@]+([:]\d+)?)/)?((?<user>[^:/@]+)/))?
+                      (?<image>[^:/@]+)(([:](?<tag>.+))|(@(?<digest>.+)))?\z}x
+
+    def url_info(image_url)
+      md = IMAGE_SPEC.match(image_url)
+      matches = md.names.zip(md.captures).each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      raise "Invalid image specification: #{image_url}" unless matches[:image]
+
+      matches[:registry] ||= DOCKER_HUB_HOST
+      matches[:user] ||= "library"
+      matches[:tag] ||= "latest" unless matches[:digest]
+      matches
+    end
+
+    def manifest_url(image_url)
+      u = url_info(image_url)
+      "https://#{u[:registry]}/v2/#{u[:user]}/#{u[:image]}/manifests/" + (u[:tag] || u[:digest])
+    end
+
+    def bearer_field(bearer, name)
+      bearer.scan(/#{name}="([^"]*)"/).last.first
+    end
+
+    def get_token(bearer)
+      realm = bearer_field(bearer, "realm")
+      service = bearer_field(bearer, "service")
+      scope = bearer_field(bearer, "scope")
+      uri = URI.parse(realm)
+      uri.query = URI.encode_www_form(service: service, scope: scope)
+      response = Net::HTTP.get_response(uri)
+      return JSON.parse(response.body)['token'] if response.code.to_i == 200
+      raise "Could no obtain token from '#{realm}'"
+    end
+
+    def authenticated_request(url, headers = {})
+      headers = headers.merge("Accept": "application/vnd.docker.distribution.manifest.v2+json")
+
+      uri = URI.parse(url)
+      response = nil
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        loop do
+          request = Net::HTTP::Get.new uri
+          headers.each { |k, v| request[k] = v }
+          response = http.request request
+          if %w(301 302 307).include?(response.code)
+            uri = URI.parse(response['location'])
+          else
+            break
+          end
+        end
+      end
+      return response if response.code.to_i == 200
+
+      # Authentication error interception
+      if response.code.to_i == 401 && headers["Authorization"].nil?
+        auth_token = response["www-authenticate"]
+        req_token = get_token(auth_token)
+        new_headers = headers.merge("Authorization" => "Bearer #{req_token}")
+        return authenticated_request(url, new_headers)
+      end
+
+      raise "Could not perform request '#{url}', response: #{response.code} #{response.message}"
+    end
+  end
+end

--- a/lib/kubernetes-deploy/renderer.rb
+++ b/lib/kubernetes-deploy/renderer.rb
@@ -68,6 +68,10 @@ module KubernetesDeploy
       raise InvalidPartialError, "Template '#{partial_path}' cannot be rendered"
     end
 
+    def image_with_digest(image)
+      @image_digests[image] ||= KubernetesDeploy::DockerRegistry.image_with_digest(image)
+    end
+
     private
 
     def template_variables
@@ -110,6 +114,10 @@ module KubernetesDeploy
 
       def partial(partial, locals = {})
         @_renderer.render_partial(partial, locals)
+      end
+
+      def image_with_digest(image)
+        @_renderer.image_with_digest(image)
       end
     end
   end

--- a/test/fixtures/test-partials/partials/sleepy-pod-spec.yaml.erb
+++ b/test/fixtures/test-partials/partials/sleepy-pod-spec.yaml.erb
@@ -1,5 +1,5 @@
 containers:
 - name: sleepy-guy
-  image: busybox
+  image: <%= image_with_digest("busybox") =>
   imagePullPolicy: IfNotPresent
   command: ["sleep", "8000"]

--- a/test/integration/docker_registry_test.rb
+++ b/test/integration/docker_registry_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class KubernetesDockerRegistryTest < KubernetesDeploy::IntegrationTest
+  def test_we_can_retrieve_image_digests
+    digest = image_digest("busybox")
+    assert !digest.nil?
+    assert_equal digest, image_digest("busybox:latest")
+    assert_equal digest, image_digest("library/busybox")
+    assert_equal digest, image_digest("library/busybox:latest")
+    assert_equal digest, image_digest("registry.hub.docker.com/library/busybox")
+    assert_equal digest, image_digest("registry.hub.docker.com/library/busybox:latest")
+  end
+
+  def test_we_can_create_image_references_using_digests
+    digest = image_digest("busybox")
+    assert !digest.nil?
+    assert_equal "busybox@#{digest}", image_with_digest("busybox")
+    assert_equal "busybox@#{digest}", image_with_digest("busybox:latest")
+    assert_equal "busybox@#{digest}", image_with_digest("library/busybox")
+    assert_equal "busybox@#{digest}", image_with_digest("library/busybox:latest")
+    assert_equal "busybox@#{digest}", image_with_digest("registry.hub.docker.com/library/busybox")
+    assert_equal "busybox@#{digest}", image_with_digest("registry.hub.docker.com/library/busybox:latest")
+  end
+
+  private
+
+  def image_digest(image)
+    KubernetesDeploy::DockerRegistry.image_digest(image)
+  end
+
+  def image_with_digest(image)
+    KubernetesDeploy::DockerRegistry.image_with_digest(image)
+  end
+end


### PR DESCRIPTION
Docker image tags, such as "latest", or a version numbering scheme like
"v1", "v2", etc., are not guaranteed to be stable. This means that when
someone pushes to the docker registry during an ongoing deployment, one
might end up with different containers on different hosts, which makes
it really hard to reason about system properties.

Fortunately, this problem can be circumvented by using docker's sha256
notation for image references. However, sha256 references are unwieldy
for humans.

This commit introduces a helper function which can used in ERB snippets
inside YAML templates to convert image references into sha256 form
automatically.

Example:

<%= image_with_digest("busybox:latest") %>

gets transformed into something like this:

busybox@sha256:187c294487772d71eb5e6675f31e8863fcd655e44f634ffbc92ed30f407a1b9d

The feature is implemented using the docker registry API to retrieve the
image shas exactly once during a deployment and works for docker hub and
private registries.