### PR TITLE
Stop running 1.10 during nightly build

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,10 +1,11 @@
-  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
-    command: bin/ci
-    agents:
-      queue: minikube-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.10-latest
+# Disableed until minikube can run 1.10
+#  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
+#    command: bin/ci
+#    agents:
+#      queue: minikube-ci
+#    env:
+#      LOGGING_LEVEL: 4
+#      KUBERNETES_VERSION: v1.10-latest
   - name: 'Run Test Suite (:kubernetes: 1.9-latest)'
     command: bin/ci
     agents:


### PR DESCRIPTION
Nightly builds always fails since minikube can't start 1.10. Let's cut down on the noise.

Not 100% sure who to tag on this pr.