### PR TITLE
Bump statsd-instrument gem version and emit dd-events after deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Master
 
+### 0.20.2
+*Enhancements*
+- Emit data dog events when deploys succeed, time out or fail.
 ### 0.20.1
 *Features*
 

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "googleauth", ">= 0.5"
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"
-  spec.add_dependency "statsd-instrument", "~> 2.1"
+  spec.add_dependency "statsd-instrument", "~> 2.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -174,15 +174,24 @@ module KubernetesDeploy
         MSG
         @logger.summary.add_paragraph(ColorizedString.new(warning).yellow)
       end
+      ::StatsD.event("Deployment of #{@namespace} succeeded",
+        "Successfully deployed all #{@namespace} resources to #{@context}",
+        alert_type: "success", tags: statsd_tags << "status:success")
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:success")
       @logger.print_summary(:success)
     rescue DeploymentTimeoutError
       @logger.print_summary(:timed_out)
+      ::StatsD.event("Deployment of #{@namespace} timed out",
+        "One or more #{@namespace} resources failed to deploy to #{@context} in time",
+        alert_type: "error", tags: statsd_tags << "status:timeout")
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:timeout")
       raise
     rescue FatalDeploymentError => error
       @logger.summary.add_action(error.message) if error.message != error.class.to_s
       @logger.print_summary(:failure)
+      ::StatsD.event("Deployment of #{@namespace} failed",
+        "One or more #{@namespace} resources failed to deploy to #{@context}",
+        alert_type: "error", tags: statsd_tags << "status:failed")
       ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
       raise
     end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -980,7 +980,11 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
     # We can't ensure that all the metrics we grab are from this specific test because they are running in parallel
     metrics = metrics.select { |m| m.tags.include? "namespace:#{@namespace}" }
-    assert_equal 4, metrics.count
+    assert_equal 5, metrics.count
+
+    event_metrics = metrics.find_all { |m| m.type == :_e }
+    assert event_metrics.any?
+    assert_equal 1, event_metrics.count
 
     metrics.each do |metric|
       assert_empty desired_tags - metric.tags


### PR DESCRIPTION
This PR achieves the following:

* Bumps `statsd-instrument` version to `v2.2.0`, this new version has support for emitting data dog events. 

* Emits data dog events after (successful | timeout | fail) deploys.

Why?

I would like to have deployment event overlays on `ingress-nginx` data dog dashboards. I'm currently working on enhancing the monitoring of the project.