### PR TITLE
Fix action summaries with failures/timeouts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,9 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.3
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -158,7 +158,7 @@ module KubernetesDeploy
         failed_resources = resources.reject(&:deploy_succeeded?)
         success = failed_resources.empty?
         if !success && failed_resources.all?(&:deploy_timed_out?)
-          raise DeploymentTimeoutError, failed_resources
+          raise DeploymentTimeoutError
         end
         raise FatalDeploymentError unless success
       else
@@ -172,13 +172,12 @@ module KubernetesDeploy
       end
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:success")
       @logger.print_summary(:success)
-    rescue DeploymentTimeoutError => error
-      @logger.summary.add_action(error.message)
+    rescue DeploymentTimeoutError
       @logger.print_summary(:timed_out)
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:timeout")
       raise
     rescue FatalDeploymentError => error
-      @logger.summary.add_action(error.message) if error.message.present?
+      @logger.summary.add_action(error.message) if error.message != error.class.to_s
       @logger.print_summary(:failure)
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
       raise

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -9,13 +9,7 @@ module KubernetesDeploy
     end
   end
 
-  class DeploymentTimeoutError < FatalDeploymentError
-    attr_reader :resources
-    def initialize(resources)
-      @resources = resources
-      super("Timed out waiting for #{@resources.count} resources.")
-    end
-  end
+  class DeploymentTimeoutError < FatalDeploymentError; end
 
   module Errors
     extend self

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -180,7 +180,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       "Triggered `web` restart",
       "Deployment/web rollout timed out",
       "Result: TIMED OUT",
-      "Failed to restart 1 resource",
+      "Timed out waiting for 1 resource to restart",
       "Deployment/web: TIMED OUT",
       "The following containers have not passed their readiness probes",
       "app must exit 0 from the following command",


### PR DESCRIPTION
Fixes a bug introduced in #244 (which is on master but has not yet been released) that I noticed in while 🎩 a different PR. @dturn @klautcomputing we need to either get this in or revert #244 so we can unblock a release for #257 

## Problem

![image](https://user-images.githubusercontent.com/4789493/38220348-b4363806-36a7-11e8-80d0-5209cd55cb37.png)

![image](https://user-images.githubusercontent.com/4789493/38220344-ac7c3138-36a7-11e8-9310-4327102e5825.png)

## Solution

Add a bunch more test coverage for the action line in existing tests, in addition to fixing the bug.

![image](https://user-images.githubusercontent.com/4789493/38220391-e7f2ee14-36a7-11e8-8c7c-7c3f2415ca0d.png)

![image](https://user-images.githubusercontent.com/4789493/38220411-06ae3f66-36a8-11e8-8d83-c7bfccf933cd.png)
