### PR TITLE
Compare generations when available

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -139,6 +139,17 @@ module KubernetesDeploy
       @instance_data.present?
     end
 
+    def current_generation
+      return -1 unless exists? # must be different default than observed_generation
+      @instance_data["metadata"]["generation"]
+    end
+
+    def observed_generation
+      return -2 unless exists?
+      # populating this is a best practice, but not all controllers actually do it
+      @instance_data["status"]["observedGeneration"]
+    end
+
     def status
       exists? ? "Exists" : "Unknown"
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -24,7 +24,8 @@ module KubernetesDeploy
     end
 
     def deploy_failed?
-      pods.present? && pods.any?(&:deploy_failed?)
+      pods.present? && pods.any?(&:deploy_failed?) &&
+      observed_generation == current_generation
     end
 
     def fetch_logs(kubectl)
@@ -34,16 +35,6 @@ module KubernetesDeploy
     end
 
     private
-
-    def current_generation
-      return -1 unless exists? # must be different default than observed_generation
-      @instance_data["metadata"]["generation"]
-    end
-
-    def observed_generation
-      return -2 unless exists?
-      @instance_data["status"]["observedGeneration"]
-    end
 
     def rollout_data
       return { "currentNumberScheduled" => 0 } unless exists?

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -31,6 +31,7 @@ module KubernetesDeploy
 
     def deploy_succeeded?
       return false unless exists? && @latest_rs.present?
+      return false unless observed_generation == current_generation
 
       if required_rollout == 'full'
         @latest_rs.deploy_succeeded? &&
@@ -51,7 +52,8 @@ module KubernetesDeploy
     end
 
     def deploy_failed?
-      @latest_rs&.deploy_failed?
+      @latest_rs&.deploy_failed? &&
+      observed_generation == current_generation
     end
 
     def failure_message

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -8,7 +8,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
-      exists?
+      exists? && observed_generation == current_generation
     end
 
     def deploy_method

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -26,12 +26,15 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
+      observed_generation == current_generation &&
       desired_replicas == rollout_data["availableReplicas"].to_i &&
       desired_replicas == rollout_data["readyReplicas"].to_i
     end
 
     def deploy_failed?
-      pods.present? && pods.all?(&:deploy_failed?)
+      pods.present? &&
+      pods.all?(&:deploy_failed?) &&
+      observed_generation == current_generation
     end
 
     def desired_replicas

--- a/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
@@ -30,6 +30,7 @@ module KubernetesDeploy
         end
         true
       else
+        observed_generation == current_generation &&
         status_data['currentRevision'] == status_data['updateRevision'] &&
         desired_replicas == status_data['readyReplicas'].to_i &&
         desired_replicas == status_data['currentReplicas'].to_i
@@ -38,7 +39,8 @@ module KubernetesDeploy
 
     def deploy_failed?
       return false if update_strategy == ONDELETE
-      pods.present? && pods.any?(&:deploy_failed?)
+      pods.present? && pods.any?(&:deploy_failed?) &&
+      observed_generation == current_generation
     end
 
     private

--- a/test/fixtures/for_unit_tests/deployment_test.yml
+++ b/test/fixtures/for_unit_tests/deployment_test.yml
@@ -33,6 +33,7 @@ spec:
         image: busybox
 status:
   replicas: 3
+  observedGeneration: 2 # current
   conditions:
   - type: Progressing
     status: True
@@ -43,6 +44,7 @@ apiVersion: apps/v1beta1
 kind: ReplicaSet
 metadata:
   name: web-1
+  generation: 1
   labels:
     name: web
     app: hello-cloud
@@ -66,4 +68,5 @@ spec:
       - name: app
         image: busybox
 status:
+  observedGeneration: 1
   replicas: 3

--- a/test/fixtures/for_unit_tests/pod_disruption_budget_test.yml
+++ b/test/fixtures/for_unit_tests/pod_disruption_budget_test.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test
+  generation: 2
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
+status:
+  observedGeneration: 2

--- a/test/fixtures/for_unit_tests/replica_set_test.yml
+++ b/test/fixtures/for_unit_tests/replica_set_test.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: test
+  generation: 2
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: test
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: test
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+status:
+  observedGeneration: 2
+  availableReplicas: 3
+  readyReplicas: 3

