### PR TITLE
Remove low-usefulness high-cardinality tags

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -407,8 +407,7 @@ module KubernetesDeploy
       else
         "unknown"
       end
-      tags = %W(context:#{context} namespace:#{namespace} resource:#{id}
-                type:#{type} sha:#{ENV['REVISION']} status:#{status})
+      tags = %W(context:#{context} namespace:#{namespace} type:#{type} status:#{status})
       tags | @optional_statsd_tags
     end
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Emit fewer tags on the pricey `KubernetesResource.resource.duration` metric.

**How is this accomplished?**
Removing the `sha` and `resource` tags, which are the top two offenders and are not really that handy anyway. We could also consider dropping the custom tags (which are derived from the namespace labels), but then we'd notably lose the ability to filter out smoke tests.

**What could go wrong?**
These tags were important to someone else. I did check the dog repo, and this metric is only used by our dash and the one for smoke tests.
