### PR TITLE
Fix problems with unit tests

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
 require 'active_support/core_ext/object/blank'

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -76,7 +76,7 @@ module KubernetesDeploy
       )
     end
 
-    def build_rbac_v1beta1_kubeclient(context)
+    def build_rbac_v1_kubeclient(context)
       _build_kubeclient(
         api_version: "v1",
         context: context,

--- a/test/fixtures/kube-config/dummy_config.yml
+++ b/test/fixtures/kube-config/dummy_config.yml
@@ -16,7 +16,7 @@ contexts:
 - context:
     cluster: invalid
     user: test-user
-  name: docker-for-mac
+  name: docker-for-desktop
 kind: Config
 users:
 - name: test-user

--- a/test/fixtures/kube-config/valid_config.yml
+++ b/test/fixtures/kube-config/valid_config.yml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Config
-preferences: {}
-
-contexts:
-- context:
-    cluster: minikube
-    user: minikube
-  name: kb-test-context

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -145,7 +145,7 @@ module FixtureSetAssertions
     end
 
     def assert_role_binding_present(name)
-      role_bindings = rbac_v1beta1_kubeclient.get_role_bindings(namespace: namespace)
+      role_bindings = rbac_v1_kubeclient.get_role_bindings(namespace: namespace)
       desired = role_bindings.find { |sa| sa.metadata.name == name }
       assert desired.present?, "Role binding #{name} does not exist"
     end

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -42,7 +42,7 @@ module KubeclientHelper
     @autoscaling_v1_kubeclient ||= build_autoscaling_v1_kubeclient(TEST_CONTEXT)
   end
 
-  def rbac_v1beta1_kubeclient
-    @rbac_v1beta1_kubeclient ||= build_rbac_v1beta1_kubeclient(TEST_CONTEXT)
+  def rbac_v1_kubeclient
+    @rbac_v1_kubeclient ||= build_rbac_v1_kubeclient(TEST_CONTEXT)
   end
 end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative './kubeclient_helper'
+
+class TestProvisioner
+  extend KubeclientHelper
+
+  class << self
+    def prepare_cluster
+      WebMock.allow_net_connect!
+      $stderr.print "Preparing test cluster... "
+      prepare_pv("pv0001")
+      prepare_pv("pv0002")
+      deploy_metric_server
+      $stderr.puts "Done."
+      WebMock.disable_net_connect!
+    end
+
+    def claim_namespace(test_name)
+      test_name = test_name.gsub(/[^-a-z0-9]/, '-').slice(0, 36) # namespace name length must be <= 63 chars
+      ns = "k8sdeploy-#{test_name}-#{SecureRandom.hex(8)}"
+      create_namespace(ns)
+      ns
+    rescue KubeException => e
+      retry if e.to_s.include?("already exists")
+      raise
+    end
+
+    def delete_namespace(namespace)
+      kubeclient.delete_namespace(namespace) if namespace.present?
+    rescue KubeException => e
+      raise unless e.to_s.include?("not found")
+    end
+
+    private
+
+    def create_namespace(namespace)
+      ns = Kubeclient::Resource.new(kind: 'Namespace')
+      ns.metadata = { name: namespace }
+      kubeclient.create_namespace(ns)
+    end
+
+    def prepare_pv(name)
+      existing_pvs = kubeclient.get_persistent_volumes(label_selector: "name=#{name}")
+      return if existing_pvs.present?
+
+      pv = Kubeclient::Resource.new(kind: 'PersistentVolume')
+      pv.metadata = {
+        name: name,
+        labels: { name: name }
+      }
+      pv.spec = {
+        accessModes: %w(ReadWriteOnce),
+        capacity: { storage: "150Mi" },
+        hostPath: { path: "/data/#{name}" },
+        persistentVolumeReclaimPolicy: "Recycle"
+      }
+      kubeclient.create_persistent_volume(pv)
+    end
+
+    def deploy_metric_server
+      # Set-up the metric server that the HPA needs https://github.com/kubernetes-incubator/metrics-server
+      logger = KubernetesDeploy::FormattedLogger.build("default", KubeclientHelper::TEST_CONTEXT, $stderr)
+      kubectl = KubernetesDeploy::Kubectl.new(namespace: "kube-system", context: KubeclientHelper::TEST_CONTEXT,
+        logger: logger, log_failure_by_default: true, default_timeout: '5s')
+
+      Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").map do |resource|
+        found = kubectl.run("get", "-f", resource, log_failure: false).last.success?
+        kubectl.run("create", "-f", resource) unless found
+      end
+    end
+  end
+end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -17,13 +17,13 @@ class TestProvisioner
     end
 
     def claim_namespace(test_name)
-      test_name = test_name.gsub(/[^-a-z0-9]/, '-').slice(0, 36) # namespace name length must be <= 63 chars
-      ns = "k8sdeploy-#{test_name}-#{SecureRandom.hex(8)}"
-      create_namespace(ns)
-      ns
-    rescue KubeException => e
-      retry if e.to_s.include?("already exists")
-      raise
+      prefix = "k8sdeploy-"
+      suffix = "-#{SecureRandom.hex(8)}"
+      max_base_length = 63 - (prefix + suffix).length # namespace name length must be <= 63 chars
+      ns_name = prefix + test_name.gsub(/[^-a-z0-9]/, '-').slice(0, max_base_length) + suffix
+
+      create_namespace(ns_name)
+      ns_name
     end
 
     def delete_namespace(namespace)

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'integration_test_helper'
 
 class SerialDeployTest < KubernetesDeploy::IntegrationTest
   # This cannot be run in parallel because it either stubs a constant or operates in a non-exclusive namespace
@@ -57,10 +57,10 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
   end
 
   # This can be run in parallel when we switch to --kubeconfig (https://github.com/Shopify/kubernetes-deploy/issues/52)
-  def test_invalid_context
+  def test_unreachable_context
     old_config = ENV['KUBECONFIG']
     begin
-      ENV['KUBECONFIG'] = File.join(__dir__, '../fixtures/kube-config/invalid_config.yml')
+      ENV['KUBECONFIG'] = File.join(__dir__, '../fixtures/kube-config/dummy_config.yml')
       kubectl_instance = build_kubectl(timeout: '0.1s')
       result = deploy_fixtures('hello-cloud', kubectl_instance: kubectl_instance)
       assert_deploy_failure(result)
@@ -111,8 +111,8 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
     reset_logger
 
-    valid_config = File.join(__dir__, '../fixtures/kube-config/valid_config.yml')
-    ENV['KUBECONFIG'] = "#{old_config}:#{valid_config}"
+    extra_config = File.join(__dir__, '../fixtures/kube-config/dummy_config.yml')
+    ENV['KUBECONFIG'] = "#{old_config}:#{extra_config}"
     result = deploy_fixtures('hello-cloud', subset: ["configmap-data.yml"])
     assert_deploy_success(result)
   ensure

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'integration_test_helper'
 
 class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
   include TaskRunnerTestHelper

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'integration_test_helper'
 
 class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_full_hello_cloud_set_deploy_succeeds
@@ -545,7 +545,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   def test_deploy_result_logging_for_mixed_result_deploy
     subset = ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml", "config_map.yml"]
     result = deploy_fixtures("invalid", subset: subset) do |f|
-      if KUBE_SERVER_VERSION >= Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
+      if kube_server_version >= Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
         f["bad_probe.yml"]["Deployment"].first["spec"]["progressDeadlineSeconds"] = 20
       end
     end
@@ -557,7 +557,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       %r{ConfigMap/test\s+Available}
     ], in_order: true)
 
