### PR TITLE
Deploys are failed if pod is evicted

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -33,8 +33,8 @@ module KubernetesDeploy
     end
 
     def status
-      return phase if @instance_data.dig('status', 'reason').blank?
-      "#{phase} (Reason: #{@instance_data['status']['reason']})"
+      return phase if reason.blank?
+      "#{phase} (Reason: #{reason})"
     end
 
     def deploy_succeeded?
@@ -57,7 +57,7 @@ module KubernetesDeploy
     end
 
     def failure_message
-      if phase == FAILED_PHASE_NAME
+      if phase == FAILED_PHASE_NAME && reason != "Evicted"
         phase_problem = "Pod status: #{status}. "
       end
 
@@ -100,6 +100,10 @@ module KubernetesDeploy
 
     def phase
       @instance_data.dig("status", "phase") || "Unknown"
+    end
+
+    def reason
+      @instance_data.dig('status', 'reason')
     end
 
     def readiness_probe_failure?

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -155,6 +155,21 @@ class PodTest < KubernetesDeploy::TestCase
     assert_equal expected_msg, pod.failure_message
   end
 
+  def test_deploy_failed_is_false_for_evicted_
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "Filler",
+          "reason" => "Evicted"
+        }
+      }
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    refute pod.deploy_failed?
+    assert_nil pod.failure_message
+  end
+
   private
 
   def pod_spec


### PR DESCRIPTION
Evictions should be recoverable so don't let them cause a failure.

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/230
