### PR TITLE
Assume no strategy is rollingUpdate on Vallidation

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -87,7 +87,7 @@ module KubernetesDeploy
       end
 
       strategy = @definition.dig('spec', 'strategy', 'type').to_s
-      if required_rollout.downcase == 'maxunavailable' && strategy.downcase != 'rollingupdate'
+      if required_rollout.downcase == 'maxunavailable' && strategy.present? && strategy.downcase != 'rollingupdate'
         @validation_errors << "'#{REQUIRED_ROLLOUT_ANNOTATION}: #{required_rollout}' is incompatible "\
         "with strategy '#{strategy}'"
       end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -227,6 +227,20 @@ class DeploymentTest < KubernetesDeploy::TestCase
     assert_equal expected, deploy.validation_error_msg
   end
 
+  def test_validation_works_with_no_strategy_and_max_anavailable_annotation
+    deploy = build_synced_deployment(
+      template: build_deployment_template(rollout: 'maxUnavailable', strategy: nil),
+      replica_sets: [build_rs_template]
+    )
+    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+      ["", "super failed", SystemExit.new(1)]
+    )
+    refute deploy.validate_definition(kubectl)
+
+    expected = 'super failed'
+    assert_equal expected, deploy.validation_error_msg
+  end
+
   def test_deploy_succeeded_not_fooled_by_stale_rs_data_in_deploy_status
     deployment_status = {
       "replicas" => 3,
@@ -345,6 +359,10 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
     if strategy == "Recreate"
       result["spec"]["strategy"] = { "type" => strategy }
+    end
+
+    if strategy.nil?
+      result["spec"]["strategy"] = nil
     end
 
     if max_unavailable

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -227,18 +227,15 @@ class DeploymentTest < KubernetesDeploy::TestCase
     assert_equal expected, deploy.validation_error_msg
   end
 
-  def test_validation_works_with_no_strategy_and_max_anavailable_annotation
+  def test_validation_works_with_no_strategy_and_max_unavailable_annotation
     deploy = build_synced_deployment(
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: nil),
       replica_sets: [build_rs_template]
     )
     kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
-      ["", "super failed", SystemExit.new(1)]
+      ["", "", SystemExit.new(0)]
     )
-    refute deploy.validate_definition(kubectl)
-
-    expected = 'super failed'
-    assert_equal expected, deploy.validation_error_msg
+    assert deploy.validate_definition(kubectl)
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_rs_data_in_deploy_status


### PR DESCRIPTION
The required-rollout requires a rollout strategy to be explicitly set or else a validation error is raised. However, the k8s default rollout strategy is compatible with the required-rollout annotation. This pr allows for that case. 

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/268