### PR TITLE
[BugFix] ActiveSupport::Duration::ISO8601Parser requires ActiveSupport >= 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### Unreleased
 *Enhancements*
-
 - Prune resource quotas ([#264](https://github.com/Shopify/kubernetes-deploy/pull/264/files))
+
+*Bug Fixes*
+- Update gemspec to reflect need for ActiveSupport >= 5.0([#270](https://github.com/Shopify/kubernetes-deploy/pull/270))
 
 ### 0.18.1
 *Enhancements*

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.3.0'
-  spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 2.4"
   spec.add_dependency "rest-client", ">= 1.7" # Minimum required by kubeclient. Remove when kubeclient releases v3.0.
   spec.add_dependency "googleauth", ">= 0.5"


### PR DESCRIPTION
ActiveSupport::Duration::ISO8601Parser was added to ActiveSupport in version 5.0. This PR updates the gemspec. 

The other option here is to disable the parser if we detect less than version 5.0. But I don't think we need to support projects pre 5.0 at this point.

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/267