### PR TITLE
Unmanaged pods should fail fast when evicted/preempted/deleted

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -93,8 +93,6 @@ module KubernetesDeploy
       kubectl.server_version
     end
 
-    NOT_FOUND_ERROR = 'NotFound'
-
     def initialize(namespace:, context:, current_sha:, template_dir:, logger:, kubectl_instance: nil, bindings: {},
       max_watch_seconds: nil)
       @namespace = namespace
@@ -399,7 +397,7 @@ module KubernetesDeploy
 
     def apply_all(resources, prune)
       return unless resources.present?
-      command = ["apply"]
+      command = %w(apply)
 
       Dir.mktmpdir do |tmp_dir|
         resources.each do |r|
@@ -500,7 +498,7 @@ module KubernetesDeploy
       st, err = nil
       with_retries(2) do
         _, err, st = kubectl.run("get", "namespace", @namespace, use_namespace: false, log_failure: true)
-        st.success? || err.include?(NOT_FOUND_ERROR)
+        st.success? || err.include?(KubernetesDeploy::Kubectl::NOT_FOUND_ERROR_TEXT)
       end
       raise FatalDeploymentError, "Failed to find namespace. #{err}" unless st.success?
       @logger.info("Namespace #{@namespace} found")

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -20,7 +20,7 @@ module KubernetesDeploy
       raise ArgumentError, "context is required" if context.blank?
     end
 
-    def run(*args, log_failure: nil, use_context: true, use_namespace: true, raise_on_404: false)
+    def run(*args, log_failure: nil, use_context: true, use_namespace: true, raise_if_not_found: false)
       log_failure = @log_failure_by_default if log_failure.nil?
 
       args = args.unshift("kubectl")
@@ -38,7 +38,7 @@ module KubernetesDeploy
           @logger.warn(err) unless output_is_sensitive?
         end
 
-        if raise_on_404 && err.match(NOT_FOUND_ERROR_TEXT)
+        if raise_if_not_found && err.match(NOT_FOUND_ERROR_TEXT)
           raise ResourceNotFoundError, err
         end
       end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -122,7 +122,7 @@ module KubernetesDeploy
     end
 
     def sync(mediator)
-      @instance_data = mediator.get_instance(kubectl_resource_type, name, raise_on_404: true)
+      @instance_data = mediator.get_instance(kubectl_resource_type, name, raise_if_not_found: true)
     rescue KubernetesDeploy::Kubectl::ResourceNotFoundError
       @disappeared = true if deploy_started?
       @instance_data = {}
@@ -131,7 +131,7 @@ module KubernetesDeploy
     def after_sync
     end
 
-    def deleted?
+    def terminating?
       @instance_data.dig('metadata', 'deletionTimestamp').present?
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -201,22 +201,26 @@ module KubernetesDeploy
     def debug_message(cause = nil, info_hash = {})
       helpful_info = []
       if cause == :gave_up
-        helpful_info << ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
+        debug_heading = ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
         helpful_info << "If you expected it to take longer than #{info_hash[:timeout]} seconds for your deploy"\
         " to roll out, increase --max-watch-seconds."
       elsif deploy_failed?
-        helpful_info << ColorizedString.new("#{id}: FAILED").red
+        debug_heading = ColorizedString.new("#{id}: FAILED").red
         helpful_info << failure_message if failure_message.present?
       elsif deploy_timed_out?
-        helpful_info << ColorizedString.new("#{id}: TIMED OUT (#{pretty_timeout_type})").yellow
+        debug_heading = ColorizedString.new("#{id}: TIMED OUT (#{pretty_timeout_type})").yellow
         helpful_info << timeout_message if timeout_message.present?
       else
         # Arriving in debug_message when we neither failed nor timed out is very unexpected. Dump all available info.
