### PR TITLE
Use distribution everywhere

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -293,7 +293,7 @@ module KubernetesDeploy
 
     def report_status_to_statsd(watch_time)
       unless @statsd_report_done
-        ::StatsD.measure('resource.duration', watch_time, tags: statsd_tags)
+        ::StatsD.distribution('resource.duration', watch_time, tags: statsd_tags)
         @statsd_report_done = true
       end
     end


### PR DESCRIPTION
This is a follow-up #374  to use `distribution` over `measure`. See  https://github.com/Shopify/statsd-instrument#statsddistribution for more details. But at a high level `distribution` has all arithmetic and calculation happening server side which is more efficient, correct, and cost effective.