### PR TITLE
"Pod spec does not contain a template container called 'task-runner'" error message swallowed

### DIFF
--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -164,7 +164,9 @@ module KubernetesDeploy
     def set_container_overrides!(pod_definition, entrypoint, args, env_vars)
       container = pod_definition.spec.containers.find { |cont| cont.name == 'task-runner' }
       if container.nil?
-        raise TaskConfigurationError, "Pod spec does not contain a template container called 'task-runner'"
+        message = "Pod spec does not contain a template container called 'task-runner'"
+        @logger.summary.add_paragraph(message)
+        raise TaskConfigurationError, message
       end
 
       container.command = entrypoint


### PR DESCRIPTION
Noticed this when messing around with something else. The runner fails, but the lack of reason is a bit frustrating. I'm working on a fix.

cc: @KnVerey 

```
[INFO][2018-10-25 17:10:32 -0700]	
[INFO][2018-10-25 17:10:32 -0700]	-------------------------------------Phase 1: Initializing task-------------------------------------
[INFO][2018-10-25 17:10:32 -0700]	Validating configuration
[INFO][2018-10-25 17:10:32 -0700]	Using namespace 'k8sdeploy-test-run-with-pod-spec-template-miss-16381c175df4feeb' in context 'minikube'
[INFO][2018-10-25 17:10:32 -0700]	Using template 'hello-cloud-template-runner'
[INFO][2018-10-25 17:10:32 -0700]	
[INFO][2018-10-25 17:10:32 -0700]	------------------------------------------Result: FAILURE-------------------------------------------
[INFO][2018-10-25 17:10:32 -0700]	
[INFO][2018-10-25 17:10:32 -0700]	-------------------------------------Phase 1: Initializing task-------------------------------------
[INFO][2018-10-25 17:10:32 -0700]	Validating configuration
[INFO][2018-10-25 17:10:32 -0700]	Using namespace 'k8sdeploy-test-run-with-pod-spec-template-miss-16381c175df4feeb' in context 'minikube'
[INFO][2018-10-25 17:10:32 -0700]	Using template 'hello-cloud-template-runner'
[INFO][2018-10-25 17:10:32 -0700]	
[INFO][2018-10-25 17:10:32 -0700]	------------------------------------------Result: FAILURE-------------------------------------------
```