-        helpful_info << ColorizedString.new("#{id}: MONITORING ERROR").red
+        debug_heading = ColorizedString.new("#{id}: MONITORING ERROR").red
         helpful_info << failure_message if failure_message.present?
         helpful_info << timeout_message if timeout_message.present? && timeout_message != STANDARD_TIMEOUT_MESSAGE
       end
-      helpful_info << "  - Final status: #{status}"
+
+      final_status = "  - Final status: #{status}"
+      final_status = "\n#{final_status}" if helpful_info.present? && !helpful_info.last.end_with?("\n")
+      helpful_info.prepend(debug_heading)
+      helpful_info << final_status
 
       if @debug_events.present?
         helpful_info << "  - Events (common success events excluded):"

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -66,7 +66,7 @@ module KubernetesDeploy
       return STANDARD_TIMEOUT_MESSAGE unless readiness_probe_failure?
       probe_failure_msgs = @containers.map(&:readiness_fail_reason).compact
       header = "The following containers have not passed their readiness probes on at least one pod:\n"
-      header + probe_failure_msgs.join("\n") + "\n"
+      header + probe_failure_msgs.join("\n")
     end
 
     def failure_message
@@ -82,7 +82,7 @@ module KubernetesDeploy
           container_problems += "> #{red_name}: #{c.doom_reason}\n"
         end
       end
-      "#{phase_failure_message} #{container_problems}".lstrip.presence
+      "#{phase_failure_message} #{container_problems}".strip.presence
     end
 
     def fetch_debug_logs(kubectl)

--- a/lib/kubernetes-deploy/sync_mediator.rb
+++ b/lib/kubernetes-deploy/sync_mediator.rb
@@ -10,13 +10,13 @@ module KubernetesDeploy
       clear_cache
     end
 
-    def get_instance(kind, resource_name, raise_on_404: false)
+    def get_instance(kind, resource_name, raise_if_not_found: false)
       unless @cache.key?(kind)
-        return request_instance(kind, resource_name, raise_on_404: raise_on_404)
+        return request_instance(kind, resource_name, raise_if_not_found: raise_if_not_found)
       end
 
       cached_instance = @cache[kind].fetch(resource_name, {})
-      if cached_instance.blank? && raise_on_404
+      if cached_instance.blank? && raise_if_not_found
         raise KubernetesDeploy::Kubectl::ResourceNotFoundError, "Resource does not exist (used cache for kind #{kind})"
       end
       cached_instance
@@ -59,17 +59,21 @@ module KubernetesDeploy
       @cache = {}
     end
 
-    def request_instance(kind, iname, raise_on_404:)
-      raw_json, _err, st = kubectl.run("get", kind, iname, "-a", "--output=json", raise_on_404: raise_on_404)
+    def request_instance(kind, iname, raise_if_not_found:)
+      raw_json, _err, st = kubectl.run("get", kind, iname, "-a", "--output=json", raise_if_not_found: raise_if_not_found)
       st.success? ? JSON.parse(raw_json) : {}
     end
 
     def fetch_by_kind(kind)
       raw_json, _, st = kubectl.run("get", kind, "-a", "--output=json")
       return unless st.success?
-      @cache[kind] = JSON.parse(raw_json)["items"].each_with_object({}) do |r, instances|
-        instances[r.dig("metadata", "name")] = r
+
+      instances = {}
+      JSON.parse(raw_json)["items"].each do |resource|
+        resource_name = resource.dig("metadata", "name")
+        instances[resource_name] = resource
       end
+      @cache[kind] = instances
     end
   end
 end

--- a/lib/kubernetes-deploy/sync_mediator.rb
+++ b/lib/kubernetes-deploy/sync_mediator.rb
@@ -60,7 +60,8 @@ module KubernetesDeploy
     end
 
     def request_instance(kind, iname, raise_if_not_found:)
