### PR TITLE
Relax googleauth versions

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "= 0.6.2" # https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency "googleauth", "~> 0.6.4" # https://github.com/google/google-auth-library-ruby/issues/153
   spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "~> 0.6", ">= 0.6.4" # https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency "googleauth", "~> 0.6.6" # https://github.com/google/google-auth-library-ruby/issues/153
   spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "~> 0.6", ">= 0.6.4# https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency "googleauth", "~> 0.6", ">= 0.6.4" # https://github.com/google/google-auth-library-ruby/issues/153
   spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "~> 0.6.4" # https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency "googleauth", "~> 0.6", ">= 0.6.4# https://github.com/google/google-auth-library-ruby/issues/153
   spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"

--- a/test/unit/kubernetes-deploy/google_friendly_config_test.rb
+++ b/test/unit/kubernetes-deploy/google_friendly_config_test.rb
@@ -14,7 +14,7 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
   def test_auth_use_default_gcp_success
     config = KubernetesDeploy::KubeclientBuilder::GoogleFriendlyConfig.new(kubeconfig, "")
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
+    stub_request(:post, 'https://oauth2.googleapis.com/token')
       .to_return(
         headers: { 'Content-Type' => 'application/json' },
         body: {
@@ -33,7 +33,7 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
   def test_auth_use_default_gcp_failure
     config = KubernetesDeploy::KubeclientBuilder::GoogleFriendlyConfig.new(kubeconfig, "")
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
+    stub_request(:post, 'https://oauth2.googleapis.com/token')
       .to_return(
         headers: { 'Content-Type' => 'application/json' },
         body: '',


### PR DESCRIPTION
The underlying issue https://github.com/google/google-auth-library-ruby/issues/153 was resolved and released in `0.6.4` https://github.com/googleapis/google-auth-library-ruby/pull/154/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR3.