### PR TITLE
K8s 110 ci with fixes

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,11 +1,11 @@
-# Disableed until minikube can run 1.10
-#  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
-#    command: bin/ci
-#    agents:
-#      queue: minikube-ci
-#    env:
-#      LOGGING_LEVEL: 4
-#      KUBERNETES_VERSION: v1.10-latest
+steps:
+  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-ci
+    env:
+      LOGGING_LEVEL: 4
+      KUBERNETES_VERSION: v1.10-latest
   - name: 'Run Test Suite (:kubernetes: 1.9-latest)'
     command: bin/ci
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,28 +2,28 @@ steps:
   - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci-110
+      queue: minikube-ci
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.10-latest
   - name: 'Run Test Suite (:kubernetes: 1.9-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci-110
+      queue: minikube-ci
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.9-latest
   - name: 'Run Test Suite (:kubernetes: 1.8-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci-110
+      queue: minikube-ci
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.8-latest
   - name: 'Run Test Suite (:kubernetes: 1.7-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci-110
+      queue: minikube-ci
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.7-latest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,21 +1,29 @@
+steps:
+  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
+    command: bin/ci
+    agents:
+      queue: minikube-ci-110
+    env:
+      LOGGING_LEVEL: 4
+      KUBERNETES_VERSION: v1.10-latest
   - name: 'Run Test Suite (:kubernetes: 1.9-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci
+      queue: minikube-ci-110
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.9-latest
   - name: 'Run Test Suite (:kubernetes: 1.8-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci
+      queue: minikube-ci-110
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.8-latest
   - name: 'Run Test Suite (:kubernetes: 1.7-latest)'
     command: bin/ci
     agents:
-      queue: minikube-ci
+      queue: minikube-ci-110
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.7-latest

--- a/dev.yml
+++ b/dev.yml
@@ -8,7 +8,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured')
-      meet: minikube start --kubernetes-version=v1.9.4 --vm-driver=hyperkit
+      meet: minikube start --kubernetes-version=v1.10.4 --vm-driver=hyperkit
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube

--- a/dev.yml
+++ b/dev.yml
@@ -8,7 +8,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured')
-      meet: minikube start --kubernetes-version=v1.10.4 --vm-driver=hyperkit
+      meet: minikube start --kubernetes-version=v1.10.0 --vm-driver=hyperkit
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -119,14 +119,14 @@ module KubernetesDeploy
     end
 
     def progress_condition
-      return unless exists?
+      return unless exists? && progress_deadline
       conditions = @instance_data.fetch("status", {}).fetch("conditions", [])
       conditions.find { |condition| condition['type'] == 'Progressing' }
     end
 
     def progress_deadline
       if exists?
-        @instance_data['spec']['progressDeadlineSeconds']
+        @instance_data['spec']['progressDeadlineSeconds'] if @definition['spec']['progressDeadlineSeconds'].present?
       else
         @definition['spec']['progressDeadlineSeconds']
       end

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -119,14 +119,14 @@ module KubernetesDeploy
     end
 
     def progress_condition
-      return unless exists? && progress_deadline
+      return unless exists?
       conditions = @instance_data.fetch("status", {}).fetch("conditions", [])
       conditions.find { |condition| condition['type'] == 'Progressing' }
     end
 
     def progress_deadline
       if exists?
-        @instance_data['spec']['progressDeadlineSeconds'] if @definition['spec']['progressDeadlineSeconds'].present?
+        @instance_data['spec']['progressDeadlineSeconds']
       else
         @definition['spec']['progressDeadlineSeconds']
       end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -535,7 +535,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   def test_deploy_result_logging_for_mixed_result_deploy
     subset = ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml", "config_map.yml"]
     result = deploy_fixtures("invalid", subset: subset) do |f|
-      if KUBE_SERVER_VERSION >= Gem::Version.new("1.10.0")
+      if KUBE_SERVER_VERSION >= Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
         f["bad_probe.yml"]["Deployment"].first["spec"]["progressDeadlineSeconds"] = 20
       end
     end
@@ -939,7 +939,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       max_watch_seconds: 20
     ) do |f|
       bad_probe = f["bad_probe.yml"]["Deployment"].first
-      if KUBE_SERVER_VERSION < Gem::Version.new("1.10.0")
+      if KUBE_SERVER_VERSION < Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
         bad_probe["metadata"]["annotations"]["kubernetes-deploy.shopify.io/timeout-override"] = '5s'
       else
         bad_probe["spec"]["progressDeadlineSeconds"] = 5

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -548,7 +548,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
         %r{Deployment/bad-probe: TIMED OUT \(timeout: \d+s\)},
         "Timeout reason: hard deadline for Deployment"
       ]
-      end_bad_probe_logs = [%r{Unhealthy: Readiness probe failed: .* \(\d+ events\)}] # event
+      end_bad_probe_logs = [/Unhealthy: Readiness probe failed: .* \(\d+ events\)}/] # event
     else
       start_bad_probe_logs = [
         %r{Deployment/bad-probe: TIMED OUT \(progress deadline: \d+s\)},


### PR DESCRIPTION
In 1.10 progressDeadlineSeconds is in instance data even if its not in the spec. As a result, our logic for progressDeadlineSeconds is triggered instead of the hard-timeout logic.

This is https://github.com/Shopify/kubernetes-deploy/pull/299 with a commit to fix the issue.