### PR TITLE
Allow for multiple `--bindings` arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ([#280](https://github.com/Shopify/kubernetes-deploy/pull/280))
 
 *Enhancements*
+- Merge multiple `--bindings` arguments, to allow a composite bindings map (multiple arguments or files)
 
 ### 0.20.0
 

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -15,7 +15,7 @@ max_watch_seconds = nil
 ARGV.options do |opts|
   opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
     "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") do |binds|
-    bindings = KubernetesDeploy::BindingsParser.parse(binds)
+    bindings.merge!(KubernetesDeploy::BindingsParser.parse(binds))
   end
 
   opts.on("--skip-wait", "Skip verification of non-priority-resource success (not recommended)") { skip_wait = true }


### PR DESCRIPTION
We developed a need to pass in multiple files with bindings in it. This allows for that usecase.