-      raw_json, _err, st = kubectl.run("get", kind, iname, "-a", "--output=json", raise_if_not_found: raise_if_not_found)
+      raw_json, _err, st = kubectl.run("get", kind, iname, "-a", "--output=json",
+        raise_if_not_found: raise_if_not_found)
       st.success? ? JSON.parse(raw_json) : {}
     end
 

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -106,6 +106,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
         sleep 0.1
       end
     end
+    deleter_thread.abort_on_exception = true
 
     result = task_runner.run(run_params(log_lines: 20, log_interval: 1))
     assert_task_run_failure(result)
@@ -116,10 +117,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       /Pod status\: (Terminating|Disappeared)/,
     ])
   ensure
-    if deleter_thread
-      deleter_thread.join # make sure we see any error messages raised in the thread
-      deleter_thread.kill
-    end
+    deleter_thread&.kill
   end
 
   def test_run_with_verify_result_neither_misses_nor_duplicates_logs_across_pollings

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -113,7 +113,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Pod creation succeeded",
       "Result: FAILURE",
-      "Pod status: Terminating",
+      /Pod status\: (Terminating|Disappeared)/,
     ])
   ensure
     if deleter_thread

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -117,7 +117,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     ])
   ensure
     if deleter_thread
-      deleter_thread.join
+      deleter_thread.join # make sure we see any error messages raised in the thread
       deleter_thread.kill
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -194,13 +194,12 @@ module KubernetesDeploy
       source_dir
     end
 
-    def stub_kubectl_response(*args, resp:, err: "", success: true, json: true, times: 1)
+    def stub_kubectl_response(*args, resp:, err: "", raise_on_404: nil, success: true, json: true, times: 1)
       resp = resp.to_json if json
       response = [resp, err, stub(success?: success)]
-      KubernetesDeploy::Kubectl.any_instance.expects(:run)
-        .with(*args)
-        .returns(response)
-        .times(times)
+      expectation = KubernetesDeploy::Kubectl.any_instance.expects(:run)
+      expectation = raise_on_404.nil? ? expectation.with(*args) : expectation.with(*args, raise_on_404: raise_on_404)
+      expectation.returns(response).times(times)
     end
 
     def build_runless_kubectl

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -194,11 +194,11 @@ module KubernetesDeploy
       source_dir
     end
 
-    def stub_kubectl_response(*args, resp:, err: "", raise_on_404: nil, success: true, json: true, times: 1)
+    def stub_kubectl_response(*args, resp:, err: "", raise_if_not_found: nil, success: true, json: true, times: 1)
       resp = resp.to_json if json
       response = [resp, err, stub(success?: success)]
       expectation = KubernetesDeploy::Kubectl.any_instance.expects(:run)
-      expectation = raise_on_404.nil? ? expectation.with(*args) : expectation.with(*args, raise_on_404: raise_on_404)
+      expectation = raise_if_not_found.nil? ? expectation.with(*args) : expectation.with(*args, raise_if_not_found: raise_if_not_found)
       expectation.returns(response).times(times)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -197,8 +197,13 @@ module KubernetesDeploy
     def stub_kubectl_response(*args, resp:, err: "", raise_if_not_found: nil, success: true, json: true, times: 1)
       resp = resp.to_json if json
       response = [resp, err, stub(success?: success)]
-      expectation = KubernetesDeploy::Kubectl.any_instance.expects(:run)
-      expectation = raise_if_not_found.nil? ? expectation.with(*args) : expectation.with(*args, raise_if_not_found: raise_if_not_found)
+
+      expectation = if raise_if_not_found.nil?
+        KubernetesDeploy::Kubectl.any_instance.expects(:run).with(*args)
+      else
+        KubernetesDeploy::Kubectl.any_instance.expects(:run).with(*args, raise_if_not_found: raise_if_not_found)
+      end
+
       expectation.returns(response).times(times)
     end
 

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -137,6 +137,22 @@ class KubectlTest < KubernetesDeploy::TestCase
     end
   end
 
