### PR TITLE
Unify render errors and handle an edge case

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -187,15 +187,6 @@ module KubernetesDeploy
 
     private
 
-    # Inspect the file referenced in the kubectl stderr
-    # to make it easier for developer to understand what's going on
-    def find_bad_files_from_kubectl_output(stderr)
-      # stderr often contains one or more lines like the following, from which we can extract the file path(s):
-      # Error from server (TypeOfError): error when creating "/path/to/service-gqq5oh.yml": Service "web" is invalid:
-      matches = stderr.scan(%r{"(/\S+\.ya?ml\S*)"})
-      matches&.flatten
-    end
-
     def deploy_has_priority_resources?(resources)
       resources.any? { |r| PREDEPLOY_SEQUENCE.include?(r.type) }
     end
@@ -225,7 +216,8 @@ module KubernetesDeploy
       return unless failed_resources.present?
 
       failed_resources.each do |r|
-        record_invalid_template(r.validation_error_msg, file_paths: [r.file_path])
+        content = File.read(r.file_path) if File.file?(r.file_path)
+        record_invalid_template(err: r.validation_error_msg, filename: File.basename(r.file_path), content: content)
       end
       raise FatalDeploymentError, "Template validation failed"
     end
@@ -244,10 +236,6 @@ module KubernetesDeploy
         end
       end
       resources
-    rescue InvalidTemplateError => e
-      debug_msg = paragraph_for_invalid_templates(e.message, filenames: [e.filename], content: e.content)
-      @logger.summary.add_paragraph(debug_msg)
-      raise FatalDeploymentError, "Failed to render and parse template"
     end
 
     def split_templates(filename)
@@ -261,29 +249,19 @@ module KubernetesDeploy
         end
         yield doc
       end
+    rescue InvalidTemplateError => e
+      record_invalid_template(err: e.message, filename: e.filename, content: e.content)
+      raise FatalDeploymentError, "Failed to render and parse template"
     rescue Psych::SyntaxError => e
-      raise InvalidTemplateError.new(e, filename: filename, content: rendered_content)
+      record_invalid_template(err: e.message, filename: filename, content: rendered_content)
+      raise FatalDeploymentError, "Failed to render and parse template"
     end
 
-    def record_invalid_template(err, file_paths:, original_filenames: nil)
-      template_names = Array(original_filenames)
-      file_content = Array(file_paths).each_with_object([]) do |file_path, contents|
-        next unless File.file?(file_path)
-        contents << File.read(file_path)
-        template_names << File.basename(file_path) unless original_filenames
-      end.join("\n")
-      debug_msg = paragraph_for_invalid_templates(err, filenames: template_names, content: file_content)
-      @logger.summary.add_paragraph(debug_msg)
-    end
-
-    def paragraph_for_invalid_templates(err, filenames:, content:)
-      template_list = filenames.compact.join(", ").presence || "See error message"
-      debug_msg = ColorizedString.new("Invalid #{'template'.pluralize(filenames.length)}: #{template_list}\n").red
+    def record_invalid_template(err:, filename:, content:)
+      debug_msg = ColorizedString.new("Invalid template: #{filename}\n").red
       debug_msg += "> Error message:\n#{indent_four(err)}"
-      if content.present?
-        debug_msg += "\n> Template content:\n#{indent_four(content)}"
-      end
-      debug_msg
+      debug_msg += "\n> Template content:\n#{indent_four(content)}"
+      @logger.summary.add_paragraph(debug_msg)
     end
 
     def indent_four(str)
@@ -411,11 +389,7 @@ module KubernetesDeploy
         if st.success?
           log_pruning(out) if prune
         else
-          file_paths = find_bad_files_from_kubectl_output(err)
-          warn_msg = "WARNING: Any resources not mentioned in the error below were likely created/updated. " \
-            "You may wish to roll back this deploy."
-          @logger.summary.add_paragraph(ColorizedString.new(warn_msg).yellow)
-          record_invalid_template(err, file_paths: file_paths)
+          record_apply_failure(err)
           raise FatalDeploymentError, "Command failed: #{Shellwords.join(command)}"
         end
       end
