### PR TITLE
Mocha is not thread-safe, and unit tests should never invoke kubectl

### DIFF
--- a/test/helpers/env_test_helper.rb
+++ b/test/helpers/env_test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module EnvTestHelper
+  extend self
+
   def with_env(key, value)
     old_env_value = ENV[key]
 

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'kubernetes-deploy/runner_task'
+
+module TaskRunnerTestHelper
+  def deploy_task_template(subset = ["template-runner.yml", "configmap-data.yml"])
+    EnvTestHelper.with_env("PRINT_LOGS", "0") do
+      result = deploy_fixtures("hello-cloud", subset: subset) do |fixtures|
+        yield fixtures if block_given?
+      end
+      logging_assertion do |logs|
+        assert_equal true, result, "Deploy failed when it was expected to succeed: \n#{logs}"
+      end
+    end
+    reset_logger
+  end
+
+  def build_task_runner(ns: @namespace, max_watch_seconds: nil)
+    KubernetesDeploy::RunnerTask.new(context: KubeclientHelper::MINIKUBE_CONTEXT, namespace: ns, logger: logger,
+      max_watch_seconds: max_watch_seconds)
+  end
+
+  def run_params(log_lines: 5, log_interval: 0.1, verify_result: true)
+    {
+      task_template: 'hello-cloud-template-runner',
+      entrypoint: ['/bin/sh', '-c'],
+      args: [
+        "i=1; " \
+        "while [ $i -le #{log_lines} ]; do " \
+          "echo \"Line $i\"; " \
+          "sleep #{log_interval};" \
+          "i=$((i+1)); " \
+        "done"
+      ],
+      verify_result: verify_result
+    }
+  end
+end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 
-class RunSerialTest < KubernetesDeploy::IntegrationTest
+class SerialDeployTest < KubernetesDeploy::IntegrationTest
   # This cannot be run in parallel because it either stubs a constant or operates in a non-exclusive namespace
   def test_deploying_to_protected_namespace_with_override_does_not_prune
     KubernetesDeploy::DeployTask.stub_const(:PROTECTED_NAMESPACES, [@namespace]) do

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
+  include TaskRunnerTestHelper
+
+  # Mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety
+  def test_run_without_verify_result_fails_if_pod_was_not_created
+    deploy_task_template
+    task_runner = build_task_runner
+
+    # Sketchy, but stubbing the kubeclient doesn't work (and wouldn't be concurrency-friendly)
+    # Finding a way to reliably trigger a create failure would be much better, if possible
+    mock = mock()
+    mock.expects(:get_namespace)
+    template = kubeclient.get_pod_template('hello-cloud-template-runner', @namespace)
+    mock.expects(:get_pod_template).returns(template)
+    mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
+    task_runner.instance_variable_set(:@kubeclient, mock)
+
+    result = task_runner.run(run_params(verify_result: false))
+    assert_task_run_failure(result)
+
+    assert_logs_match_all([
+      "Running pod",
+      "Result: FAILURE",
+      "Failed to create pod",
+      "Kubeclient::HttpError: Pod with same name exists"
+    ], in_order: true)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,6 +65,7 @@ module KubernetesDeploy
 
     def setup
       unless is_a?(KubernetesDeploy::IntegrationTest)
+        Kubectl.any_instance.expects(:run).never
         WebMock.disable_net_connect!
       end
       @logger_stream = StringIO.new

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
-  def setup
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-    super
-  end
-
   def test_secret_changes_required_based_on_ejson_file_existence
     stub_kubectl_response("get", "secrets", "--output=json", resp: { items: [dummy_ejson_secret] })
 

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 
 class KubectlTest < KubernetesDeploy::TestCase
   def setup
-    Open3.expects(:capture3).never
     super
+    KubernetesDeploy::Kubectl.any_instance.unstub(:run)
+    Open3.expects(:capture3).never
   end
 
   def test_raises_if_initialized_with_null_context

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class DaemonSetTest < KubernetesDeploy::TestCase
-  def setup
-    super
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-  end
-
   def test_deploy_not_successful_when_updated_available_does_not_match
     ds_template = build_ds_template
     ds = build_synced_ds(template: ds_template)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class DeploymentTest < KubernetesDeploy::TestCase
-  def setup
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-    super
-  end
-
   def test_deploy_succeeded_with_none_annotation
     deployment_status = {
       "replicas" => 3,

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class PodDisruptionBudgetTest < KubernetesDeploy::TestCase
-  def setup
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-    super
-  end
-
   def test_deploy_succeeded_is_true_as_soon_as_controller_observes_new_version
     template = build_pdb_template(status: { "observedGeneration": 2 })
     pdb = build_synced_pdb(template: template)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -196,6 +196,7 @@ class PodTest < KubernetesDeploy::TestCase
       logger: @logger, deploy_started_at: Time.now.utc)
     mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
     mediator.expects(:get_instance).with('Pod', anything).returns(template)
+    KubernetesDeploy::ContainerLogs.any_instance.stubs(:sync)
     pod.sync(mediator)
     pod
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class ReplicaSetTest < KubernetesDeploy::TestCase
-  def setup
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-    super
-  end
-
   def test_deploy_succeeded_is_true_when_generation_and_replica_counts_match
     template = build_rs_template(status: { "observedGeneration": 2 })
     rs = build_synced_rs(template: template)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -2,11 +2,6 @@
 require 'test_helper'
 
 class StatefulSetTest < KubernetesDeploy::TestCase
-  def setup
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).never
-    super
-  end
-
   def test_deploy_succeeded_is_true_when_revision_and_replica_counts_match
     template = build_ss_template(status: { "observedGeneration": 2 })
     ss = build_synced_ss(template: template)


### PR DESCRIPTION
The reason for the intermittent mock failure I was seeing in CI ([example](https://buildkite.com/shopify/kubernetes-deploy-gem/builds/1050#5653d9e2-29d1-4aa6-af42-cd3e50109f6b)) is that mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety

> Mocha is currently not thread-safe. There are two main reasons for this: (a) in multi-threaded code Mocha exceptions may be raised in a thread other than the one which is running the test and thus a Mocha exception may not be correctly intercepted by Mocha exception handling code; and (b) partial mocking changes the state of objects in the ObjectSpace which is shared across all threads in the Ruby process and this access to what is effectively global state is not synchronized.

This moves the integration tests that uses mocks to a new serially-run integration test file for the task runner (which required extracting shared helpers). **The test and helpers are unmodified.**

I also noticed that my PR caused a real `kubectl` call to happen during unit tests, which isn't obvious until you try to run them when your local cluster is unavailable. I added an `expects.never` on all kubectl instances in the same place where we disable net connect for unit tests. Previously many but not all suites were doing this in their individual setup.