+  def test_run_with_raise_err_on_404_raises_the_correct_thing
+    err = 'Error from server (NotFound): pods "foobar" not found'
+    stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
+      resp: "", err: err, success: false)
+    assert_raises_message(KubernetesDeploy::Kubectl::ResourceNotFoundError, err) do
+      build_kubectl.run("get", "pod", "foobar", raise_on_404: true)
+    end
+  end
+
+  def test_run_with_raise_err_on_404_does_not_raise_on_other_errors
+    err = 'Error from server (TooManyRequests): Please try again later'
+    stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
+      resp: "", err: err, success: false)
+    build_kubectl.run("get", "pod", "foobar", raise_on_404: true)
+  end
+
   private
 
   def stub_version_request(client:, server:)

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -137,7 +137,7 @@ class KubectlTest < KubernetesDeploy::TestCase
     end
   end
 
-  def test_run_with_raise_err_on_404_raises_the_correct_thing
+  def test_run_with_raise_if_not_found_raises_the_correct_thing
     err = 'Error from server (NotFound): pods "foobar" not found'
     stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
       resp: "", err: err, success: false)
@@ -146,7 +146,7 @@ class KubectlTest < KubernetesDeploy::TestCase
     end
   end
 
-  def test_run_with_raise_err_on_404_does_not_raise_on_other_errors
+  def test_run_with_raise_if_not_found_does_not_raise_on_other_errors
     err = 'Error from server (TooManyRequests): Please try again later'
     stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
       resp: "", err: err, success: false)

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -142,7 +142,7 @@ class KubectlTest < KubernetesDeploy::TestCase
     stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
       resp: "", err: err, success: false)
     assert_raises_message(KubernetesDeploy::Kubectl::ResourceNotFoundError, err) do
-      build_kubectl.run("get", "pod", "foobar", raise_on_404: true)
+      build_kubectl.run("get", "pod", "foobar", raise_if_not_found: true)
     end
   end
 
@@ -150,7 +150,7 @@ class KubectlTest < KubernetesDeploy::TestCase
     err = 'Error from server (TooManyRequests): Please try again later'
     stub_open3(%w(kubectl get pod foobar --namespace=testn --context=testc --request-timeout=30),
       resp: "", err: err, success: false)
-    build_kubectl.run("get", "pod", "foobar", raise_on_404: true)
+    build_kubectl.run("get", "pod", "foobar", raise_if_not_found: true)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -51,9 +51,8 @@ class DaemonSetTest < KubernetesDeploy::TestCase
   def build_synced_ds(template:)
     ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = build_sync_mediator
-    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json").returns(
-      [template.to_json, "", SystemExit.new(0)]
-    )
+    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json", raise_on_404: true)
+      .returns([template.to_json, "", SystemExit.new(0)])
 
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -51,7 +51,8 @@ class DaemonSetTest < KubernetesDeploy::TestCase
   def build_synced_ds(template:)
     ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = build_sync_mediator
