### PR TITLE
Add HPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 *Enhancements*
 - Add Job resource class ([#295](https://github.com/Shopify/kubernetes-deploy/pull/296))
-- Add CustomResourceDefinition resource class ([#305](https://github.com/Shopify/kubernetes-deploy/pull/306))
+- Add CustomResourceDefinition resource class ([#306](https://github.com/Shopify/kubernetes-deploy/pull/306))
 - Officially support Kubernetes 1.10 ([#308](https://github.com/Shopify/kubernetes-deploy/pull/308))
 - SyncMediator will only batch fetch resources when there is a sufficiently large enough set of resources
 being tracked ([#316](https://github.com/Shopify/kubernetes-deploy/pull/316))
 - Allow CRs to be pruned based on `kubernetes-deploy.shopify.io/prunable` annotation on the custom resource definitions ([312](https://github.com/Shopify/kubernetes-deploy/pull/312))
+- Add HorizontalPodAutoscaler resource class ([#305](https://github.com/Shopify/kubernetes-deploy/pull/305))
 
 ### 0.20.4
 *Enhancements*

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -29,6 +29,7 @@ require 'kubernetes-deploy/kubernetes_resource'
   cron_job
   job
   custom_resource_definition
+  horizontal_pod_autoscaler
 ).each do |subresource|
   require "kubernetes-deploy/kubernetes_resource/#{subresource}"
 end

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -68,6 +68,14 @@ module KubernetesDeploy
       )
     end
 
+    def build_autoscaling_v1_kubeclient(context)
+      _build_kubeclient(
+        api_version: "v2beta1",
+        context: context,
+        endpoint_path: "/apis/autoscaling"
+      )
+    end
+
     def _build_kubeclient(api_version:, context:, endpoint_path: nil)
       # Find a context defined in kube conf files that matches the input context by name
       friendly_configs = config_files.map { |f| GoogleFriendlyConfig.read(f) }

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -115,7 +115,7 @@ module KubernetesDeploy
     end
 
     def sync(mediator)
-      @instance_data = mediator.get_instance(type, name)
+      @instance_data = mediator.get_instance(kubectl_resource_type, name)
     end
 
     def deploy_failed?
@@ -145,6 +145,10 @@ module KubernetesDeploy
 
     def type
       @type || self.class.kind
+    end
+
+    def kubectl_resource_type
+      type
     end
 
     def deploy_timed_out?

--- a/lib/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class HorizontalPodAutoscaler < KubernetesResource
+    TIMEOUT = 3.minutes
+    RECOVERABLE_CONDITIONS = %w(ScalingDisabled FailedGet)
+
+    def deploy_succeeded?
+      scaling_active_condition["status"] == "True"
+    end
+
+    def deploy_failed?
+      return false unless exists?
+      recoverable = RECOVERABLE_CONDITIONS.any? { |c| scaling_active_condition.fetch("reason", "").start_with?(c) }
+      scaling_active_condition["status"] == "False" && !recoverable
+    end
+
+    def kubectl_resource_type
+      'hpa.v2beta1.autoscaling'
+    end
+
+    def status
+      if !exists?
+        super
+      elsif deploy_succeeded?
+        "Configured"
+      elsif scaling_active_condition.present? || able_to_scale_condition.present?
+        condition = scaling_active_condition.presence || able_to_scale_condition
+        condition['reason']
+      else
+        "Unknown"
+      end
+    end
+
+    def failure_message
+      condition = scaling_active_condition.presence || able_to_scale_condition.presence || {}
+      condition['message']
+    end
+
+    def timeout_message
+      failure_message.presence || super
+    end
+
+    private
+
+    def conditions
+      @instance_data.dig("status", "conditions") || []
+    end
+
+    def able_to_scale_condition
+      conditions.detect { |c| c["type"] == "AbleToScale" } || {}
+    end
+
+    def scaling_active_condition
+      conditions.detect { |c| c["type"] == "ScalingActive" } || {}
+    end
+  end
+end

--- a/lib/kubernetes-deploy/sync_mediator.rb
+++ b/lib/kubernetes-deploy/sync_mediator.rb
@@ -36,7 +36,7 @@ module KubernetesDeploy
         dependencies = resources.map(&:class).uniq.flat_map do |c|
           c::SYNC_DEPENDENCIES if c.const_defined?('SYNC_DEPENDENCIES')
         end
-        kinds = (resources.map(&:type) + dependencies).compact.uniq
+        kinds = (resources.map(&:kubectl_resource_type) + dependencies).compact.uniq
         kinds.each { |kind| fetch_by_kind(kind) }
       end
 

--- a/test/fixtures/hpa/deployment.yml
+++ b/test/fixtures/hpa/deployment.yml
@@ -19,4 +19,3 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 1Gi

--- a/test/fixtures/hpa/deployment.yml
+++ b/test/fixtures/hpa/deployment.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: hpa-deployment
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 60
+  template:
+    metadata:
+      labels:
+        name: hpa
+        app: hpa-deployment
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi

--- a/test/fixtures/hpa/hpa.yml
+++ b/test/fixtures/hpa/hpa.yml
@@ -1,0 +1,16 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hello-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hpa-deployment
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 50

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -33,4 +33,8 @@ module KubeclientHelper
   def apiextensions_v1beta1_kubeclient
     @apiextensions_v1beta1_kubeclient ||= build_apiextensions_v1beta1_kubeclient(MINIKUBE_CONTEXT)
   end
+
+  def autoscaling_v1_kubeclient
+    @autoscaling_v1_kubeclient ||= build_autoscaling_v1_kubeclient(MINIKUBE_CONTEXT)
+  end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1053,4 +1053,21 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "  datapoint: value1"
     ], in_order: true)
   end
+
+  def test_hpa_can_be_successful
+    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.8.0')
+    assert_deploy_success(deploy_fixtures("hpa"))
+    assert_logs_match_all([
+      "Deploying resources:",
+      "HorizontalPodAutoscaler/hello-hpa (timeout: 180s)",
+      %r{HorizontalPodAutoscaler/hello-hpa\s+Configured}
+    ])
+  end
+
+  def test_hpa_can_be_pruned
+    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.8.0')
+    assert_deploy_success(deploy_fixtures("hpa"))
+    assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
+    assert_logs_match_all(['The following resources were pruned: horizontalpodautoscaler "hello-hpa"'])
+  end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1055,7 +1055,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_successful
-    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.8.0')
+    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_logs_match_all([
       "Deploying resources:",
@@ -1065,7 +1065,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_pruned
-    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.8.0')
+    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([/The following resources were pruned: horizontalpodautoscaler(.autoscaling)? "hello-hpa"/])

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1068,6 +1068,6 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     skip if KUBE_SERVER_VERSION < Gem::Version.new('1.8.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
-    assert_logs_match_all(['The following resources were pruned: horizontalpodautoscaler "hello-hpa"'])
+    assert_logs_match_all([/The following resources were pruned: horizontalpodautoscaler(.autoscaling)? "hello-hpa"/])
   end
 end

--- a/test/setup/metrics-server/auth-delegator.yaml
+++ b/test/setup/metrics-server/auth-delegator.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/test/setup/metrics-server/auth-reader.yaml
+++ b/test/setup/metrics-server/auth-reader.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/test/setup/metrics-server/metrics-apiservice.yaml
+++ b/test/setup/metrics-server/metrics-apiservice.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/test/setup/metrics-server/metrics-server-deployment.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      containers:
+      - name: metrics-server
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        imagePullPolicy: Always
+        command:
+        - /metrics-server
+        - --source=kubernetes.summary_api:''

--- a/test/setup/metrics-server/metrics-server-service.yaml
+++ b/test/setup/metrics-server/metrics-server-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443

--- a/test/setup/metrics-server/resource-reader.yaml
+++ b/test/setup/metrics-server/resource-reader.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -282,10 +282,18 @@ module KubernetesDeploy
       }
       kubeclient.create_persistent_volume(pv)
     end
+
+    def self.deploy_metric_server
+      # Set-up the metric server that the HPA needs https://github.com/kubernetes-incubator/metrics-server
+      Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").map do |resource|
+        Kubeclient::Resource.new(YAML.safe_load(File.read(resource))).create
+      end
+    end
   end
 
   WebMock.allow_net_connect!
   TestProvisioner.prepare_pv("pv0001")
   TestProvisioner.prepare_pv("pv0002")
+  TestProvisioner.deploy_metric_server
   WebMock.disable_net_connect!
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -285,8 +285,13 @@ module KubernetesDeploy
 
     def self.deploy_metric_server
       # Set-up the metric server that the HPA needs https://github.com/kubernetes-incubator/metrics-server
+      logger = KubernetesDeploy::FormattedLogger.build("default", KubeclientHelper::MINIKUBE_CONTEXT, $stderr)
+      kubectl = KubernetesDeploy::Kubectl.new(namespace: "kube-system", context: KubeclientHelper::MINIKUBE_CONTEXT,
+        logger: logger, log_failure_by_default: true, default_timeout: '5s')
+
       Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").map do |resource|
-        Kubeclient::Resource.new(YAML.safe_load(File.read(resource))).create
+        found = kubectl.run("get", "-f", resource, log_failure: false).last.success?
+        kubectl.run("create", "-f", resource) unless found
       end
     end
   end


### PR DESCRIPTION
Add HPA Resource (part of splitting of https://github.com/Shopify/kubernetes-deploy/pull/188/files)

 In v2beta1 we get access to three[condition statuses](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#appendix-horizontal-pod-autoscaler-status-conditions)`AbleToScale, ScalingActive , and ScalingLimited`. I think it makes sense to succeeded when `AbleToScale` is true.

>The first, AbleToScale, indicates whether or not the HPA is able to fetch and update scales, as well as whether or not any backoff-related conditions would prevent scaling.  

The downside of using v2beta is no support in 1.7. I think its worth the tradeoff