### PR TITLE
Bump kubeclient to 3.0

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "kubeclient", "~> 2.4"
+  spec.add_dependency "kubeclient", "~> 3.0"
   spec.add_dependency "rest-client", ">= 1.7" # Minimum required by kubeclient. Remove when kubeclient releases v3.0.
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "rest-client", ">= 1.7" # Minimum required by kubeclient. Remove when kubeclient releases v3.0.
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -131,11 +131,11 @@ module KubernetesDeploy
 
     def patch_kubeclient_deployments(deployments)
       deployments.each do |record|
-        response = patch_deployment_with_restart(record)
-        if HTTP_OK_RANGE.cover?(response.code)
+        begin
+          patch_deployment_with_restart(record)
           @logger.info "Triggered `#{record.metadata.name}` restart"
-        else
-          raise RestartAPIError.new(record.metadata.name, response)
+        rescue Kubeclient::ResourceNotFoundError, Kubeclient::HttpError => e
+          raise RestartAPIError.new(record.metadata.name, e.message)
         end
       end
     end

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -18,7 +18,7 @@ module FixtureSetAssertions
         labels: { name: 'ejson-keys' }
       }
       encoded_data = { test_public_key => test_private_key }
-      secret = Kubeclient::Secret.new(type: 'Opaque', metadata: metadata, data: encoded_data)
+      secret = Kubeclient::Resource.new(kind: 'Secret', type: 'Opaque', metadata: metadata, data: encoded_data)
       kubeclient.create_secret(secret)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -254,7 +254,7 @@ module KubernetesDeploy
     end
 
     def self.create_namespace(namespace)
-      ns = Kubeclient::Namespace.new
+      ns = Kubeclient::Resource.new(kind: 'Namespace')
       ns.metadata = { name: namespace }
       kubeclient.create_namespace(ns)
     end
@@ -269,7 +269,7 @@ module KubernetesDeploy
       existing_pvs = kubeclient.get_persistent_volumes(label_selector: "name=#{name}")
       return if existing_pvs.present?
 
-      pv = Kubeclient::PersistentVolume.new
+      pv = Kubeclient::Resource.new(kind: 'PersistentVolume')
       pv.metadata = {
         name: name,
         labels: { name: name }


### PR DESCRIPTION
Bumping kubeclient to 3.0. 


Two major changes  (https://github.com/abonas/kubeclient/blob/master/CHANGELOG.md):
- Entity classes (`Kubeclient::Namespace`) have been dropped  everything is now a `Kubeclient::Resource` with a kind. This only impacted tests.
- patch_xxx now returns a `Kubeclient::Resource`. Failure to update the resource will raise an error.

Minor Change:
- Was able to remove the dependecy on `"rest-client"` since the min version was fixed in kubeclient