-    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json", raise_if_not_found: true)
+    sync_mediator.kubectl.expects(:run)
+      .with("get", "DaemonSet", "ds-app", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
 
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -51,7 +51,7 @@ class DaemonSetTest < KubernetesDeploy::TestCase
   def build_synced_ds(template:)
     ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = build_sync_mediator
-    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json", raise_on_404: true)
+    sync_mediator.kubectl.expects(:run).with("get", "DaemonSet", "ds-app", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
 
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -367,9 +367,9 @@ class DeploymentTest < KubernetesDeploy::TestCase
   def build_synced_deployment(template:, replica_sets:, server_version: Gem::Version.new("1.8"))
     deploy = KubernetesDeploy::Deployment.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = build_sync_mediator
-    sync_mediator.kubectl.expects(:run).with("get", "Deployment", "web", "-a", "--output=json").returns(
-      [template.to_json, "", SystemExit.new(0)]
-    )
+    sync_mediator.kubectl.expects(:run)
+      .with("get", "Deployment", "web", "-a", "--output=json", raise_on_404: true)
+      .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:server_version).returns(server_version)
 
     if replica_sets.present?

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -368,7 +368,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
     deploy = KubernetesDeploy::Deployment.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = build_sync_mediator
     sync_mediator.kubectl.expects(:run)
-      .with("get", "Deployment", "web", "-a", "--output=json", raise_on_404: true)
+      .with("get", "Deployment", "web", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:server_version).returns(server_version)
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
@@ -24,9 +24,9 @@ class PodDisruptionBudgetTest < KubernetesDeploy::TestCase
     pdb = KubernetesDeploy::PodDisruptionBudget.new(namespace: "test", context: "nope",
       logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
-    sync_mediator.kubectl.expects(:run).with("get", "PodDisruptionBudget", "test", "-a", "--output=json").returns(
-      [template.to_json, "", SystemExit.new(0)]
-    )
+    sync_mediator.kubectl.expects(:run)
+      .with("get", "PodDisruptionBudget", "test", "-a", "--output=json", raise_on_404: true)
+      .returns([template.to_json, "", SystemExit.new(0)])
     pdb.sync(sync_mediator)
     pdb
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
@@ -25,7 +25,7 @@ class PodDisruptionBudgetTest < KubernetesDeploy::TestCase
       logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
     sync_mediator.kubectl.expects(:run)
-      .with("get", "PodDisruptionBudget", "test", "-a", "--output=json", raise_on_404: true)
+      .with("get", "PodDisruptionBudget", "test", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
     pdb.sync(sync_mediator)
     pdb

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -18,7 +18,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_missing_tag_error
@@ -38,7 +38,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_false_for_intermittent_image_error
@@ -72,7 +72,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_container_config_error_post_18
@@ -91,7 +91,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to generate container configuration: The reason it failed
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_container_config_error_pre_18
@@ -110,7 +110,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to generate container configuration: The reason it failed
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_crash_loop_backoffs
@@ -132,7 +132,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Crashing repeatedly (exit 1). See logs for more information.
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_container_cannot_run_error
@@ -152,7 +152,7 @@ class PodTest < KubernetesDeploy::TestCase
       The following containers encountered errors:
       > hello-cloud: Failed to start (exit 127): /not/a/command: no such file or directory
     STRING
-    assert_equal expected_msg, pod.failure_message
+    assert_equal expected_msg.strip, pod.failure_message
   end
 
   def test_deploy_failed_is_true_for_evicted_unmanaged_pods
@@ -167,7 +167,7 @@ class PodTest < KubernetesDeploy::TestCase
     pod = build_synced_pod(template)
 
     assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Failed (Reason: Evicted). ", pod.failure_message
+    assert_equal "Pod status: Failed (Reason: Evicted).", pod.failure_message
   end
 
   def test_deploy_failed_is_false_for_evicted_managed_pods
@@ -197,7 +197,7 @@ class PodTest < KubernetesDeploy::TestCase
     pod = build_synced_pod(template)
 
     assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Failed (Reason: Preempting). ", pod.failure_message
+    assert_equal "Pod status: Failed (Reason: Preempting).", pod.failure_message
   end
 
   def test_deploy_failed_is_false_for_preempted_managed_pods
@@ -222,7 +222,7 @@ class PodTest < KubernetesDeploy::TestCase
 
     assert_predicate pod, :terminating?
     assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Terminating. ", pod.failure_message
+    assert_equal "Pod status: Terminating.", pod.failure_message
   end
 
   def test_deploy_failed_is_false_for_terminating_managed_pods
@@ -245,7 +245,7 @@ class PodTest < KubernetesDeploy::TestCase
 
     assert_predicate pod, :disappeared?
     assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Disappeared. ", pod.failure_message
+    assert_equal "Pod status: Disappeared.", pod.failure_message
   end
 
   def test_deploy_failed_is_false_for_disappeared_managed_pods

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -31,7 +31,7 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
     rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
     sync_mediator.kubectl.expects(:run)
-      .with("get", "ReplicaSet", "test", "-a", "--output=json", raise_on_404: true)
+      .with("get", "ReplicaSet", "test", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -30,9 +30,9 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
   def build_synced_rs(template:)
     rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
-    sync_mediator.kubectl.expects(:run).with("get", "ReplicaSet", "test", "-a", "--output=json").returns(
-      [template.to_json, "", SystemExit.new(0)]
-    )
+    sync_mediator.kubectl.expects(:run)
+      .with("get", "ReplicaSet", "test", "-a", "--output=json", raise_on_404: true)
+      .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]
     )

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -7,13 +7,13 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc = build_service(svc_def)
 
     stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", success: false,
-      resp: {}, raise_on_404: true)
+      resp: {}, raise_if_not_found: true)
     svc.sync(build_sync_mediator)
     refute svc.exists?
     refute svc.deploy_succeeded?
     assert_equal "Not found", svc.status
 
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -24,7 +24,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('selectorless')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -38,9 +38,9 @@ class ServiceTest < KubernetesDeploy::TestCase
       build_service(service_fixture('zero-replica'))
     ]
 
