### PR TITLE
Replace measure with distribution

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -162,14 +162,14 @@ module KubernetesDeploy
       ::StatsD.event("Deployment of #{@namespace} succeeded",
         "Successfully deployed all #{@namespace} resources to #{@context}",
         alert_type: "success", tags: statsd_tags << "status:success")
-      ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:success")
+      ::StatsD.distribution('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:success")
       @logger.print_summary(:success)
     rescue DeploymentTimeoutError
       @logger.print_summary(:timed_out)
       ::StatsD.event("Deployment of #{@namespace} timed out",
         "One or more #{@namespace} resources failed to deploy to #{@context} in time",
         alert_type: "error", tags: statsd_tags << "status:timeout")
-      ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:timeout")
+      ::StatsD.distribution('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:timeout")
       raise
     rescue FatalDeploymentError => error
       @logger.summary.add_action(error.message) if error.message != error.class.to_s
@@ -177,7 +177,7 @@ module KubernetesDeploy
       ::StatsD.event("Deployment of #{@namespace} failed",
         "One or more #{@namespace} resources failed to deploy to #{@context}",
         alert_type: "error", tags: statsd_tags << "status:failed")
-      ::StatsD.measure('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
+      ::StatsD.distribution('all_resources.duration', StatsD.duration(start), tags: statsd_tags << "status:failed")
       raise
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -293,7 +293,7 @@ module KubernetesDeploy
 
     def report_status_to_statsd(watch_time)
       unless @statsd_report_done
-        ::StatsD.measure('resource.duration', watch_time, tags: statsd_tags)
+        ::StatsD.distribution('resource.duration', watch_time, tags: statsd_tags)
         @statsd_report_done = true
       end
     end


### PR DESCRIPTION
This is a follow-up #374 to use distribution over measure. See https://github.com/Shopify/statsd-instrument#statsddistribution for more details. But at a high level distribution has all arithmetic and calculation happening server side which is more efficient, correct, and cost effective.

Note: this replaces #383 rather than deal with rebase conflicts 


