### PR TITLE
Raise an error when 'kind' is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 *Bug Fixes*
 - Prevent calling sleep with a negative value ([#273](https://github.com/Shopify/kubernetes-deploy/pull/273))
 - Prevent no-op redeploys of bad code from hanging forever ([#262](https://github.com/Shopify/kubernetes-deploy/pull/262))
+- Display a nice error instead of crashing when a YAML document is missing 'Kind'
+([#280](https://github.com/Shopify/kubernetes-deploy/pull/280))
 
 *Enhancements*
 - Improve output for rendering errors ([#253](https://github.com/Shopify/kubernetes-deploy/pull/253))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *Features*
 
 *Bug Fixes*
+- Display a nice error instead of crashing when a YAML document is missing 'Kind'
+([#280](https://github.com/Shopify/kubernetes-deploy/pull/280))
 
 *Enhancements*
 
@@ -14,8 +16,6 @@
 *Bug Fixes*
 - Prevent calling sleep with a negative value ([#273](https://github.com/Shopify/kubernetes-deploy/pull/273))
 - Prevent no-op redeploys of bad code from hanging forever ([#262](https://github.com/Shopify/kubernetes-deploy/pull/262))
-- Display a nice error instead of crashing when a YAML document is missing 'Kind'
-([#280](https://github.com/Shopify/kubernetes-deploy/pull/280))
 
 *Enhancements*
 - Improve output for rendering errors ([#253](https://github.com/Shopify/kubernetes-deploy/pull/253))

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -253,6 +253,7 @@ module KubernetesDeploy
         yield doc
       end
     rescue InvalidTemplateError => e
+      e.filename ||= filename
       record_invalid_template(err: e.message, filename: e.filename, content: e.content)
       raise FatalDeploymentError, "Failed to render and parse template"
     rescue Psych::SyntaxError => e

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -4,7 +4,8 @@ module KubernetesDeploy
   class KubectlError < StandardError; end
 
   class InvalidTemplateError < FatalDeploymentError
-    attr_reader :filename, :content
+    attr_reader :content
+    attr_accessor :filename
     def initialize(err, filename:, content: nil)
       @filename = filename
       @content = content

--- a/lib/kubernetes-deploy/errors.rb
+++ b/lib/kubernetes-deploy/errors.rb
@@ -6,7 +6,7 @@ module KubernetesDeploy
   class InvalidTemplateError < FatalDeploymentError
     attr_reader :content
     attr_accessor :filename
-    def initialize(err, filename:, content: nil)
+    def initialize(err, filename: nil, content: nil)
       @filename = filename
       @content = content
       super(err)

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -32,7 +32,7 @@ module KubernetesDeploy
         opts = { namespace: namespace, context: context, definition: definition, logger: logger,
                  statsd_tags: statsd_tags }
         if definition["kind"].blank?
-          raise InvalidTemplateError.new("Template missing 'Kind'", filename: nil, content: definition.to_s)
+          raise InvalidTemplateError.new("Template missing 'Kind'", content: definition.to_yaml)
         elsif KubernetesDeploy.const_defined?(definition["kind"])
           klass = KubernetesDeploy.const_get(definition["kind"])
           klass.new(**opts)

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -31,7 +31,9 @@ module KubernetesDeploy
       def build(namespace:, context:, definition:, logger:, statsd_tags:)
         opts = { namespace: namespace, context: context, definition: definition, logger: logger,
                  statsd_tags: statsd_tags }
-        if KubernetesDeploy.const_defined?(definition["kind"])
+       if definition["kind"].blank?
+         raise InvalidTemplateError.new("Template missing 'Kind'", filename: nil, content: definition.to_s)
+       elsif KubernetesDeploy.const_defined?(definition["kind"])
           klass = KubernetesDeploy.const_get(definition["kind"])
           klass.new(**opts)
         else

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -31,9 +31,9 @@ module KubernetesDeploy
       def build(namespace:, context:, definition:, logger:, statsd_tags:)
         opts = { namespace: namespace, context: context, definition: definition, logger: logger,
                  statsd_tags: statsd_tags }
-       if definition["kind"].blank?
-         raise InvalidTemplateError.new("Template missing 'Kind'", filename: nil, content: definition.to_s)
-       elsif KubernetesDeploy.const_defined?(definition["kind"])
+        if definition["kind"].blank?
+          raise InvalidTemplateError.new("Template missing 'Kind'", filename: nil, content: definition.to_s)
+        elsif KubernetesDeploy.const_defined?(definition["kind"])
           klass = KubernetesDeploy.const_get(definition["kind"])
           klass.new(**opts)
         else

--- a/test/fixtures/invalid-resources/missing_kind.yml
+++ b/test/fixtures/invalid-resources/missing_kind.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+metadata:
+  name: test
+data:
+  datapoint: value1

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -993,7 +993,14 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Invalid template: missing_kind.yml",
       "> Error message:",
-      "Template missing 'Kind'"
+      "Template missing 'Kind'",
+      "> Template content:",
+      "---",
+      "apiVersion: v1",
+      "metadata:",
+      "  name: test",
+      "data:",
+      "  datapoint: value1"
     ], in_order: true)
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -986,4 +986,14 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       assert_empty desired_tags - metric.tags
     end
   end
+
+  def test_raise_on_yaml_missing_kind
+    result = deploy_fixtures("invalid-resources", subset: ["missing_kind.yml"])
+    assert_deploy_failure(result)
+    assert_logs_match_all([
+      "Invalid template: missing_kind.yml",
+      "> Error message:",
+      "Template missing 'Kind'"
+    ], in_order: true)
+  end
 end


### PR DESCRIPTION
Currently we crash with a stack dump if a yaml document is missing a `Kind`. This PR prints a nice error instead of crashing

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/277


```
***************************************************************************
 Begin test: test_raise_on_yaml_missing_kind
***************************************************************************

[INFO][2018-04-17 17:24:58 -0700]	
[INFO][2018-04-17 17:24:58 -0700]	------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2018-04-17 17:24:58 -0700]	All required parameters and files are present
[INFO][2018-04-17 17:24:58 -0700]	Context minikube found
[INFO][2018-04-17 17:24:58 -0700]	Namespace k8sdeploy-test-raise-on-yaml-missing-kind-b0469b977d430aff found
[INFO][2018-04-17 17:24:58 -0700]	Discovering templates:
[INFO][2018-04-17 17:24:58 -0700]	
[INFO][2018-04-17 17:24:58 -0700]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2018-04-17 17:24:58 -0700]	Failed to render and parse template
[FATAL][2018-04-17 17:24:58 -0700]	
[FATAL][2018-04-17 17:24:58 -0700]	Invalid template: missing_kind.yml
[FATAL][2018-04-17 17:24:58 -0700]	> Error message:
[FATAL][2018-04-17 17:24:58 -0700]	    Template missing 'Kind'
[FATAL][2018-04-17 17:24:58 -0700]	> Template content:
[FATAL][2018-04-17 17:24:58 -0700]	    {"apiVersion"=>"v1", "metadata"=>{"name"=>"test"}, "data"=>{"datapoint"=>"value1"}}
```