### PR TITLE
Replace Apply, for pruning

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -23,7 +23,7 @@ module KubernetesDeploy
     end
 
     def deploy_method
-      :replace
+      :replace_apply
     end
 
     private


### PR DESCRIPTION
Add a new mode `replace_apply`  for `deploy_method`. In this mode a resource will first be replaced/created as if it were just `replace`. It will then be `kubectl apply` because this is done second it should be a noop, expect that it allows for pruning.

Testing this seems tricky...