### PR TITLE
Add an annotation that skips rollout verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### Master
+*Features*
+- Make it possible to skip rollout verification for a single resouce via the
+`kubernetes-deploy.shopify.io/no-rollout-verification` annotation
+([#282](https://github.com/Shopify/kubernetes-deploy/pull/282))
 
 *Enhancements*
 - Add Job resource class ([#295](https://github.com/Shopify/kubernetes-deploy/pull/296))

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ before the deployment is considered successful.
   - `true`: The custom resource will be pruned if the resource is not in the deploy directory.
   - All other values: The custom resource will not be pruned.
 
+- `kubernetes-deploy.shopify.io/no-rollout-verification`: When set on a resource the deploy will be
+considered successful even if the resource fails to deploy.
+
+
 ### Running tasks at the beginning of a deploy
 
 To run a task in your cluster at the beginning of every deploy, simply include a `Pod` template in your deploy directory. `kubernetes-deploy` will first deploy any `ConfigMap` and `PersistentVolumeClaim` resources in your template set, followed by any such pods. If the command run by one of these pods fails (i.e. exits with a non-zero status), the overall deploy will fail at this step (no other resources will be deployed).

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -166,7 +166,7 @@ module KubernetesDeploy
         start_normal_resource = Time.now.utc
         deploy_resources(resources, prune: prune, verify: true)
         ::StatsD.measure('normal_resources.duration', StatsD.duration(start_normal_resource), tags: statsd_tags)
-        failed_resources = resources.reject(&:deploy_succeeded?)
+        failed_resources = resources.reject(&:skip_rollout_verification?).reject(&:deploy_succeeded?)
         success = failed_resources.empty?
         if !success && failed_resources.all?(&:deploy_timed_out?)
           raise DeploymentTimeoutError

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -52,7 +52,7 @@ module KubernetesDeploy
       resources = build_watchables(deployments, start)
       ResourceWatcher.new(resources: resources, sync_mediator: @sync_mediator,
         logger: @logger, operation_name: "restart", timeout: @max_watch_seconds).run
-      failed_resources = resources.reject(&:deploy_succeeded?)
+      failed_resources = resources.reject(&:skip_rollout_verification?).reject(&:deploy_succeeded?)
       success = failed_resources.empty?
       if !success && failed_resources.all?(&:deploy_timed_out?)
         raise DeploymentTimeoutError

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -154,7 +154,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_failure
-    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
+    result = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30
       container = deployment["spec"]["template"]["spec"]["containers"].first
@@ -171,7 +171,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
         }
       }
     end
-    assert_deploy_success(success)
+    assert_deploy_success(result)
 
     restart = build_restart_task
     assert_raises(KubernetesDeploy::DeploymentTimeoutError) { restart.perform!(%w(web)) }
@@ -188,6 +188,32 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       "Unhealthy: Readiness probe failed"
     ],
       in_order: true)
+  end
+
+  def test_restart_failure_can_be_ignored
+    result = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
+      deployment = fixtures["web.yml.erb"]["Deployment"].first
+      deployment["spec"]["progressDeadlineSeconds"] = 30
+      annotation_key = KubernetesDeploy::KubernetesResource::NO_ROLLOUT_VERIFICATION_ANNOTATION
+      deployment["metadata"]["annotations"][annotation_key] = '1'
+      container = deployment["spec"]["template"]["spec"]["containers"].first
+      container["readinessProbe"] = {
+        "failureThreshold" => 1,
+        "periodSeconds" => 1,
+        "initialDelaySeconds" => 0,
+        "exec" => {
+          "command" => [
+            "/bin/sh",
+            "-c",
+            "test $(env | grep -s RESTARTED_AT -c) -eq 0"
+          ]
+        }
+      }
+    end
+    assert_deploy_success(result)
+
+    restart = build_restart_task
+    assert_restart_success(restart.perform(%w(web)))
   end
 
   def test_restart_successful_with_partial_availability

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -149,6 +149,10 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       status == "timeout" && hits_complete?
     end
 
+    def skip_rollout_verification?
+      status == "ingnored"
+    end
+
     def timeout
       hits_to_complete
     end


### PR DESCRIPTION
Allow a resource to skip rollout verification via a new annotation `'kubernetes-deploy.shopify.io/no-rollout-verification'`

This prevents the deploy from being a failure if the resource fails to deploy, by causing `ResourceWatcher` to ignore the resource though it does print a  message saying its ignoring the resource.

Feature wanted from: https://github.com/Shopify/kubernetes-deploy/issues/229

<img width="1220" alt="screen shot 2018-04-18 at 10 17 50 am" src="https://user-images.githubusercontent.com/12193286/38947544-f3000b56-42f1-11e8-8796-a45105b68236.png">
