### PR TITLE
GoogleFriendlyConfig.read: Use YAML.safe_load to avoid arbitrary Ruby class construction

### DIFF
--- a/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb
@@ -13,7 +13,7 @@ module KubernetesDeploy
       end
 
       def self.read(filename)
-        new(YAML.load_file(filename), File.dirname(filename))
+        new(YAML.safe_load(File.read(filename)), File.dirname(filename))
       end
 
       def new_token


### PR DESCRIPTION
Same as https://github.com/abonas/kubeclient/pull/334, you have a copy-paste of that code since #88.

I don't think there is any security impact in this project, like most uses of Config.read out there it's a command-line tool, config(s) come from $KUBECONFIG env var, so user that runs this controls the config but can only "attack themself".

P.S. https://github.com/abonas/kubeclient/pull/213 finally landed in kubeclient 3.1, you could in principle drop GoogleFriendlyConfig in favor of that — though it doesn't autodetect auth-provider 'gcp', you'd need to know when to call it.

P.S. you have some unrelated `YAML.load` uses, consider checking which can be `safe_load`.

Cheers