### PR TITLE
Fix "Running tasks at the beginning of a deploy" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Especially in a CI/CD environment, we need a clear, actionable pass/fail result 
 
 :closed_lock_with_key:  [Creates Kubernetes secrets from encrypted EJSON](#deploying-kubernetes-secrets-from-ejson), which you can safely commit to your repository
 
-​:running: [Runs tasks at the beginning of the deploy](#deploy-time-tasks) using bare pods (example use case: Rails migrations)
+​:running: [Running tasks at the beginning of a deploy](#running-tasks-at-the-beginning-of-a-deploy) using bare pods (example use case: Rails migrations)
 
 This repo also includes related tools for [running tasks](#kubernetes-run) and [restarting deployments](#kubernetes-restart).
 


### PR DESCRIPTION
Summary
-------

The hyperlink "Running tasks at the beginning of a deploy" in the
high level feature listing of the README.md references a non-existent
anchor (#deploy-time-tasks). Looking through the history it seems like
this anchor never existed in any commits in the master history
chain. It would seem this link was always intended to point to the
content listed in the section titled "Running tasks at the beginning
of a deploy", but was perhaps missed in renaming edit.

This change makes the hyperlink in the feature listing mirror that in
the of the kubernetes-deploy 'usage' table of contents.

References
----------

- Originating Commit https://github.com/Shopify/kubernetes-deploy/pull/120/commits/36d916c64ee20a24e694fca9b1961482c71217d6