@@ -427,6 +401,41 @@ module KubernetesDeploy
 
       @logger.info("The following resources were pruned: #{pruned.join(', ')}")
       @logger.summary.add_action("pruned #{pruned.length} #{'resource'.pluralize(pruned.length)}")
+    end
+
+    def record_apply_failure(err)
+      warn_msg = "WARNING: Any resources not mentioned in the error(s) below were likely created/updated. " \
+        "You may wish to roll back this deploy."
+      @logger.summary.add_paragraph(ColorizedString.new(warn_msg).yellow)
+
+      unidentified_errors = []
+      err.each_line do |line|
+        bad_files = find_bad_files_from_kubectl_output(line)
+        if bad_files.present?
+          bad_files.each { |f| record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content]) }
+        else
+          unidentified_errors << line
+        end
+      end
+
+      if unidentified_errors.present?
+        msg = "#{ColorizedString.new('Unidentified error(s):').red}\n#{indent_four(unidentified_errors.join)}"
+        @logger.summary.add_paragraph(msg)
+      end
+    end
+
+    # Inspect the file referenced in the kubectl stderr
+    # to make it easier for developer to understand what's going on
+    def find_bad_files_from_kubectl_output(line)
+      # stderr often contains one or more lines like the following, from which we can extract the file path(s):
+      # Error from server (TypeOfError): error when creating "/path/to/service-gqq5oh.yml": Service "web" is invalid:
+
+      line.scan(%r{"(/\S+\.ya?ml\S*)"}).each_with_object([]) do |matches, bad_files|
+        matches.each do |path|
+          content = File.read(path) if File.file?(path)
+          bad_files << { filename: File.basename(path), err: line, content: content }
+        end
+      end
     end
 
     def confirm_context_exists

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -3,6 +3,15 @@ module KubernetesDeploy
   class FatalDeploymentError < StandardError; end
   class KubectlError < StandardError; end
 
+  class InvalidTemplateError < FatalDeploymentError
+    attr_reader :filename, :content
+    def initialize(err, filename:, content: nil)
+      @filename = filename
+      @content = content
+      super(err)
+    end
+  end
+
   class NamespaceNotFoundError < FatalDeploymentError
     def initialize(name, context)
       super("Namespace `#{name}` not found in context `#{context}`")

--- a/lib/kubernetes-deploy/renderer.rb
+++ b/lib/kubernetes-deploy/renderer.rb
@@ -7,11 +7,11 @@ require 'json'
 
 module KubernetesDeploy
   class Renderer
-    class InvalidPartialError < FatalDeploymentError
-      attr_reader :parents
-      def initialize(msg, parents = [])
+    class InvalidPartialError < InvalidTemplateError
+      attr_reader :parents, :content, :filename
+      def initialize(msg, parents: [], content: nil, filename:)
         @parents = parents
-        super(msg)
+        super(msg, content: content, filename: filename)
       end
     end
     class PartialNotFound < InvalidPartialError; end
@@ -36,10 +36,10 @@ module KubernetesDeploy
       ERB.new(raw_template, nil, '-').result(erb_binding)
     rescue InvalidPartialError => err
       all_parents = err.parents.dup.unshift(filename)
-      raise FatalDeploymentError, "#{err.message} (included from: #{all_parents.join(' -> ')})"
+      raise InvalidTemplateError.new(err.message,
+        filename: "#{err.filename} (partial included from: #{all_parents.join(' -> ')})", content: err.content)
     rescue StandardError => err
-      report_template_invalid(err.message, raw_template)
-      raise FatalDeploymentError, "Template '#{filename}' cannot be rendered"
+      raise InvalidTemplateError.new(err.message, filename: filename, content: raw_template)
     end
 
     def render_partial(partial, locals)
