### PR TITLE
Fix bug where redeploy hangs forever because PDS condition is ignored

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -145,10 +145,11 @@ module KubernetesDeploy
         return false unless Time.now.utc - @deploy_started_at >= progress_deadline.to_i
       end
 
+      # This assumes that when the controller bumps the observed generation, it also updates/clears all the status
+      # conditions. Specifically, it assumes the progress condition is immediately set to True if a rollout is starting.
       deploy_started? &&
       current_generation == observed_generation &&
-      progress_condition["status"] == 'False' &&
-      progress_condition["reason"] == "ProgressDeadlineExceeded"
+      progress_condition["status"] == 'False'
     end
 
     def find_latest_rs(mediator)

--- a/test/fixtures/for_unit_tests/deployment_test.yml
+++ b/test/fixtures/for_unit_tests/deployment_test.yml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: web
   uid: foobar
+  generation: 2
   annotations:
     "deployment.kubernetes.io/revision": "1"
   labels:


### PR DESCRIPTION
There's a logic error in `deploy_failing_to_progress?`: it assumes that the deploy currently doing the watching also initiated the latest changes to the deployment. Because of this, no-op redeploys of bad code will hang forever, as seen in this shipit stack:

<img src="https://user-images.githubusercontent.com/4789493/38282163-a88dc3ea-377c-11e8-861d-d4eb19b6352f.png" width="200px">

This PR proposes a new assumption: that if the status generation matches the resource generation, the conditions in that status must refer to the latest version. I'm not entirely sure this is a safe assumption to make. It could reintroduce something like https://github.com/Shopify/kubernetes-deploy/pull/213 (though that case was caused by a Kubernetes bug). Let me know if you have any better ideas. Another thing we could do is always return false if `Time.now - deploy_started_at` is less than PDS, without even checking the condition (like we do for <=1.7.7).