### PR TITLE
Check for presence of the `STATSD_IMPLEMENTATION' env:

### DIFF
--- a/lib/kubernetes-deploy/statsd.rb
+++ b/lib/kubernetes-deploy/statsd.rb
@@ -15,7 +15,7 @@ module KubernetesDeploy
       if ENV['STATSD_DEV'].present?
         ::StatsD.backend = ::StatsD::Instrument::Backends::LoggerBackend.new(Logger.new($stderr))
       elsif ENV['STATSD_ADDR'].present?
-        statsd_impl = ENV['STATSD_IMPLEMENTATION'].empty? ? "datadog" : ENV['STATSD_IMPLEMENTATION']
+        statsd_impl = ENV['STATSD_IMPLEMENTATION'].present? ? ENV['STATSD_IMPLEMENTATION'] : "datadog"
         ::StatsD.backend = ::StatsD::Instrument::Backends::UDPBackend.new(ENV['STATSD_ADDR'], statsd_impl)
       else
         ::StatsD.backend = ::StatsD::Instrument::Backends::NullBackend.new

--- a/test/unit/kubernetes-deploy/statsd_test.rb
+++ b/test/unit/kubernetes-deploy/statsd_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StatsDTest < KubernetesDeploy::TestCase
+  def test_build_when_statsd_addr_env_present_but_statsd_implementation_is_not
+    original_addr = ENV['STATSD_ADDR']
+    ENV['STATSD_ADDR'] = '127.0.0.1'
+    original_impl = ENV['STATSD_IMPLEMENTATION']
+    ENV['STATSD_IMPLEMENTATION'] = nil
+    original_dev = ENV['STATSD_DEV']
+    ENV['STATSD_DEV'] = nil
+
+    KubernetesDeploy::StatsD.build
+
+    assert_equal :datadog, StatsD.backend.implementation
+  ensure
+    ENV['STATSD_ADDR'] = original_addr
+    ENV['STATSD_IMPLEMENTATION'] = original_impl
+    ENV['STATSD_DEV'] = original_dev
+  end
+end


### PR DESCRIPTION
Check for presence of the `STATSD_IMPLEMENTATION' env:

- Calling `empty?` when ENV['STATSD_IMPLEMENTATION'] isn't set makes kubernetes-deploy to crash.

  Fixing the issue by calling ActiveSuport's `present?` instead