### PR TITLE
Switch to using updated number instead of current for ds rollout

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -18,7 +18,7 @@ module KubernetesDeploy
 
     def deploy_succeeded?
       return false unless exists?
-      rollout_data["desiredNumberScheduled"].to_i == rollout_data["currentNumberScheduled"].to_i &&
+      rollout_data["desiredNumberScheduled"].to_i == rollout_data["updatedNumberScheduled"].to_i &&
       rollout_data["desiredNumberScheduled"].to_i == rollout_data["numberReady"].to_i &&
       current_generation == observed_generation
     end
@@ -48,7 +48,7 @@ module KubernetesDeploy
     def rollout_data
       return { "currentNumberScheduled" => 0 } unless exists?
       @instance_data["status"]
-        .slice("currentNumberScheduled", "desiredNumberScheduled", "numberReady")
+        .slice("updatedNumberScheduled", "desiredNumberScheduled", "numberReady")
     end
 
     def parent_of_pod?(pod_data)

--- a/test/fixtures/for_unit_tests/daemon_set.yml
+++ b/test/fixtures/for_unit_tests/daemon_set.yml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: ds-app
+  generation: 2
+spec:
+  selector:
+    matchLabels:
+      app: ds-app
+      name: ds-app
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: ds-app
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        ports:
+        - containerPort: 80
+status:
+  currentNumberScheduled: 2
+  desiredNumberScheduled: 2
+  numberAvailable: 2
+  numberMisscheduled: 0
+  numberReady: 2
+  observedGeneration: 2
+  updatedNumberScheduled: 1

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -19,7 +19,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{ReplicaSet/bare-replica-set\s+1 replica, 1 availableReplica, 1 readyReplica},
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
       %r{Service/web\s+Selects at least 1 pod},
-      %r{DaemonSet/ds-app\s+1 currentNumberScheduled, 1 desiredNumberScheduled, 1 numberReady},
+      %r{DaemonSet/ds-app\s+1 updatedNumberScheduled, 1 desiredNumberScheduled, 1 numberReady},
       %r{StatefulSet/stateful-busybox},
       %r{Service/redis-external\s+Doesn't require any endpoint}
     ])
@@ -759,7 +759,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Failed to deploy 1 resource",
       "DaemonSet/crash-loop: FAILED",
       "crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
-      "Final status: 1 currentNumberScheduled, 1 desiredNumberScheduled, 0 numberReady",
+      "Final status: 1 updatedNumberScheduled, 1 desiredNumberScheduled, 0 numberReady",
       "Events (common success events excluded):",
       "BackOff: Back-off restarting failed container",
       "Logs from container 'crash-loop-back-off' (last 250 lines shown):",

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class DaemonSetTest < KubernetesDeploy::TestCase
+  def setup
+    super
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
+  end
+
+  def test_deploy_fails_when_updated_available_does_not_match
+    ds_template = build_ds_template
+    ds = build_synced_ds(template: ds_template)
+    refute ds.deploy_succeeded?
+  end
+
+  def test_deploy_passes_when_updated_available_does_match
+    status = {
+      "currentNumberScheduled": 3,
+      "desiredNumberScheduled": 2,
+      "numberReady": 2,
+      "updatedNumberScheduled": 2,
+      "observedGeneration": 2,
+    }
+
+    ds_template = build_ds_template(status: status)
+    ds = build_synced_ds(template: ds_template)
+    assert ds.deploy_succeeded?
+  end
+
+  private
+
+  def build_ds_template(status: {})
+    base_ds_maifest = YAML.load_stream(File.read(File.join(fixture_path('for_unit_tests'), 'daemon_set.yml'))).first
+    base_ds_maifest.deep_merge("status" => status)
+  end
+
+  def build_synced_ds(template:)
+    ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
+    sync_mediator = build_sync_mediator
+    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json").returns(
+      [template.to_json, "", SystemExit.new(0)]
+    )
+
+    sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
+      ['{ "items": [] }', "", SystemExit.new(0)]
+    )
+
+    ds.sync(sync_mediator)
+    ds
+  end
+
+  def build_sync_mediator
+    KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+  end
+end


### PR DESCRIPTION
## What?
- Fixes bug : https://github.com/Shopify/kubernetes-deploy/issues/288
- Switch from using `currentNumberScheduled` to `updatedNumberScheduled` since that is more important to judge correct success condition
- Add unit tests that makes sure the deploy doesn't pass until the updated and desired numbers are equal in the status