### PR TITLE
Directory based kubectl apply when there are more than 1k resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 deploy fails due to one or more resources failing to deploy in time.
 ([#244](https://github.com/Shopify/kubernetes-deploy/pull/244))
 
+*Bug Fixes*
+- Handle deploying thousands of resources at a time, previously kubernetes-deploy would fail with
+ `Argument list too long - kubectl (Errno::E2BIG)`.
+
 ### 0.17.0
 *Enhancements*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ deploy fails due to one or more resources failing to deploy in time.
 
 *Bug Fixes*
 - Handle deploying thousands of resources at a time, previously kubernetes-deploy would fail with
- `Argument list too long - kubectl (Errno::E2BIG)`.
+ `Argument list too long - kubectl (Errno::E2BIG)`. ([#257](https://github.com/Shopify/kubernetes-deploy/pull/257))
 
 ### 0.17.0
 *Enhancements*


### PR DESCRIPTION
Deploys with thousands of resources can fail with `Argument list too long - kubectl (Errno::E2BIG). This happens because we render each resource to its own file and then pass all of the files to kubectl apply via the `-f` flag. This pr detects when there are greater than 1k resources copies them to a temp directory and passes only the directory to kubectl apply.

cc: @dwradcliffe