-    if KUBE_SERVER_VERSION < Gem::Version.new("1.10.0")
+    if kube_server_version < Gem::Version.new("1.10.0")
       start_bad_probe_logs = [
         %r{Deployment/bad-probe: TIMED OUT \(timeout: \d+s\)},
         "Timeout reason: hard deadline for Deployment"
@@ -964,7 +964,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       max_watch_seconds: 20
     ) do |f|
       bad_probe = f["bad_probe.yml"]["Deployment"].first
-      if KUBE_SERVER_VERSION < Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
+      if kube_server_version < Gem::Version.new("1.10.0") # https://github.com/kubernetes/kubernetes/issues/66135
         bad_probe["metadata"]["annotations"]["kubernetes-deploy.shopify.io/timeout-override"] = '5s'
       else
         bad_probe["spec"]["progressDeadlineSeconds"] = 5
@@ -974,7 +974,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     end
     assert_deploy_failure(result)
 
-    bad_probe_timeout = if KUBE_SERVER_VERSION < Gem::Version.new("1.10.0")
+    bad_probe_timeout = if kube_server_version < Gem::Version.new("1.10.0")
       "Deployment/bad-probe: TIMED OUT (timeout: 5s)"
     else
       "Deployment/bad-probe: TIMED OUT (progress deadline: 5s)"