--- a/test/fixtures/for_unit_tests/stateful_set_test.yml
+++ b/test/fixtures/for_unit_tests/stateful_set_test.yml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: test-ss
+  generation: 2
+spec:
+  selector:
+    matchLabels:
+      name: test-ss
+      app: hello-cloud
+  serviceName: "test-ss"
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: test-ss
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+status:
+  replicas: 2
+  readyReplicas: 2
+  currentReplicas: 2
+  observedGeneration: 2
+  currentRevision: 2
+  updateRevision: 2

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class PodDisruptionBudgetTest < KubernetesDeploy::TestCase
+  def setup
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
+    super
+  end
+
+  def test_deploy_succeeded_is_true_as_soon_as_controller_observes_new_version
+    template = build_pdb_template(status: { "observedGeneration": 2 })
+    pdb = build_synced_pdb(template: template)
+    assert_predicate pdb, :deploy_succeeded?
+  end
+
+  def test_deploy_succeeded_not_fooled_by_stale_status
+    template = build_pdb_template(status: { "observedGeneration": 1 })
+    pdb = build_synced_pdb(template: template)
+    refute_predicate pdb, :deploy_succeeded?
+  end
+
+  private
+
+  def build_pdb_template(status: {})
+    pdb_fixture.dup.deep_merge("status" => status)
+  end
+
+  def build_synced_pdb(template:)
+    pdb = KubernetesDeploy::PodDisruptionBudget.new(namespace: "test", context: "nope",
+      logger: logger, definition: template)
+    sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+    sync_mediator.kubectl.expects(:run).with("get", "PodDisruptionBudget", "test", "-a", "--output=json").returns(
+      [template.to_json, "", SystemExit.new(0)]
+    )
+    pdb.sync(sync_mediator)
+    pdb
+  end
+
+  def pdb_fixture
+    @pdb_fixture ||= YAML.load_stream(
+      File.read(File.join(fixture_path('for_unit_tests'), 'pod_disruption_budget_test.yml'))
+    ).find { |fixture| fixture["kind"] == "PodDisruptionBudget" }
+  end
+end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ReplicaSetTest < KubernetesDeploy::TestCase
+  def setup
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
+    super
+  end
+
+  def test_deploy_succeeded_is_true_when_generation_and_replica_counts_match
+    template = build_rs_template(status: { "observedGeneration": 2 })
+    rs = build_synced_rs(template: template)
+    assert_predicate rs, :deploy_succeeded?
+  end
+
+  def test_deploy_succeeded_not_fooled_by_stale_status
+    template = build_rs_template(status: { "observedGeneration": 1 })
+    rs = build_synced_rs(template: template)
+    refute_predicate rs, :deploy_succeeded?
+  end
+
+  def test_deploy_failed_ensures_controller_has_observed_deploy
+    template = build_rs_template(status: { "observedGeneration": 1 })
+    rs = build_synced_rs(template: template)
+    rs.stubs(:pods).returns([stub(deploy_failed?: true)])
+    refute_predicate rs, :deploy_failed?
+  end
+
+  private
+
+  def build_rs_template(status: {})
+    rs_fixture.dup.deep_merge("status" => status)
+  end
+
+  def build_synced_rs(template:)
+    rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
+    sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+    sync_mediator.kubectl.expects(:run).with("get", "ReplicaSet", "test", "-a", "--output=json").returns(
+      [template.to_json, "", SystemExit.new(0)]
+    )
+    sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
+      ['{ "items": [] }', "", SystemExit.new(0)]
+    )
+    rs.sync(sync_mediator)
+    rs
+  end
+
+  def rs_fixture
+    @rs_fixture ||= YAML.load_stream(
+      File.read(File.join(fixture_path('for_unit_tests'), 'replica_set_test.yml'))
+    ).find { |fixture| fixture["kind"] == "ReplicaSet" }
+  end
+end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class StatefulSetTest < KubernetesDeploy::TestCase
+  def setup
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
+    super
+  end
+
+  def test_deploy_succeeded_is_true_when_revision_and_replica_counts_match
+    template = build_ss_template(status: { "observedGeneration": 2 })
+    ss = build_synced_ss(template: template)
+    assert_predicate ss, :deploy_succeeded?
+  end
+
+  def test_deploy_failed_ensures_controller_has_observed_deploy
+    template = build_ss_template(status: { "observedGeneration": 1 })
+    ss = build_synced_ss(template: template)
+    refute_predicate ss, :deploy_succeeded?
+  end
+
+  def test_deploy_failed_not_fooled_by_stale_status
+    status = {
+      "observedGeneration": 1,
+      "readyReplicas": 0,
+    }
+    template = build_ss_template(status: status)
+    ss = build_synced_ss(template: template)
+    ss.stubs(:pods).returns([stub(deploy_failed?: true)])
+    refute_predicate ss, :deploy_failed?
+  end
+
+  private
+
+  def build_ss_template(status: {})
+    ss_fixture.dup.deep_merge("status" => status)
+  end
+
+  def build_synced_ss(template:)
+    ss = KubernetesDeploy::StatefulSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
+    sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
+    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json").returns(
+      [template.to_json, "", SystemExit.new(0)]
+    )
+    sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
+      ['{ "items": [] }', "", SystemExit.new(0)]
+    )
+    sync_mediator.kubectl.expects(:server_version).returns(Gem::Version.new("1.8"))
+    ss.sync(sync_mediator)
+    ss
+  end
+
+  def ss_fixture
+    @ss_fixture ||= YAML.load_stream(
+      File.read(File.join(fixture_path('for_unit_tests'), 'stateful_set_test.yml'))
+    ).find { |fixture| fixture["kind"] == "StatefulSet" }
+  end
+end


### PR DESCRIPTION
## Problem

I just observed a instant false positive success on a web deployment. Relevant lines:

```yaml
[INFO][2018-08-07 19:27:25 +0000]	Successfully deployed in 1.9s: [...] Deployment/web
[INFO][2018-08-07 19:27:25 +0000]	Deployment/web                                    3 replicas, 3 updatedReplicas, 3 availableReplicas
```

The rollout definitely did not complete in less than 2s.

Checking the code made me notice that we aren't comparing `metadata.generation` to `status.observedGeneration` before using the status to determine success. This means we might be making that determination with state data, which could explain the above behaviour.

## Solution

Compare `metadata.Generation` to `status.observedGeneration` before `_succeeded?` and `_failed?` determinations whenever possible. I used the API documentation to figure out which controllers actually populate the observed generation.

Since this is a controller race, I can't think of a way to make it happen for integration tests. I have added regression tests at the unit test level. 

@Shopify/cloudx 