@@ -60,12 +60,12 @@ module KubernetesDeploy
       # Note that JSON is a subset of YAML.
       JSON.generate(docs.children.first.to_ruby)
     rescue PartialNotFound => err
-      raise InvalidPartialError, err.message
+      raise InvalidPartialError.new(err.message, filename: err.filename)
     rescue InvalidPartialError => err
-      raise InvalidPartialError.new(err.message, err.parents.dup.unshift(File.basename(partial_path)))
+      parents = err.parents.dup.unshift(File.basename(partial_path))
+      raise InvalidPartialError.new(err.message, parents: parents, filename: err.filename, content: err.content)
     rescue StandardError => err
-      report_template_invalid(err.message, expanded_template)
-      raise InvalidPartialError, "Template '#{partial_path}' cannot be rendered"
+      raise InvalidPartialError.new(err.message, filename: partial_path, content: expanded_template || template)
     end
 
     private
@@ -91,12 +91,8 @@ module KubernetesDeploy
           return partial_path if File.exist?(partial_path)
         end
       end
-      raise PartialNotFound, "Could not find partial '#{name}' in any of #{@partials_dirs.join(':')}"
-    end
-
-    def report_template_invalid(message, content)
-      @logger.summary.add_paragraph("Error from renderer:\n  #{message.tr("\n", ' ')}")
-      @logger.summary.add_paragraph("Rendered template content:\n#{content}")
+      raise PartialNotFound.new("Could not find partial '#{name}' in any of #{@partials_dirs.join(':')}",
+        filename: name)
     end
 
     class TemplateContext

--- a/test/fixtures/invalid/wrong-extension-erb.yml
+++ b/test/fixtures/invalid/wrong-extension-erb.yml
@@ -1,0 +1,12 @@
+<% (0..2).each do |n| %>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <%= "test#{n}" %>
+  labels:
+    name: <%= "test#{n}" %>
+    app: hello-cloud
+data:
+  test<%= n %>: <%= n * n %>
+<% end %>

--- a/test/fixtures/missing-partials/include-missing-partials.yml.erb
+++ b/test/fixtures/missing-partials/include-missing-partials.yml.erb
@@ -1,1 +1,0 @@
-<%= partial 'nest-missing-partial' %>

--- a/test/fixtures/missing-partials/parent-with-missing-child.yml.erb
+++ b/test/fixtures/missing-partials/parent-with-missing-child.yml.erb
@@ -1,0 +1,1 @@
+<%= partial 'does-not-exist' %>

--- a/test/fixtures/missing-partials/parent-with-missing-grandchild.yml.erb
+++ b/test/fixtures/missing-partials/parent-with-missing-grandchild.yml.erb
@@ -1,0 +1,1 @@
+<%= partial 'parent-with-missing-child' %>

--- a/test/fixtures/missing-partials/partials/nest-missing-partial.yml.erb
+++ b/test/fixtures/missing-partials/partials/nest-missing-partial.yml.erb
@@ -1,1 +1,0 @@
-<%= partial 'missing' %>

--- a/test/fixtures/missing-partials/partials/parent-with-missing-child.yml.erb
+++ b/test/fixtures/missing-partials/partials/parent-with-missing-child.yml.erb
@@ -1,0 +1,1 @@
+<%= partial 'does-not-exist' %>

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -44,6 +44,11 @@ module FixtureDeployHelper
     success = false
     if subset
       Dir.mktmpdir("fixture_dir") do |target_dir|
+        partials_dir = File.join(fixture_path(set), 'partials')
+        if File.directory?(partials_dir)
+          FileUtils.copy_entry(partials_dir, File.join(target_dir, 'partials'))
+        end
+
         subset.each do |file|
           FileUtils.copy_entry(File.join(fixture_path(set), file), File.join(target_dir, file))
         end

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -40,8 +40,19 @@ module FixtureDeployHelper
     success
   end
 