-    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: {}, raise_on_404: true)
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: {}, raise_on_404: true)
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: {}, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: {}, raise_if_not_found: true)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: {}, raise_if_not_found: true)
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: {}, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: pod_fixtures })
 
@@ -57,7 +57,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('standard')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)
@@ -66,7 +66,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     refute svc.deploy_succeeded?
     assert_equal "Selects 0 pods", svc.status
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: pod_fixtures })
     svc.sync(build_sync_mediator)
@@ -80,7 +80,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('standard')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: [] })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)
@@ -94,7 +94,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('zero-replica')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: svc_def, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -6,13 +6,14 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('external-name')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", success: false, resp: {})
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", success: false,
+      resp: {}, raise_on_404: true)
     svc.sync(build_sync_mediator)
     refute svc.exists?
     refute svc.deploy_succeeded?
     assert_equal "Not found", svc.status
 
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -23,7 +24,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('selectorless')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -37,9 +38,9 @@ class ServiceTest < KubernetesDeploy::TestCase
       build_service(service_fixture('zero-replica'))
     ]
 
-    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: {})
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: {})
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: {})
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: {}, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: {}, raise_on_404: true)
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: {}, raise_on_404: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: pod_fixtures })
 
@@ -56,7 +57,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('standard')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)
@@ -65,7 +66,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     refute svc.deploy_succeeded?
     assert_equal "Selects 0 pods", svc.status
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: pod_fixtures })
     svc.sync(build_sync_mediator)
@@ -79,7 +80,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('standard')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "standard", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: [] })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)
@@ -93,7 +94,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('zero-replica')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: svc_def)
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: svc_def, raise_on_404: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -13,7 +13,8 @@ class ServiceTest < KubernetesDeploy::TestCase
     refute svc.deploy_succeeded?
     assert_equal "Not found", svc.status
 
