### PR TITLE
[Caching-Queuing] Rename redis resources

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -7,8 +7,12 @@ module KubernetesDeploy
     SYNC_DEPENDENCIES = %w(Deployment Service)
     def sync(mediator)
       super
-      @deployment = mediator.get_instance(Deployment.kind, "redis-#{redis_resource_uuid}")
-      @service = mediator.get_instance(Service.kind, "redis-#{redis_resource_uuid}")
+
+      @deployment = mediator.get_instance(Deployment.kind, name)
+      @deployment = mediator.get_instance(Deployment.kind, deprecated_name) if @deployment.empty?
+
+      @service = mediator.get_instance(Service.kind, name)
+      @service = mediator.get_instance(Service.kind, deprecated_name) if @service.empty?
     end
 
     def status
@@ -39,6 +43,14 @@ module KubernetesDeploy
       return false unless @service.present?
       # the service has an assigned cluster IP and is therefore functioning
       @service.dig("spec", "clusterIP").present?
+    end
+
+    def name
+      @definition.dig('metadata', 'name')
+    end
+
+    def deprecated_name
+      "redis-#{redis_resource_uuid}"
     end
 
     def redis_resource_uuid


### PR DESCRIPTION
This commit follows the work performed in https://github.com/Shopify/cloudbuddies/pull/1115.

The redis resources were renamed. The kubernetes deployment script specifically looked for a prefix 'redis-' in the name. Whereas we wish to name resources according to their given names.

The current commit first looks for resources using the new names, otherwise it default to the 'legacy' naming. Legacy naming can be deployed once we migrate all redis instances.

@Shopify/caching-queuing 