### PR TITLE
Don't consider pod preempting a failure

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -4,6 +4,10 @@ module KubernetesDeploy
     TIMEOUT = 10.minutes
 
     FAILED_PHASE_NAME = "Failed"
+    TRANSIENT_FAILURE_REASONS = %w(
+      Evicted
+      Preempting
+    )
 
     def initialize(namespace:, context:, definition:, logger:,
       statsd_tags: nil, parent: nil, deploy_started_at: nil)
@@ -57,7 +61,7 @@ module KubernetesDeploy
     end
 
     def failure_message
-      if phase == FAILED_PHASE_NAME && reason != "Evicted"
+      if phase == FAILED_PHASE_NAME && !TRANSIENT_FAILURE_REASONS.include?(reason)
         phase_problem = "Pod status: #{status}. "
       end
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -170,6 +170,21 @@ class PodTest < KubernetesDeploy::TestCase
     assert_nil pod.failure_message
   end
 
+  def test_deploy_failed_is_false_for_preempting
+    container_state = pod_spec.merge(
+      "status" => {
+        "message" => "Preempted in order to admit critical pod",
+        "phase" => "Failed",
+        "reason" => "Preempting",
+        "startTime" => "2018-04-13T22:43:23Z"
+      }
+    )
+    pod = build_synced_pod(container_state)
+
+    refute_predicate pod, :deploy_failed?
+    assert_nil pod.failure_message
+  end
+
   private
 
   def pod_spec


### PR DESCRIPTION
Similar to #293, pod/node preempting is a recoverable state (the desired pod count will reduce once the node has been reaped), so isn't a valid condition for fast failure.