@@ -1058,7 +1058,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_successful
-    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.9.0')
+    skip if kube_server_version < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_logs_match_all([
       "Deploying resources:",
@@ -1068,7 +1068,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_pruned
-    skip if KUBE_SERVER_VERSION < Gem::Version.new('1.9.0')
+    skip if kube_server_version < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'integration_test_helper'
 require 'kubernetes-deploy/restart_task'
 
 class RestartTaskTest < KubernetesDeploy::IntegrationTest

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'integration_test_helper'
 
 class RunnerTaskTest < KubernetesDeploy::IntegrationTest
   include TaskRunnerTestHelper

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module KubernetesDeploy
+  class IntegrationTest < KubernetesDeploy::TestCase
+    include KubeclientHelper
+    include FixtureDeployHelper
+
+    TestProvisioner.prepare_cluster
+
+    if ENV["PARALLELIZE_ME"]
+      puts "Running tests in parallel!"
+      parallelize_me!
+    end
+
+    def run
+      WebMock.allow_net_connect!
+      @namespace = TestProvisioner.claim_namespace(name)
+      super
+    ensure
+      TestProvisioner.delete_namespace(@namespace)
+    end
+
+    def ban_net_connect?
+      false
+    end
+
+    def prune_matcher(kind, group, name)
+      kind + '(.' + group + ')?[ \/]"?' + name + '"?'
+    end
+
+    def kube_client_version
+      _kubectl.client_version
+    end
+
+    def kube_server_version
+      _kubectl.server_version
+    end
+
+    def _kubectl
+      @_kubectl ||= KubernetesDeploy::Kubectl.new(namespace: "default", context: TEST_CONTEXT, logger: logger,
+        log_failure_by_default: true, default_timeout: '5s')
+    end
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -15,9 +15,7 @@ module KubernetesDeploy
     end
 
     def run
-      WebMock.allow_net_connect!
-      @namespace = TestProvisioner.claim_namespace(name)
-      super
+      super { @namespace = TestProvisioner.claim_namespace(name) }
     ensure
       TestProvisioner.delete_namespace(@namespace)
     end

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -13,8 +13,8 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
   def test_build_client_from_multiple_config_files
     old_config = ENV['KUBECONFIG']
     # Set KUBECONFIG to include multiple config files
-    valid_config = File.join(__dir__, '../../fixtures/kube-config/valid_config.yml')
-    ENV['KUBECONFIG'] = "#{old_config}:#{valid_config}"
+    dummy_config = File.join(__dir__, '../../fixtures/kube-config/dummy_config.yml')
+    ENV['KUBECONFIG'] = "#{old_config}:#{dummy_config}"
     # Build kubeclient for an unknown context fails
     context_name = "unknown_context"
     assert_raises_message(ContextMissingError,
@@ -22,8 +22,8 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
       "(#{ENV['KUBECONFIG']}).") do
       build_v1_kubeclient(context_name)
     end
-    # Build kubeclient for an existing context success
-    context_name = KubeclientHelper::TEST_CONTEXT
+    # Build kubeclient for a context present in the dummy config succeeds
+    context_name = "docker-for-desktop"
     client = build_v1_kubeclient(context_name)
     assert !client.nil?, "Expected Kubeclient is built for context " \
     	"#{context_name} with success."

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -68,7 +68,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     fourth = build_mock_resource(final_status: "success", hits_to_complete: 4, name: "fourth")
 
     watcher = build_watcher([first, second, third, fourth])
-    watcher.run(delay_sync: 0.1)
+    watcher.run(delay_sync: 0.01)
 
     assert_logs_match_all([
       /Successfully deployed in \d.\ds: first/,
@@ -86,7 +86,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     resource2 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'second')
     resource3 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'third')
     watcher = build_watcher([resource1, resource2, resource3])
-    watcher.run(delay_sync: 0.1, reminder_interval: 0.5.seconds)
+    watcher.run(delay_sync: 0.01, reminder_interval: 0.05)
 
     assert_logs_match_all([
       /Successfully deployed in \d.\ds: first/,
@@ -111,9 +111,9 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     resource = build_mock_resource(hits_to_complete: 10**100)
     sync_mediator = KubernetesDeploy::SyncMediator.new(namespace: 'test', context: 'minikube', logger: logger)
     watcher = KubernetesDeploy::ResourceWatcher.new(resources: [resource], logger: logger,
-      timeout: 2, sync_mediator: sync_mediator)
+      timeout: 0.02, sync_mediator: sync_mediator)
 
-    assert_raises(KubernetesDeploy::DeploymentTimeoutError) { watcher.run(delay_sync: 0.1) }
+    assert_raises(KubernetesDeploy::DeploymentTimeoutError) { watcher.run(delay_sync: 0.01) }
   end
 
   private

--- a/test/unit/kubernetes-deploy/statsd_test.rb
+++ b/test/unit/kubernetes-deploy/statsd_test.rb
@@ -18,5 +18,6 @@ class StatsDTest < KubernetesDeploy::TestCase
     ENV['STATSD_ADDR'] = original_addr
     ENV['STATSD_IMPLEMENTATION'] = original_impl
     ENV['STATSD_DEV'] = original_dev
+    KubernetesDeploy::StatsD.build
   end
 end


### PR DESCRIPTION
- Makes it possible to run the unit tests without a local k8s cluster running
- Fixes sporadic UDP errors that get logged from unit tests
- Makes unit test 4x faster by tuning some unnecessarily long sleeps used in the slowest tests (based on the list we print on every run)
 - Fixes two naming errors (`docker-for-mac` should have been `docker-for-desktop`, and the rbac client we're using is v1 not v1beta1)
- Removes the "valid_config.yml" fixture, which isn't really needed and furthermore isn't a valid config!