### PR TITLE
Only batch fetch when there is a sufficiently large number requested

### DIFF
--- a/lib/kubernetes-deploy/sync_mediator.rb
+++ b/lib/kubernetes-deploy/sync_mediator.rb
@@ -32,7 +32,7 @@ module KubernetesDeploy
     def sync(resources)
       clear_cache
 
-      if resources.count < LARGE_BATCH_THRESHOLD
+      if resources.count > LARGE_BATCH_THRESHOLD
         dependencies = resources.map(&:class).uniq.flat_map do |c|
           c::SYNC_DEPENDENCIES if c.const_defined?('SYNC_DEPENDENCIES')
         end

--- a/lib/kubernetes-deploy/sync_mediator.rb
+++ b/lib/kubernetes-deploy/sync_mediator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class SyncMediator
-    LARGE_BATCH_THRESHOLD = 5
+    LARGE_BATCH_THRESHOLD = Concurrency::MAX_THREADS * 3
 
     def initialize(namespace:, context:, logger:)
       @namespace = namespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -192,7 +192,7 @@ module KubernetesDeploy
 
     def stub_kubectl_response(*args, resp:, err: "", success: true, json: true, times: 1)
       resp = resp.to_json if json
-      response = times > 0 ? [resp, err, stub(success?: success)] : []
+      response = [resp, err, stub(success?: success)]
       KubernetesDeploy::Kubectl.any_instance.expects(:run)
         .with(*args)
         .returns(response)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -192,7 +192,7 @@ module KubernetesDeploy
 
     def stub_kubectl_response(*args, resp:, err: "", success: true, json: true, times: 1)
       resp = resp.to_json if json
-      response = [resp, err, stub(success?: success)]
+      response = times > 0 ? [resp, err, stub(success?: success)] : []
       KubernetesDeploy::Kubectl.any_instance.expects(:run)
         .with(*args)
         .returns(response)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -37,7 +37,9 @@ class ServiceTest < KubernetesDeploy::TestCase
       build_service(service_fixture('zero-replica'))
     ]
 
-    stub_kubectl_response("get", "Service", "-a", "--output=json", resp: { items: [] })
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: {})
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: {})
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: {})
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: pod_fixtures })
 

--- a/test/unit/sync_mediator_test.rb
+++ b/test/unit/sync_mediator_test.rb
@@ -132,20 +132,10 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
     mediator.sync(test_resources)
   end
 
-  def test_sync_does_not_batch_with_few_resources
-    stub_kubectl_response('get', 'FakeConfigMap', @fake_cm.name, *@params,
-      resp: { "items" => [@fake_cm.kubectl_response] }, times: 0)
+  def test_sync_does_not_warm_cache_with_few_resources
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).with('get', 'FakeConfigMap', @fake_cm.name, *@params).never
 
     test_resources = [@fake_cm]
-    test_resources.each { |r| r.expects(:sync).once }
-    mediator.sync(test_resources)
-  end
-
-  def test_sync_does_batch_with_enough_resources
-    stub_kubectl_response('get', 'FakeConfigMap', *@params,
-      resp: { "items" => [@fake_cm.kubectl_response] }, times: 1)
-
-    test_resources = [@fake_cm] * (KubernetesDeploy::SyncMediator::LARGE_BATCH_THRESHOLD + 1)
     test_resources.each { |r| r.expects(:sync).once }
     mediator.sync(test_resources)
   end

--- a/test/unit/sync_mediator_test.rb
+++ b/test/unit/sync_mediator_test.rb
@@ -133,11 +133,14 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
   end
 
   def test_sync_does_not_warm_cache_with_few_resources
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).with('get', 'FakeConfigMap', @fake_cm.name, *@params).never
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).with('get', 'FakeConfigMap', *@params).never
 
-    test_resources = [@fake_cm]
+    test_resources = [@fake_cm] * KubernetesDeploy::SyncMediator::LARGE_BATCH_THRESHOLD
     test_resources.each { |r| r.expects(:sync).once }
     mediator.sync(test_resources)
+
+    stub_kubectl_response('get', 'FakeConfigMap', @fake_cm.name, *@params, resp: @fake_cm.kubectl_response, times: 1)
+    mediator.get_instance('FakeConfigMap', @fake_cm.name)
   end
 
   private


### PR DESCRIPTION
Polling can take a long time for small resource groups when the cluster contains a large number of resources of that type. Don't batch fetch when number of resources being tracked is small.

fixes: https://github.com/Shopify/kubernetes-deploy/issues/314