### PR TITLE
Updates README to describe JSON as as --bindings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All templates must be YAML formatted. You can also use ERB. The following local 
 * `current_sha`: The value of `$REVISION`
 * `deployment_id`:  A randomly generated identifier for the deploy. Useful for creating unique names for task-runner pods (e.g. a pod that runs rails migrations at the beginning of deploys).
 
-You can add additional variables using the `--bindings=BINDINGS` option. For example, `kubernetes-deploy my-app cluster1 --bindings=color=blue,size=large` will expose `color` and `size` in your templates.
+You can add additional variables using the `--bindings=BINDINGS` option which can be formated as comma separated or as JSON. For example, `kubernetes-deploy my-app cluster1 --bindings=color=blue,size=large` or `kubernetes-deploy my-app cluster1 --bindings='{"color":"blue","size":"large"}'` will expose `color` and `size` in your templates. Complex JSON data will be converted to a Hash for use in templates.
 
 #### Using partials
 


### PR DESCRIPTION
Only a documentation update. The existing README described the comma separated option for `--bindings` and did not mention the JSON option. This adds a description for JSON. The command line help does mention the JSON option.  