### PR TITLE
[bug fix] A failed deployment hasn't timed out

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -74,6 +74,7 @@ module KubernetesDeploy
     end
 
     def deploy_timed_out?
+      return false if deploy_failed?
       # Do not use the hard timeout if progress deadline is set
       progress_condition.present? ? deploy_failing_to_progress? : super
     end


### PR DESCRIPTION
If both `deploy_timed_out?` and `deploy_failed?` return true the result is `Result: TIMED OUT` not `Result: FAILURE` . This can only happen for deployments since other resources have deploy_timed_out? dependent on !deploy_failed? . 

This is a short term patch. The long term solution is https://github.com/Shopify/kubernetes-deploy/issues/285

Creating a test to show this behavior was easy:
```
    KubernetesDeploy::Deployment.any_instance.stubs(:deploy_timed_out?).returns(true)
    KubernetesDeploy::Deployment.any_instance.stubs(:deploy_failed?).returns(true)
    result = deploy_fixtures("invalid", subset: ["cannot_run.yml"])
   ...
```

However, the fix is in `deploy_timed_out?` so the test doesn't go green with the fix in place. 