### PR TITLE
[bug fix] Make sure we sleep for positive duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Master
+
+*Bug Fixes*
+- Prevent calling sleep with a negative value ([#273](https://github.com/Shopify/kubernetes-deploy/pull/273))
+
 ### 0.19.0
 *Features*
 - Added `--max-watch-seconds=seconds` to kubernetes-restart and kubernetes-deploy. When set

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -24,8 +24,8 @@ module KubernetesDeploy
         if @timeout && (Time.now.utc - monitoring_started > @timeout)
           report_and_give_up(remainder)
         end
-        if Time.now.utc < delay_sync_until
-          sleep(delay_sync_until - Time.now.utc)
+        if (sleep_duration = delay_sync_until - Time.now.utc) > 0
+          sleep(sleep_duration)
         end
         delay_sync_until = Time.now.utc + delay_sync # don't pummel the API if the sync is fast
 

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -893,8 +893,9 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       subset: ["bad_probe.yml", "cannot_run.yml", "missing_volumes.yml", "config_map.yml"],
       max_watch_seconds: 15
     ) do |f|
-      deployment = f["bad_probe.yml"]["Deployment"].first
-      deployment["metadata"]["annotations"]["kubernetes-deploy.shopify.io/timeout-override"] = '5s'
+      bad_probe = f["bad_probe.yml"]["Deployment"].first
+      bad_probe["metadata"]["annotations"]["kubernetes-deploy.shopify.io/timeout-override"] = '5s'
+      f["missing_volumes.yml"]["Deployment"].first["spec"]["progressDeadlineSeconds"] = 25
       f["cannot_run.yml"]["Deployment"].first["spec"]["replicas"] = 1
     end
     assert_deploy_failure(result)


### PR DESCRIPTION
Due to calling `Time.now.utc` twice, it was possible for sleep to receive a negative value. Fix that by calling `Time.now.utc` once and ensure the sleep duration is `> 0`.

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/272#issuecomment-379361407

Attempted to improve: https://github.com/Shopify/kubernetes-deploy/issues/274