### PR TITLE
Use Oj instead of JSON to speed up json parsing

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ejson", "~> 1.0"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.3"
+  spec.add_dependency "oj", "~> 3.7"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -11,6 +11,7 @@ require 'active_support/duration'
 require 'colorized_string'
 
 require 'kubernetes-deploy/version'
+require 'kubernetes-deploy/oj'
 require 'kubernetes-deploy/errors'
 require 'kubernetes-deploy/formatted_logger'
 require 'kubernetes-deploy/statsd'

--- a/lib/kubernetes-deploy/oj.rb
+++ b/lib/kubernetes-deploy/oj.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require 'oj'
+
+Oj.mimic_JSON


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Speed up large deploys.

**How is this accomplished?**
Use the [OJ gem](https://github.com/ohler55/oj) which is almost a drop in replacement for the JSON module but 2-3x faster. We get large json blobs back from k8s, so parsing them faster should be an easy win.

**What could go wrong?**
OJ isn't an exact replacement, we could hit a corner case.
