### PR TITLE
Pin googleauth due to bug

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "= 0.6.2"
+  spec.add_dependency "googleauth", "= 0.6.2" # https://github.com/google/google-auth-library-ruby/issues/153
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", ">= 0.5"
+  spec.add_dependency "googleauth", "= 0.6.2"
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"


### PR DESCRIPTION
Bug is this line: https://github.com/google/google-auth-library-ruby/pull/145/files#diff-213fdc02c21601908a9d0b021cbf527fR56

Constant is scoped wrong `Google::Auth::CredentialsLoader::CLIENT_ID_VAR`

Diff: https://github.com/google/google-auth-library-ruby/compare/328fed6d63cc96bdb87d24275aa749022f5ac34e...master

```
➜ rt test/unit/kubernetes-deploy/google_friendly_config_test.rb

# Running tests with run options --seed 47771:

F.E

Finished tests in 0.009410s, 318.8098 tests/s, 318.8098 assertions/s.


Failure:
Minitest::Result#test_auth_use_default_gcp_failure [test/unit/kubernetes-deploy/google_friendly_config_test.rb:43]
Minitest::Assertion: [KubeException] exception expected, not
Class: <RuntimeError>
Message: <"Unable to read the credential file specified by GOOGLE_APPLICATION_CREDENTIALS: uninitialized constant Google::Auth::DefaultCredentials::CLIENT_ID_VAR\nDid you mean?  Google::Auth::ClientId">
---Backtrace---
/Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/credentials_loader.rb:94:in `rescue in from_env'
/Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/credentials_loader.rb:84:in `from_env'
/Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/application_default.rb:57:in `get_application_default'
/Users/dturner/src/github.com/Shopify/kubernetes-deploy/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb:21:in `new_token'
/Users/dturner/src/github.com/Shopify/kubernetes-deploy/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb:9:in `fetch_user_auth_options'
/Users/dturner/.gem/ruby/2.3.3/gems/kubeclient-3.1.2/lib/kubeclient/config.rb:42:in `context'
test/unit/kubernetes-deploy/google_friendly_config_test.rb:44:in `block in test_auth_use_default_gcp_failure'
/Users/dturner/src/github.com/Shopify/kubernetes-deploy/test/test_helper.rb:176:in `block in assert_raises'
---------------

Error:
Minitest::Result#test_auth_use_default_gcp_success:
RuntimeError: Unable to read the credential file specified by GOOGLE_APPLICATION_CREDENTIALS: uninitialized constant Google::Auth::DefaultCredentials::CLIENT_ID_VAR
Did you mean?  Google::Auth::ClientId
    /Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/credentials_loader.rb:94:in `rescue in from_env'
    /Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/credentials_loader.rb:84:in `from_env'
    /Users/dturner/.gem/ruby/2.3.3/gems/googleauth-0.6.3/lib/googleauth/application_default.rb:57:in `get_application_default'
    /Users/dturner/src/github.com/Shopify/kubernetes-deploy/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb:21:in `new_token'
    /Users/dturner/src/github.com/Shopify/kubernetes-deploy/lib/kubernetes-deploy/kubeclient_builder/google_friendly_config.rb:9:in `fetch_user_auth_options'
    /Users/dturner/.gem/ruby/2.3.3/gems/kubeclient-3.1.2/lib/kubeclient/config.rb:42:in `context'
    test/unit/kubernetes-deploy/google_friendly_config_test.rb:29:in `test_auth_use_default_gcp_success'

Slowest tests:

0.004117s test_auth_use_default_gcp_failure#Minitest::Result
0.002908s test_auth_use_default_gcp_success#Minitest::Result
0.000210s test_non_google_auth_works#Minitest::Result

3 tests, 3 assertions, 1 failures, 1 errors, 0 skips

```