### PR TITLE
Only runs the right tests when TEST is set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,28 +2,42 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+files = {
+  integration_test: FileList['test/integration/**/*_test.rb'],
+  serial_integration_test: FileList['test/integration-serial/**/*_test.rb'],
+  unit_test: FileList['test/unit/**/*_test.rb']
+}
+
 desc "Run integration tests that can be run in parallel"
 Rake::TestTask.new(:integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/integration/**/*_test.rb']
+  t.test_files = files[t.name]
 end
 
 desc "Run integration tests that CANNOT be run in parallel"
 Rake::TestTask.new(:serial_integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/integration-serial/**/*_test.rb']
+  t.test_files = files[t.name]
 end
 
 desc "Run unit tests"
 Rake::TestTask.new(:unit_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/unit/**/*_test.rb']
+  t.test_files = files[t.name]
+end
+
+all_test = %w(unit_test serial_integration_test integration_test)
+
+tests_to_run = if ENV['TEST']
+  files.select { |_, v| v.include?(ENV['TEST']) }.keys
+else
+  all_test
 end
 
 desc "Run all tests"
-task test: %w(unit_test serial_integration_test integration_test)
+task test: tests_to_run
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-files = {
+test_to_files = {
   integration_test: FileList['test/integration/**/*_test.rb'],
   serial_integration_test: FileList['test/integration-serial/**/*_test.rb'],
   unit_test: FileList['test/unit/**/*_test.rb']
@@ -12,29 +12,27 @@ desc "Run integration tests that can be run in parallel"
 Rake::TestTask.new(:integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = files[t.name]
+  t.test_files = test_to_files[t.name]
 end
 
 desc "Run integration tests that CANNOT be run in parallel"
 Rake::TestTask.new(:serial_integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = files[t.name]
+  t.test_files = test_to_files[t.name]
 end
 
 desc "Run unit tests"
 Rake::TestTask.new(:unit_test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = files[t.name]
+  t.test_files = test_to_files[t.name]
 end
 
-all_test = %w(unit_test serial_integration_test integration_test)
-
 tests_to_run = if ENV['TEST']
-  files.select { |_, v| v.include?(ENV['TEST']) }.keys
+  test_to_files.select { |_, v| v.include?(ENV['TEST']) }.keys
 else
-  all_test
+  test_to_files.keys
 end
 
 desc "Run all tests"


### PR DESCRIPTION
Setting the `TEST=foo` on the command line overrides `test_files`.  Currently `TEST=test/integration/kubernetes_deploy_test.rb be rake test` causes the file to be run three times. This PR fixes things up so that its only run once.