-    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
+    stub_kubectl_response("get", "Service", "external-name", "-a", "--output=json",
+      resp: svc_def, raise_if_not_found: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -24,7 +25,8 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('selectorless')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
+    stub_kubectl_response("get", "Service", "selectorless", "-a", "--output=json",
+      resp: svc_def, raise_if_not_found: true)
     svc.sync(build_sync_mediator)
     assert svc.exists?
     assert svc.deploy_succeeded?
@@ -94,7 +96,8 @@ class ServiceTest < KubernetesDeploy::TestCase
     svc_def = service_fixture('zero-replica')
     svc = build_service(svc_def)
 
-    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json", resp: svc_def, raise_if_not_found: true)
+    stub_kubectl_response("get", "Service", "zero-replica", "-a", "--output=json",
+      resp: svc_def, raise_if_not_found: true)
     stub_kubectl_response("get", "Deployment", "-a", "--output=json", resp: { items: deployment_fixtures })
     stub_kubectl_response("get", "Pod", "-a", "--output=json", resp: { items: [] })
     svc.sync(build_sync_mediator)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -34,7 +34,7 @@ class StatefulSetTest < KubernetesDeploy::TestCase
   def build_synced_ss(template:)
     ss = KubernetesDeploy::StatefulSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
-    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json", raise_on_404: true)
+    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -34,9 +34,8 @@ class StatefulSetTest < KubernetesDeploy::TestCase
   def build_synced_ss(template:)
     ss = KubernetesDeploy::StatefulSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
-    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json").returns(
-      [template.to_json, "", SystemExit.new(0)]
-    )
+    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json", raise_on_404: true)
+      .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]
     )

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -34,7 +34,8 @@ class StatefulSetTest < KubernetesDeploy::TestCase
   def build_synced_ss(template:)
     ss = KubernetesDeploy::StatefulSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
-    sync_mediator.kubectl.expects(:run).with("get", "StatefulSet", "test-ss", "-a", "--output=json", raise_if_not_found: true)
+    sync_mediator.kubectl.expects(:run)
+      .with("get", "StatefulSet", "test-ss", "-a", "--output=json", raise_if_not_found: true)
       .returns([template.to_json, "", SystemExit.new(0)])
     sync_mediator.kubectl.expects(:run).with("get", "Pod", "-a", "--output=json", anything).returns(
       ['{ "items": [] }', "", SystemExit.new(0)]

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -224,6 +224,43 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     end
   end
 
+  def test_whitespace_in_debug_message
+    dummy = DummyResource.new
+    dummy.deploy_failed = true
+    expected_message = <<~STRING
+      DummyResource/test: FAILED
+        - Final status: Exists
+        - Events: None found. Please check your usual logging service (e.g. Splunk).
+        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+    STRING
+    assert_equal expected_message.strip, dummy.debug_message
+
+    dummy.stubs(:failure_message).returns("Something went wrong I guess")
+
+    expected_message = <<~STRING
+      DummyResource/test: FAILED
+      Something went wrong I guess
+
+        - Final status: Exists
+        - Events: None found. Please check your usual logging service (e.g. Splunk).
+        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+    STRING
+    assert_equal expected_message.strip, dummy.debug_message
+
+    dummy.stubs(:failure_message).returns("Something went wrong I guess\n> Some container: boom!\n")
+
+    expected_message = <<~STRING
+      DummyResource/test: FAILED
+      Something went wrong I guess
+      > Some container: boom!
+
+        - Final status: Exists
+        - Events: None found. Please check your usual logging service (e.g. Splunk).
+        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+    STRING
+    assert_equal expected_message.strip, dummy.debug_message
+  end
+
   def test_disappeared_is_true_if_resource_has_been_deployed_and_404s
     dummy = DummyResource.new
     mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)

--- a/test/unit/sync_mediator_test.rb
+++ b/test/unit/sync_mediator_test.rb
@@ -13,15 +13,15 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
 
   def test_get_instance_retrieves_the_resource_and_leaves_the_cache_alone_when_cache_is_empty
     stub_kubectl_response('get', 'FakeConfigMap', @fake_cm.name, *@params,
-      raise_on_404: false, resp: @fake_cm.kubectl_response)
+      raise_if_not_found: false, resp: @fake_cm.kubectl_response)
     assert_equal @fake_cm.kubectl_response, mediator.get_instance('FakeConfigMap', @fake_cm.name)
 
     # get_instance shouldn't populate the cache, so these new calls should make new requests and return correct results