-  def deploy_raw_fixtures(set, wait: true, bindings: {})
-    deploy_dir(fixture_path(set), wait: wait, bindings: bindings)
+  def deploy_raw_fixtures(set, wait: true, bindings: {}, subset: nil)
+    success = false
+    if subset
+      Dir.mktmpdir("fixture_dir") do |target_dir|
+        subset.each do |file|
+          FileUtils.copy_entry(File.join(fixture_path(set), file), File.join(target_dir, file))
+        end
+        success = deploy_dir(target_dir, wait: wait, bindings: bindings)
+      end
+    else
+      success = deploy_dir(fixture_path(set), wait: wait, bindings: bindings)
+    end
+    success
   end
 
   def deploy_dir_without_profiling(dir, wait: true, allow_protected_ns: false, prune: true, bindings: {},

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -254,13 +254,18 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_failure(result)
     assert_logs_match_all([
       "Command failed: apply -f",
-      "WARNING: Any resources not mentioned in the error below were likely created/updated.",
-      /Invalid templates: (Deployment|Service)-web.*\.yml, (Deployment|Service)-web.*\.yml/,
-      "Error from server (Invalid): error when creating",
-      "Error from server (Invalid): error when creating", # once for deployment, once for svc
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      /Invalid template: Deployment-web.*\.yml/,
+      "> Error message:",
+      /Error from server \(Invalid\): error when creating.*Deployment\.?\w* "web" is invalid/,
       "> Template content:",
-      /(name|targetPort): http_test_is_really_long_and_invalid_chars/, # error in svc template
-      /(name|targetPort): http_test_is_really_long_and_invalid_chars/ # error in deployment template
+      "              name: http_test_is_really_long_and_invalid_chars",
+
+      /Invalid template: Service-web.*\.yml/,
+      "> Error message:",
+      /Error from server \(Invalid\): error when creating.*Service "web" is invalid/,
+      "> Template content:",
+      "        targetPort: http_test_is_really_long_and_invalid_chars"
     ], in_order: true)
   end
 
@@ -272,9 +277,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_failure(result)
     assert_logs_match_all([
       "Command failed: apply -f",
-      "WARNING: Any resources not mentioned in the error below were likely created/updated.",
-      "Invalid templates: See error message",
-      "> Error message:",
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      "Unidentified error(s):",
       '    The Service "web" is invalid:',
       'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"'
     ], in_order: true)
@@ -616,9 +620,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
     assert_logs_match_all([
       "Command failed: apply -f",
-      "WARNING: Any resources not mentioned in the error below were likely created/updated.",
-      "Invalid templates: See error message",
-      "> Error message:",
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      "Unidentified error(s):",
       /The Deployment "web" is invalid.*`selector` does not match template `labels`/
     ], in_order: true)
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -143,19 +143,24 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_invalid_yaml_fails_fast
     refute deploy_dir(fixture_path("invalid"))
     assert_logs_match_all([
-      /Template 'yaml-error.yml' cannot be parsed/,
-      /datapoint1: value1:/
-    ])
+      "Failed to render and parse template",
+      "Invalid template: yaml-error.yml",
+      "mapping values are not allowed in this context",
+      "> Template content:",
+      "datapoint1: value1:"
+    ], in_order: true)
   end
 
   def test_invalid_yaml_in_partial_prints_helpful_error
     refute deploy_raw_fixtures("invalid-partials")
