### PR TITLE
Relax the ejson depenencies constraints

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
   spec.add_dependency "googleauth", "= 0.6.2" # https://github.com/google/google-auth-library-ruby/issues/153
-  spec.add_dependency "ejson", "1.0.1"
+  spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"
 


### PR DESCRIPTION
There is no reason to restrict app to use a specific version of `ejson`, there is nothing indicating that this gem would break if an app uses ejson `1.0.x` or even `1.x.x`. 