-    stub_kubectl_response('get', 'FakeConfigMap', 'does-not-exist', *@params, raise_on_404: false, resp: {})
+    stub_kubectl_response('get', 'FakeConfigMap', 'does-not-exist', *@params, raise_if_not_found: false, resp: {})
     assert_equal({}, mediator.get_instance('FakeConfigMap', 'does-not-exist'))
 
     stub_kubectl_response('get', 'FakeConfigMap', @fake_cm2.name, *@params,
-      raise_on_404: false, resp: @fake_cm2.kubectl_response)
+      raise_if_not_found: false, resp: @fake_cm2.kubectl_response)
     assert_equal @fake_cm2.kubectl_response, mediator.get_instance('FakeConfigMap', @fake_cm2.name)
   end
 
@@ -32,7 +32,7 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
 
     # Only configmap is cached, so we should still make a request and get a result for a Deployment
     stub_kubectl_response('get', 'FakeDeployment', @fake_deployment.name, *@params,
-      raise_on_404: false, resp: @fake_deployment.kubectl_response)
+      raise_if_not_found: false, resp: @fake_deployment.kubectl_response)
     uncached = mediator.get_instance('FakeDeployment', @fake_deployment.name)
     assert_equal @fake_deployment.name, uncached.dig('metadata', 'name')
 
@@ -55,7 +55,7 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
   def test_get_all_does_not_cache_error_result_from_kubectl
     stub_kubectl_response('get', 'FakeConfigMap', *@params, success: false, resp: { "items" => [] }, err: 'no').times(2)
     stub_kubectl_response('get', 'FakeConfigMap', @fake_cm.name, *@params,
-      raise_on_404: false, resp: @fake_cm.kubectl_response, times: 1)
+      raise_if_not_found: false, resp: @fake_cm.kubectl_response, times: 1)
 
     # Neither the main code path nor the selector-based code path should cause error results to be cached
     assert_equal [], mediator.get_all('FakeConfigMap')
@@ -143,7 +143,7 @@ class SyncMediatorTest < KubernetesDeploy::TestCase
     mediator.sync(test_resources)
 
     stub_kubectl_response('get', 'FakeConfigMap', @fake_cm.name, *@params,
-      raise_on_404: false, resp: @fake_cm.kubectl_response, times: 1)
+      raise_if_not_found: false, resp: @fake_cm.kubectl_response, times: 1)
     mediator.get_instance('FakeConfigMap', @fake_cm.name)
   end
 


### PR DESCRIPTION
## Purpose

- Bugfix: Unmanaged pods should fail fast if they're evicted or preempted. Previously, we made pods' failure condition ignore these two statuses, because it was very occasionally making a parent's deploy fail incorrectly because the parent was unlucky enough to have all its children hit one of those conditions (which are recoverable, because the parent spawns replacement children). For unmanaged pods, these states are not recoverable and should not be ignored.
- Improvement: We should not wait around forever if a pod is deleted out of band. If we've deployed it and it doesn't exist, it isn't magically going to appear in the future. This is especially important for the runner. Note that I'm continuing to treat non-404 errors as transient. Related to https://github.com/Shopify/kubernetes-deploy/issues/347
- Improvement: same as above, but handles the window where the deletion request has been made successfully but the pod isn't actually gone yet (i.e. deletion timestamp is set). **Reviewers, do you agree with this?** The containers should at least have received SIGTERM when we see this, but they may still be running.

## Things I don't like

- I think we should try splitting `Pod` into `Pod` and `ManagedPod`. _Many_ of its methods do different things based on whether or not it has a parent. I don't think that is necessary for this PR though.
- The `disappeared?` thing should be implemented for all resources, not just this one (https://github.com/Shopify/kubernetes-deploy/issues/347). I do think this is a good start though, and it is a lot more important for pods (because of kubernetes-run).
- Because we're using kubectl to get these resources (which is _really_ difficult to change at this point), I can't check the actual response status. The "404" check is actually looking for a non-zero exit and an error string.
- I had to change a ton of the unit tests to accommodate the new `raise_on_404` option. We could probably improve the mocking strategy to make this less painful, but I just brute-forced it for now.

cc @Shopify/cloudx 