+    included_from = "partial included from: include-invalid-partial.yml.erb"
     assert_logs_match_all([
       "Result: FAILURE",
-      %r{Template '.*/partials/invalid.yml.erb' cannot be rendered \(included from: include-invalid-partial.yml.erb\)},
-      "Error from renderer:",
-      "  (<unknown>): mapping values are not allowed in this context",
-      "Rendered template content:",
+      "Failed to render and parse template",
+      %r{Invalid template: .*/partials/invalid.yml.erb \(#{included_from}\)},
+      "> Error message:",
+      "(<unknown>): mapping values are not allowed in this context",
+      "> Template content:",
       "containers:",
       "- name: invalid-container",
       "notField: notval:"
@@ -163,21 +168,22 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
 
     # make sure we're not displaying duplicate errors
     refute_logs_match("Template 'include-invalid-partial.yml.erb' cannot be rendered")
-    assert_logs_match("Rendered template content:", 1)
-    assert_logs_match("Error from renderer:", 1)
+    assert_logs_match("Template content:", 1)
+    assert_logs_match("Error message:", 1)
   end
 
   def test_missing_nested_partial_prints_helpful_error
     refute deploy_raw_fixtures("missing-partials")
+    included_from = "partial included from: include-missing-partials.yml.erb -> nest-missing-partial.yml.erb"
     assert_logs_match_all([
       "Result: FAILURE",
-      %r{Could not find partial 'missing' in any of.*fixtures/missing-partials/partials:.*/fixtures/partials},
-      "(included from: include-missing-partials.yml.erb -> nest-missing-partial.yml.erb)"
+      "Failed to render and parse template",
+      "Invalid template: missing (#{included_from})",
+      "> Error message:",
+      %r{Could not find partial 'missing' in any of.*fixtures/missing-partials/partials:.*/fixtures/partials}
     ], in_order: true)
 
-    # make sure we're not displaying empty errors from the parents
-    refute_logs_match("Rendered template content:")
-    refute_logs_match("Error from renderer:")
+    refute_logs_match("Template content")
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_fails_fast_and_prints_template
@@ -191,19 +197,19 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
-        "> Error from kubectl:",
+        "> Error message:",
         "error validating data: found invalid field myKey for v1.ObjectMeta",
-        "> Rendered template content:",
+        "> Template content:",
         "      myKey: uhOh"
       ], in_order: true)
     else
       assert_logs_match_all([
         "Template validation failed",
         /Invalid template: ConfigMap-hello-cloud-configmap-data.*yml/,
-        "> Error from kubectl:",
+        "> Error message:",
         "error validating data: ValidationError(ConfigMap.metadata): \
 unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-        "> Rendered template content:",
+        "> Template content:",
         "      myKey: uhOh"
       ], in_order: true)
     end
@@ -238,7 +244,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       /Invalid templates: (Deployment|Service)-web.*\.yml, (Deployment|Service)-web.*\.yml/,
       "Error from server (Invalid): error when creating",
       "Error from server (Invalid): error when creating", # once for deployment, once for svc
-      "> Rendered template content:",
+      "> Template content:",
       /(name|targetPort): http_test_is_really_long_and_invalid_chars/, # error in svc template
       /(name|targetPort): http_test_is_really_long_and_invalid_chars/ # error in deployment template
     ], in_order: true)
@@ -254,7 +260,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error below were likely created/updated.",
       "Invalid templates: See error message",
-      "> Error from kubectl:",
+      "> Error message:",
       '    The Service "web" is invalid:',
       'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"'
     ], in_order: true)
@@ -427,7 +433,15 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
   def test_deploy_fails_if_required_binding_not_present
     assert_deploy_failure(deploy_fixtures('collection-with-erb', subset: ["conf_map.yaml.erb"]))
-    assert_logs_match("Template 'conf_map.yaml.erb' cannot be rendered")
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Failed to render and parse template",
+      "Invalid template: conf_map.yaml.erb",
+      "> Error message:",
+      "undefined local variable or method `binding_test_a'",
+      "> Template content:",
+      'BINDING_TEST_A: "<%= binding_test_a %>"'
+    ], in_order: true)
   end
 
   def test_long_running_deployment
@@ -590,7 +604,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error below were likely created/updated.",
       "Invalid templates: See error message",
