### PR TITLE
Predeploy RoleBinding before unmanaged pods

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -52,6 +52,7 @@ module KubernetesDeploy
       ConfigMap
       PersistentVolumeClaim
       ServiceAccount
+      RoleBinding
       Pod
     )
 

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -76,6 +76,14 @@ module KubernetesDeploy
       )
     end
 
+    def build_rbac_v1beta1_kubeclient(context)
+      _build_kubeclient(
+        api_version: "v1",
+        context: context,
+        endpoint_path: "/apis/rbac.authorization.k8s.io"
+      )
+    end
+
     def _build_kubeclient(api_version:, context:, endpoint_path: nil)
       # Find a context defined in kube conf files that matches the input context by name
       friendly_configs = config_files.map { |f| GoogleFriendlyConfig.read(f) }

--- a/lib/kubernetes-deploy/kubernetes_resource/role_binding.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/role_binding.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class RoleBinding < KubernetesResource
+    TIMEOUT = 30.seconds
+
+    def status
+      exists? ? "Created" : "Unknown"
+    end
+
+    def deploy_succeeded?
+      exists?
+    end
+
+    def deploy_failed?
+      false
+    end
+
+    def timeout_message
+      UNUSUAL_FAILURE_MESSAGE
+    end
+  end
+end

--- a/test/fixtures/hello-cloud/role-binding.yml
+++ b/test/fixtures/hello-cloud/role-binding.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: build-robot

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -144,6 +144,12 @@ module FixtureSetAssertions
       assert desired.present?, "Service account #{name} does not exist"
     end
 
+    def assert_role_binding_present(name)
+      role_bindings = rbac_v1beta1_kubeclient.get_role_bindings(namespace: namespace)
+      desired = role_bindings.find { |sa| sa.metadata.name == name }
+      assert desired.present?, "Role binding #{name} does not exist"
+    end
+
     def assert_annotated(obj, annotation)
       annotations = obj.metadata.annotations.to_h.stringify_keys
       assert annotations.key?(annotation), "Expected secret to have annotation #{annotation}, but it did not"

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -15,6 +15,7 @@ module FixtureSetAssertions
       assert_poddisruptionbudget
       assert_bare_replicaset_up
       assert_all_service_accounts_up
+      assert_all_role_bindings_up
       assert_daemon_set_up
       assert_stateful_set_up
       assert_job_up
@@ -86,6 +87,10 @@ module FixtureSetAssertions
 
     def assert_all_service_accounts_up
       assert_service_account_present("build-robot")
+    end
+
+    def assert_all_role_bindings_up
+      assert_role_binding_present("role-binding")
     end
 
     def assert_daemon_set_up

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -41,4 +41,8 @@ module KubeclientHelper
   def autoscaling_v1_kubeclient
     @autoscaling_v1_kubeclient ||= build_autoscaling_v1_kubeclient(TEST_CONTEXT)
   end
+
+  def rbac_v1beta1_kubeclient
+    @rbac_v1beta1_kubeclient ||= build_rbac_v1beta1_kubeclient(TEST_CONTEXT)
+  end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -62,6 +62,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_configmap_data_present
     hello_cloud.assert_all_service_accounts_up
+    hello_cloud.assert_all_role_bindings_up
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: RoleBinding/role-binding},


### PR DESCRIPTION
RoleBindings should be deployed before unmanaged pods. This matters when RoleBindings define Pod Security Policies. This might prevent unmanaged pods from starting unless RoleBinding has been set up and the deployment fails.

For normal deployments only scenario it already works. Even if there is a race condition, it works as the pods retry.

Should there be a separate resource type? Other similar resource types seemed to have also the corresponding class defined.