### PR TITLE
Predeploy roles before RoleBindings

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -52,6 +52,7 @@ module KubernetesDeploy
       ConfigMap
       PersistentVolumeClaim
       ServiceAccount
+      Role
       RoleBinding
       Pod
     )

--- a/lib/kubernetes-deploy/kubernetes_resource/role.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/role.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class Role < KubernetesResource
+    TIMEOUT = 30.seconds
+
+    def status
+      exists? ? "Created" : "Unknown"
+    end
+
+    def deploy_succeeded?
+      exists?
+    end
+
+    def deploy_failed?
+      false
+    end
+
+    def timeout_message
+      UNUSUAL_FAILURE_MESSAGE
+    end
+  end
+end

--- a/test/fixtures/hello-cloud/role.yml
+++ b/test/fixtures/hello-cloud/role.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role
+rules: []

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -144,6 +144,12 @@ module FixtureSetAssertions
       assert desired.present?, "Service account #{name} does not exist"
     end
 
+    def assert_role_present(name)
+      roles = rbac_v1_kubeclient.get_roles(namespace: namespace)
+      desired = roles.find { |sa| sa.metadata.name == name }
+      assert desired.present?, "Role #{name} does not exist"
+    end
+
     def assert_role_binding_present(name)
       role_bindings = rbac_v1_kubeclient.get_role_bindings(namespace: namespace)
       desired = role_bindings.find { |sa| sa.metadata.name == name }

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -89,6 +89,10 @@ module FixtureSetAssertions
       assert_service_account_present("build-robot")
     end
 
+    def assert_all_roles_up
+      assert_role_present("role")
+    end
+
     def assert_all_role_bindings_up
       assert_role_binding_present("role-binding")
     end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -12,7 +12,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{Deploying Pod/unmanaged-pod-[-\w]+ \(timeout: 60s\)}, # annotation timeout override
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 20 resources"
+      "Successfully deployed 21 resources"
     ], in_order: true)
 
     num_ds = expected_daemonset_pod_count
@@ -53,18 +53,27 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
   end
 
-  def test_role_binding_predeployed_before_unmanaged_pod
+  def test_role_and_role_binding_predeployed_before_unmanaged_pod
     result = deploy_fixtures("hello-cloud",
-      subset: ["configmap-data.yml", "unmanaged-pod.yml.erb", "role-binding.yml", "service-account.yml"])
+      subset: [
+        "configmap-data.yml",
+        "unmanaged-pod.yml.erb",
+        "role-binding.yml",
+        "role.yml",
+        "service-account.yml"
+      ]
+    )
 
     # Expect that role binding account is deployed before the unmanaged pod
     assert_deploy_success(result)
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     hello_cloud.assert_configmap_data_present
     hello_cloud.assert_all_service_accounts_up
+    hello_cloud.assert_all_roles_up
     hello_cloud.assert_all_role_bindings_up
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
     assert_logs_match_all([
+      %r{Successfully deployed in \d.\ds: Role/role},
       %r{Successfully deployed in \d.\ds: RoleBinding/role-binding},
       %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*}
     ], in_order: true)


### PR DESCRIPTION
RoleBindings were added to predeploy in #354. If role bindings rely on a role, deployment fails as role is not available. Fixed by predeploying roles. 