-      "> Error from kubectl:",
+      "> Error message:",
       /The Deployment "web" is invalid.*`selector` does not match template `labels`/
     ], in_order: true)
   end
@@ -925,6 +939,17 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Service/multi-replica",
       "Deployment/undying: GLOBAL WATCH TIMEOUT (5 seconds)",
       "If you expected it to take longer than 5 seconds for your deploy to roll out, increase --max-watch-seconds."
+    ], in_order: true)
+  end
+
+  def test_friendly_error_on_misidentified_erb_file
+    assert_deploy_failure(deploy_raw_fixtures('invalid', subset: ['wrong-extension-erb.yml']))
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Invalid template: wrong-extension-erb.yml",
+      "Template is not a valid Kubernetes manifest",
+      "> Template content:",
+      "<% (0..2).each do |n| %>"
     ], in_order: true)
   end
 end

--- a/test/unit/kubernetes-deploy/renderer_test.rb
+++ b/test/unit/kubernetes-deploy/renderer_test.rb
@@ -58,8 +58,8 @@ class RendererTest < KubernetesDeploy::TestCase
     end
     base = "Could not find partial 'foobarbaz' in any of"
     assert_match %r{#{base} .*/fixtures/for_unit_tests/partials:.*/fixtures/partials}, err.message
-    assert_equal "foobarbaz (partial included from: including-non-existent-partial.yaml.erb)", err.filename
-    assert_nil err.content
+    assert_equal "including-non-existent-partial.yaml.erb", err.filename
+    assert_equal "---\n<%= partial 'foobarbaz' %>\n", err.content
   end
 
   def test_nesting_fields


### PR DESCRIPTION
Started off fixing an edge case where a `.yml` file that actually _starts_ with some ERB would raise an exception instead of failing gracefully with a nice message. Ended up shaving a small yak upon noticing that we displayed errors about invalid templates several different ways.

## Before
`test_deploy_fails_if_required_binding_not_present`
![image](https://user-images.githubusercontent.com/4789493/37627251-05d956e2-2baa-11e8-8cab-927a6e05c6ec.png)

`test_missing_nested_partial_prints_helpful_error`
![image](https://user-images.githubusercontent.com/4789493/37627267-12ad7b32-2baa-11e8-9185-c460884cca06.png)

`test_invalid_yaml_in_partial_prints_helpful_error`
![image](https://user-images.githubusercontent.com/4789493/37627290-2b826636-2baa-11e8-849e-6edfffc117da.png)

`test_invalid_yaml_fails_fast`
![image](https://user-images.githubusercontent.com/4789493/37627315-38a60796-2baa-11e8-9be0-83e4dcdd0aff.png)

`test_multiple_invalid_k8s_specs_fails_on_apply_and_prints_template`
![image](https://user-images.githubusercontent.com/4789493/37627235-f1694212-2ba9-11e8-97ea-e2fd710656e0.png)


## After

`test_deploy_fails_if_required_binding_not_present`
![image](https://user-images.githubusercontent.com/4789493/37627130-69732594-2ba9-11e8-88bf-490c4bb0b6df.png)

`test_missing_nested_partial_correctly_identifies_invalid_template_and_its_parents` [improved test]
![image](https://user-images.githubusercontent.com/4789493/37741862-81302f4c-2d39-11e8-9c2e-a5022b33612d.png)

`test_invalid_yaml_in_partial_prints_helpful_error`
![image](https://user-images.githubusercontent.com/4789493/37627196-b6e99d1c-2ba9-11e8-8ace-748c378d88cc.png)

`test_invalid_yaml_fails_fast`
![image](https://user-images.githubusercontent.com/4789493/37627210-c9be6b16-2ba9-11e8-9d01-d054a48dd00a.png)

`test_multiple_invalid_k8s_specs_fails_on_apply_and_prints_template`
![image](https://user-images.githubusercontent.com/4789493/37627230-e23808be-2ba9-11e8-9961-d7544c10561b.png)
