### PR TITLE
Disable rule exemptions and autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,15 +4,6 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.3
 
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
-Style/MethodCallWithArgsParentheses:
-  Enabled: false
-
 Naming/FileName:
   Enabled: true
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -2,28 +2,28 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-desc "Run integration tests that can be run in parallel"
+desc("Run integration tests that can be run in parallel")
 Rake::TestTask.new(:integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration/**/*_test.rb']
 end
 
-desc "Run integration tests that CANNOT be run in parallel"
+desc("Run integration tests that CANNOT be run in parallel")
 Rake::TestTask.new(:serial_integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration-serial/**/*_test.rb']
 end
 
-desc "Run unit tests"
+desc("Run unit tests")
 Rake::TestTask.new(:unit_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/unit/**/*_test.rb']
 end
 
-desc "Run all tests"
-task test: %w(unit_test serial_integration_test integration_test)
+desc("Run all tests")
+task(test: %w(unit_test serial_integration_test integration_test))
 
-task default: :test
+task(default: :test)

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -63,7 +63,7 @@ begin
     prune: prune
   )
 rescue KubernetesDeploy::DeploymentTimeoutError
-  exit 70
+  exit(70)
 rescue KubernetesDeploy::FatalDeploymentError
-  exit 1
+  exit(1)
 end

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -29,4 +29,4 @@ runner = KubernetesDeploy::RenderTask.new(
 )
 
 success = runner.run(STDOUT, templates)
-exit 1 unless success
+exit(1) unless success

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -23,7 +23,7 @@ restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: conte
 begin
   restart.perform!(raw_deployments)
 rescue KubernetesDeploy::DeploymentTimeoutError
-  exit 70
+  exit(70)
 rescue KubernetesDeploy::FatalDeploymentError
-  exit 1
+  exit(1)
 end

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -41,4 +41,4 @@ success = runner.run(
   args: ARGV[2..-1],
   env_vars: env_vars
 )
-exit 1 unless success
+exit(1) unless success

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -23,19 +23,19 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.required_ruby_version = '>= 2.3.0'
-  spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "kubeclient", "~> 3.0"
-  spec.add_dependency "googleauth", "~> 0.6.6" # https://github.com/google/google-auth-library-ruby/issues/153
-  spec.add_dependency "ejson", "~> 1.0"
-  spec.add_dependency "colorize", "~> 0.8"
-  spec.add_dependency "statsd-instrument", '~> 2.3', '>= 2.3.2'
-  spec.add_dependency "oj", "~> 3.7"
-  spec.add_dependency "concurrent-ruby", "~> 1.1"
+  spec.add_dependency("activesupport", ">= 5.0")
+  spec.add_dependency("kubeclient", "~> 3.0")
+  spec.add_dependency("googleauth", "~> 0.6.6") # https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency("ejson", "~> 1.0")
+  spec.add_dependency("colorize", "~> 0.8")
+  spec.add_dependency("statsd-instrument", '~> 2.3', '>= 2.3.2')
+  spec.add_dependency("oj", "~> 3.7")
+  spec.add_dependency("concurrent-ruby", "~> 1.1")
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "minitest-stub-const", "~> 0.6"
-  spec.add_development_dependency "webmock", "~> 3.0"
-  spec.add_development_dependency "mocha", "~> 1.5"
+  spec.add_development_dependency("bundler")
+  spec.add_development_dependency("rake", "~> 10.0")
+  spec.add_development_dependency("minitest", "~> 5.0")
+  spec.add_development_dependency("minitest-stub-const", "~> 0.6")
+  spec.add_development_dependency("webmock", "~> 3.0")
+  spec.add_development_dependency("mocha", "~> 1.5")
 end

--- a/lib/kubernetes-deploy/container_logs.rb
+++ b/lib/kubernetes-deploy/container_logs.rb
@@ -29,7 +29,7 @@ module KubernetesDeploy
       prefix_str = "[#{container_name}]  " if prefix
 
       lines[@next_print_index..-1].each do |msg|
-        @logger.info "#{prefix_str}#{msg}"
+        @logger.info("#{prefix_str}#{msg}")
       end
 
       @next_print_index = lines.length

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -261,7 +261,7 @@ module KubernetesDeploy
           r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger,
                                        definition: r_def, statsd_tags: @namespace_tags)
           resources << r
-          @logger.info "  - #{r.id}"
+          @logger.info("  - #{r.id}")
         end
       end
       if (global = resources.select(&:global?).presence)

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -145,9 +145,9 @@ module KubernetesDeploy
           "name" => secret_name,
           "labels" => { "name" => secret_name },
           "namespace" => @namespace,
-          "annotations" => { MANAGEMENT_ANNOTATION => "true" }
+          "annotations" => { MANAGEMENT_ANNOTATION => "true" },
         },
-        "data" => encoded_data
+        "data" => encoded_data,
       }
       secret.to_yaml
     end

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -100,7 +100,7 @@ module KubernetesDeploy
         auth_options: kube_context.auth_options,
         timeouts: {
           open: KubernetesDeploy::Kubectl::DEFAULT_TIMEOUT,
-          read: KubernetesDeploy::Kubectl::DEFAULT_TIMEOUT
+          read: KubernetesDeploy::Kubectl::DEFAULT_TIMEOUT,
         }
       )
       client.discover

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -30,7 +30,7 @@ module KubernetesDeploy
       out, err, st = nil
 
       (1..attempts).to_a.each do |attempt|
-        @logger.debug "Running command (attempt #{attempt}): #{args.join(' ')}"
+        @logger.debug("Running command (attempt #{attempt}): #{args.join(' ')}")
         out, err, st = Open3.capture3(*args)
         @logger.debug("Kubectl out: " + out.gsub(/\s+/, ' ')) unless output_is_sensitive?
 
@@ -47,7 +47,7 @@ module KubernetesDeploy
           @logger.debug("Kubectl err: #{err}") unless output_is_sensitive?
           StatsD.increment('kubectl.error', 1, tags: { context: @context, namespace: @namespace, cmd: args[1] })
         end
-        sleep retry_delay(attempt) unless attempt == attempts
+        sleep(retry_delay(attempt)) unless attempt == attempts
       end
 
       [out.chomp, err.chomp, st]

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -319,7 +319,7 @@ module KubernetesDeploy
           '(ne .reason "SuccessfulCreate")',
           '(ne .reason "Scheduled")',
           '(ne .reason "Pulling")',
-          '(ne .reason "Pulled")'
+          '(ne .reason "Pulled")',
         ]
         condition_start = "{{if and #{and_conditions.join(' ')}}}"
         field_part = FIELDS.map { |f| "{{#{f}}}" }.join(%({{print "#{FIELD_SEPARATOR}"}}))

--- a/lib/kubernetes-deploy/options_helper.rb
+++ b/lib/kubernetes-deploy/options_helper.rb
@@ -11,7 +11,7 @@ module KubernetesDeploy
         puts "Template directory is unknown. " \
           "Either specify --template-dir argument or set $ENVIRONMENT to use config/deploy/$ENVIRONMENT " \
         + "as a default path."
-        exit 1
+        exit(1)
       end
 
       template_dir

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -59,7 +59,7 @@ module KubernetesDeploy
       {
         namespace: @namespace,
         context: @context,
-        sha: @sha
+        sha: @sha,
       }
     end
 

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -132,7 +132,7 @@ module KubernetesDeploy
       deployments.each do |record|
         begin
           patch_deployment_with_restart(record)
-          @logger.info "Triggered `#{record.metadata.name}` restart"
+          @logger.info("Triggered `#{record.metadata.name}` restart")
         rescue Kubeclient::ResourceNotFoundError, Kubeclient::HttpError => e
           raise RestartAPIError.new(record.metadata.name, e.message)
         end
@@ -164,12 +164,12 @@ module KubernetesDeploy
               containers: containers.map do |container|
                 {
                   name: container.name,
-                  env: [{ name: "RESTARTED_AT", value: Time.now.to_i.to_s }]
+                  env: [{ name: "RESTARTED_AT", value: Time.now.to_i.to_s }],
                 }
-              end
-            }
-          }
-        }
+              end,
+            },
+          },
+        },
       }
     end
 

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -59,7 +59,7 @@ module KubernetesDeploy
     private
 
     def create_pod(pod)
-      @logger.info "Creating pod '#{pod.name}'"
+      @logger.info("Creating pod '#{pod.name}'")
       pod.deploy_started_at = Time.now.utc
       kubeclient.create_pod(pod.to_kubeclient_resource)
       @pod_name = pod.name
@@ -121,7 +121,7 @@ module KubernetesDeploy
 
       begin
         kubeclient.get_namespace(@namespace) if @namespace.present?
-        @logger.info "Using namespace '#{@namespace}' in context '#{@context}'"
+        @logger.info("Using namespace '#{@namespace}' in context '#{@context}'")
       rescue KubeException => e
         msg = e.error_code == 404 ? "Namespace was not found" : "Could not connect to kubernetes cluster"
         errors << msg

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -31,7 +31,7 @@ module FixtureSetAssertions
       client = beta ? v1beta1_kubeclient : kubeclient
       res = client.public_send("get_#{type}", name, namespace)
       if res.metadata.deletionTimestamp.blank?
-        flunk "#{type} #{name} unexpectedly existed and is not being deleted."
+        flunk("#{type} #{name} unexpectedly existed and is not being deleted.")
       end
     rescue KubeException => e
       raise unless e.to_s.include?("not found")
@@ -42,17 +42,17 @@ module FixtureSetAssertions
       num_with_status = pods.count { |pod| pod.status.phase == status }
 
       msg = "Expected to find #{count} #{pod_name} pods with status #{status}, found #{num_with_status}"
-      assert_equal count, num_with_status, msg
+      assert_equal(count, num_with_status, msg)
     end
 
     def assert_service_up(svc_name)
       services = kubeclient.get_services(namespace: namespace, label_selector: "name=#{svc_name},app=#{app_name}")
-      assert_equal 1, services.size, "Expected 1 #{svc_name} service, got #{services.size}"
-      refute services.first["spec"]["clusterIP"].empty?, "Cluster IP was not assigned"
+      assert_equal(1, services.size, "Expected 1 #{svc_name} service, got #{services.size}")
+      refute(services.first["spec"]["clusterIP"].empty?, "Cluster IP was not assigned")
 
       endpoints_obj = kubeclient.get_endpoint(svc_name, namespace)
       num_endpoints = endpoints_obj["subsets"].first["addresses"].length
-      assert_equal 1, num_endpoints
+      assert_equal(1, num_endpoints)
     end
 
     def assert_deployment_up(dep_name, replicas:)
@@ -60,11 +60,11 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{dep_name},app=#{app_name}"
       )
-      assert_equal 1, deployments.size, "Expected 1 #{dep_name} deployment, got #{deployments.size}"
+      assert_equal(1, deployments.size, "Expected 1 #{dep_name} deployment, got #{deployments.size}")
       available = deployments.first["status"]["availableReplicas"].to_i
 
       msg = "Expected #{dep_name} deployment to have #{replicas} available replicas, saw #{available}"
-      assert_equal replicas, available, msg
+      assert_equal(replicas, available, msg)
     end
 
     def assert_replica_set_up(rs_name, replicas:)
@@ -72,11 +72,11 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{rs_name},app=#{app_name}"
       )
-      assert_equal 1, replica_sets.size, "Expected 1 #{rs_name} replica set, got #{replica_sets.size}"
+      assert_equal(1, replica_sets.size, "Expected 1 #{rs_name} replica set, got #{replica_sets.size}")
       available = replica_sets.first["status"]["availableReplicas"]
 
       msg = "Expected #{rs_name} replica_sets to have #{replicas} available replicas, saw #{available}"
-      assert_equal replicas, available, msg
+      assert_equal(replicas, available, msg)
     end
 
     def assert_pvc_status(pvc_name, status)
@@ -84,19 +84,19 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{pvc_name},app=#{app_name}"
       )
-      assert_equal 1, pvc.size, "Expected 1 #{pvc_name} pvc, saw #{pvc.size}"
-      assert_equal status, pvc.first.status.phase
+      assert_equal(1, pvc.size, "Expected 1 #{pvc_name} pvc, saw #{pvc.size}")
+      assert_equal(status, pvc.first.status.phase)
     end
 
     def assert_ingress_up(ing_name)
       ing = v1beta1_kubeclient.get_ingresses(namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}")
-      assert_equal 1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}"
+      assert_equal(1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}")
     end
 
     def assert_configmap_present(cm_name, expected_data)
       configmaps = kubeclient.get_config_maps(namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}")
-      assert_equal 1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}"
-      assert_equal expected_data, configmaps.first["data"].to_h
+      assert_equal(1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}")
+      assert_equal(expected_data, configmaps.first["data"].to_h)
     end
 
     def assert_cronjob_exists(job_name)
@@ -104,7 +104,7 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{job_name},app=#{app_name}"
       )
-      assert_equal 1, cronjobs.size, "Expected 1 cronjob, got #{cronjobs.size}"
+      assert_equal(1, cronjobs.size, "Expected 1 cronjob, got #{cronjobs.size}")
     end
 
     def assert_job_exists(job_name)
@@ -112,7 +112,7 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{job_name},app=#{app_name}"
       )
-      assert_equal 1, jobs.size, "Expected 1 job, got #{jobs.size}"
+      assert_equal(1, jobs.size, "Expected 1 job, got #{jobs.size}")
     end
 
     def assert_pod_templates_present(cm_name)
@@ -120,58 +120,58 @@ module FixtureSetAssertions
         namespace: namespace,
         label_selector: "name=#{cm_name},app=#{app_name}"
       )
-      assert_equal 1, pod_templates.size, "Expected 1 podtemplate, got #{pod_templates.size}"
+      assert_equal(1, pod_templates.size, "Expected 1 podtemplate, got #{pod_templates.size}")
     end
 
     def assert_secret_present(secret_name, expected_data = nil, type: 'Opaque', managed: false)
       secrets = kubeclient.get_secrets(namespace: namespace, label_selector: "name=#{secret_name}")
-      assert_equal 1, secrets.size, "Expected 1 secret, got #{secrets.size}"
+      assert_equal(1, secrets.size, "Expected 1 secret, got #{secrets.size}")
       secret = secrets.first
       assert_annotated(secret, KubernetesDeploy::EjsonSecretProvisioner::MANAGEMENT_ANNOTATION) if managed
-      assert_equal type, secret["type"]
+      assert_equal(type, secret["type"])
       return unless expected_data
 
       secret_data = secret["data"].to_h.stringify_keys
       secret_data.each do |key, value|
         secret_data[key] = Base64.decode64(value)
       end
-      assert_equal expected_data, secret_data
+      assert_equal(expected_data, secret_data)
     end
 
     def assert_service_account_present(name)
       service_accounts = kubeclient.get_service_accounts(namespace: namespace)
       desired = service_accounts.find { |sa| sa.metadata.name == name }
-      assert desired.present?, "Service account #{name} does not exist"
+      assert(desired.present?, "Service account #{name} does not exist")
     end
 
     def assert_role_present(name)
       roles = rbac_v1_kubeclient.get_roles(namespace: namespace)
       desired = roles.find { |sa| sa.metadata.name == name }
-      assert desired.present?, "Role #{name} does not exist"
+      assert(desired.present?, "Role #{name} does not exist")
     end
 
     def assert_role_binding_present(name)
       role_bindings = rbac_v1_kubeclient.get_role_bindings(namespace: namespace)
       desired = role_bindings.find { |sa| sa.metadata.name == name }
-      assert desired.present?, "Role binding #{name} does not exist"
+      assert(desired.present?, "Role binding #{name} does not exist")
     end
 
     def assert_annotated(obj, annotation)
       annotations = obj.metadata.annotations.to_h.stringify_keys
-      assert annotations.key?(annotation), "Expected secret to have annotation #{annotation}, but it did not"
+      assert(annotations.key?(annotation), "Expected secret to have annotation #{annotation}, but it did not")
     end
 
     def assert_daemon_set_present(name)
       daemon_sets = v1beta1_kubeclient.get_daemon_sets(namespace: namespace)
       desired = daemon_sets.find { |ds| ds.metadata.name == name }
-      assert desired.present?, "Daemon set #{name} does not exist"
+      assert(desired.present?, "Daemon set #{name} does not exist")
     end
 
     def assert_stateful_set_present(name)
       labels = "name=#{name},app=#{app_name}"
       stateful_sets = apps_v1beta1_kubeclient.get_stateful_sets(namespace: namespace, label_selector: labels)
       desired = stateful_sets.find { |ss| ss.metadata.name == name }
-      assert desired.present?, "Stateful set #{name} does not exist"
+      assert(desired.present?, "Stateful set #{name} does not exist")
     end
   end
 end

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -15,7 +15,7 @@ module FixtureSetAssertions
       metadata = {
         name: 'ejson-keys',
         namespace: namespace,
-        labels: { name: 'ejson-keys' }
+        labels: { name: 'ejson-keys' },
       }
       encoded_data = { test_public_key => test_private_key }
       secret = Kubeclient::Resource.new(kind: 'Secret', type: 'Opaque', metadata: metadata, data: encoded_data)

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -24,13 +24,13 @@ module FixtureSetAssertions
 
     def assert_unmanaged_pod_statuses(status, count = 1)
       pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
-      assert_equal count, pods.size, "Expected to find #{count} unmanaged pod(s), found #{pods.size}"
-      assert pods.all? { |pod| pod.status.phase == status }
+      assert_equal(count, pods.size, "Expected to find #{count} unmanaged pod(s), found #{pods.size}")
+      assert(pods.all? { |pod| pod.status.phase == status })
     end
 
     def refute_unmanaged_pod_exists
       pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
-      assert_equal 0, pods.size, "Expected to find 0 unmanaged pods, found #{pods.size}"
+      assert_equal(0, pods.size, "Expected to find 0 unmanaged pods, found #{pods.size}")
     end
 
     def assert_configmap_data_present
@@ -77,13 +77,13 @@ module FixtureSetAssertions
 
     def assert_poddisruptionbudget
       budgets = policy_v1beta1_kubeclient.get_pod_disruption_budgets(namespace: namespace)
-      assert_equal 1, budgets.size, "Expected 1 PodDisruptionBudget"
-      assert_equal 2, budgets[0].spec.minAvailable, "Unexpected value in PodDisruptionBudget spec"
+      assert_equal(1, budgets.size, "Expected 1 PodDisruptionBudget")
+      assert_equal(2, budgets[0].spec.minAvailable, "Unexpected value in PodDisruptionBudget spec")
     end
 
     def assert_bare_replicaset_up
       assert_pod_status("bare-replica-set", "Running")
-      assert assert_replica_set_up("bare-replica-set", replicas: 1)
+      assert(assert_replica_set_up("bare-replica-set", replicas: 1))
     end
 
     def assert_all_service_accounts_up

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -29,9 +29,9 @@ module TaskRunnerTestHelper
           "echo \"Line $i\"; " \
           "sleep #{log_interval};" \
           "i=$((i+1)); " \
-        "done"
+        "done",
       ],
-      verify_result: verify_result
+      verify_result: verify_result,
     }
   end
 end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -8,7 +8,7 @@ class TestProvisioner
   class << self
     def prepare_cluster
       WebMock.allow_net_connect!
-      $stderr.print "Preparing test cluster... "
+      $stderr.print("Preparing test cluster... ")
       prepare_pv("pv0001")
       prepare_pv("pv0002")
       deploy_metric_server
@@ -47,13 +47,13 @@ class TestProvisioner
       pv = Kubeclient::Resource.new(kind: 'PersistentVolume')
       pv.metadata = {
         name: name,
-        labels: { name: name }
+        labels: { name: name },
       }
       pv.spec = {
         accessModes: %w(ReadWriteOnce),
         capacity: { storage: "150Mi" },
         hostPath: { path: "/data/#{name}" },
-        persistentVolumeReclaimPolicy: "Recycle"
+        persistentVolumeReclaimPolicy: "Recycle",
       }
       kubeclient.create_persistent_volume(pv)
     end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -13,7 +13,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
       hello_cloud.assert_poddisruptionbudget
       assert_logs_match_all([
         /cannot be pruned/,
-        /Please do not deploy to #{@namespace} unless you really know what you are doing/
+        /Please do not deploy to #{@namespace} unless you really know what you are doing/,
       ])
 
       result = deploy_fixtures("hello-cloud", subset: ["disruption-budgets.yml"],
@@ -36,7 +36,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       /Creating secret catphotoscom/,
       /Creating secret unused-secret/,
-      /Creating secret monitoring-token/
+      /Creating secret monitoring-token/,
     ])
 
     refute_logs_match(ejson_cloud.test_private_key)
@@ -88,7 +88,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       'Result: FAILURE',
       'Configuration invalid',
-      "Kube config not found at #{config_file}"
+      "Kube config not found at #{config_file}",
     ], in_order: true)
     reset_logger
 
@@ -98,7 +98,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       'Result: FAILURE',
       'Configuration invalid',
-      "Kube config file name(s) not set in $KUBECONFIG"
+      "Kube config file name(s) not set in $KUBECONFIG",
     ], in_order: true)
     reset_logger
 
@@ -108,7 +108,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       'Result: FAILURE',
       'Configuration invalid',
-      "$KUBECONFIG not set"
+      "$KUBECONFIG not set",
     ], in_order: true)
     reset_logger
 
@@ -151,7 +151,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Deploying CustomResourceDefinition/others.stable.example.io (timeout: 120s)",
       "CustomResourceDefinition/others.stable.example.io: FAILED",
-      'Final status: ListKindConflict ("Conflict" is already in use)'
+      'Final status: ListKindConflict ("Conflict" is already in use)',
     ])
   ensure
     wait_for_all_crd_deletion
@@ -165,19 +165,19 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
       " - CustomResourceDefinition/mail.stable.example.io",
       "Phase 3: Deploying all resources",
       "CustomResourceDefinition/mail.stable.example.io (timeout: 120s)",
-      %r{CustomResourceDefinition/mail.stable.example.io\s+Names accepted}
+      %r{CustomResourceDefinition/mail.stable.example.io\s+Names accepted},
     ])
     assert_deploy_success(deploy_fixtures("crd", subset: %w(mail_cr.yml widgets_cr.yml configmap-data.yml)))
     # Deploy any other non-priority (predeployable) resource to trigger pruning
     assert_deploy_success(deploy_fixtures("crd", subset: %w(configmap-data.yml configmap2.yml)))
 
-    assert_predicate build_kubectl.run("get", "mail.stable.example.io", "my-first-mail").last, :success?
+    assert_predicate(build_kubectl.run("get", "mail.stable.example.io", "my-first-mail").last, :success?)
     refute_logs_match(
       /The following resources were pruned: #{prune_matcher("mail", "stable.example.io", "my-first-mail")}/
     )
     assert_logs_match_all([
       /The following resources were pruned: #{prune_matcher("widget", "stable.example.io", "my-first-widget")}/,
-      "Pruned 1 resource and successfully deployed 2 resource"
+      "Pruned 1 resource and successfully deployed 2 resource",
     ])
   ensure
     wait_for_all_crd_deletion
@@ -213,7 +213,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
       assert_deploy_success(result)
     end
 
-    assert_equal 1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric"
+    assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
 
     %w(
       KubernetesDeploy.validate_configuration.duration
@@ -242,6 +242,6 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     crds.each do |crd|
       apiextensions_v1beta1_kubeclient.delete_custom_resource_definition(crd.metadata.name)
     end
-    sleep 0.5 until apiextensions_v1beta1_kubeclient.get_custom_resource_definitions.none?
+    sleep(0.5) until apiextensions_v1beta1_kubeclient.get_custom_resource_definitions.none?
   end
 end

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -26,7 +26,7 @@ class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
       "Running pod",
       "Result: FAILURE",
       "Failed to create pod",
-      "Kubeclient::HttpError: Pod with same name exists"
+      "Kubeclient::HttpError: Pod with same name exists",
     ], in_order: true)
   end
 
@@ -44,9 +44,9 @@ class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
     metric = metrics.find do |m|
       m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
     end
-    assert metric, "No result metric found for this test"
-    assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}"
-    assert_includes metric.tags, "status:failure"
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:failure")
   end
 
   def test_success_statsd_metric_emitted
@@ -61,9 +61,9 @@ class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
     metric = metrics.find do |m|
       m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
     end
-    assert metric, "No result metric found for this test"
-    assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}"
-    assert_includes metric.tags, "status:success"
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:success")
   end
 
   def test_timedout_statsd_metric_emitted
@@ -78,8 +78,8 @@ class SerialTaskRunTest < KubernetesDeploy::IntegrationTest
     metric = metrics.find do |m|
       m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
     end
-    assert metric, "No result metric found for this test"
-    assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}"
-    assert_includes metric.tags, "status:timeout"
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:timeout")
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -12,7 +12,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{Deploying Pod/unmanaged-pod-[-\w]+ \(timeout: 60s\)}, # annotation timeout override
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 21 resources"
+      "Successfully deployed 21 resources",
     ], in_order: true)
 
     num_ds = expected_daemonset_pod_count
@@ -49,7 +49,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded")
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
-      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*}
+      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*},
     ], in_order: true)
   end
 
@@ -61,7 +61,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
         "unmanaged-pod.yml.erb",
         "role-binding.yml",
         "role.yml",
-        "service-account.yml"
+        "service-account.yml",
       ]
     )
 
@@ -76,7 +76,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: Role/role},
       %r{Successfully deployed in \d.\ds: RoleBinding/role-binding},
-      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*}
+      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*},
     ], in_order: true)
   end
 
@@ -125,7 +125,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_deploy_failure(deploy_fixtures("hello-cloud", allow_protected_ns: true, prune: true))
     assert_logs_match_all([
       "Configuration invalid",
-      "- Refusing to deploy to protected namespace 'default' with pruning enabled"
+      "- Refusing to deploy to protected namespace 'default' with pruning enabled",
     ], in_order: true)
   ensure
     @namespace = generated_ns
@@ -137,7 +137,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_deploy_failure(deploy_fixtures("hello-cloud", prune: false))
     assert_logs_match_all([
       "Configuration invalid",
-      "- Refusing to deploy to protected namespace"
+      "- Refusing to deploy to protected namespace",
     ], in_order: true)
   ensure
     @namespace = generated_ns
@@ -159,7 +159,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "apiVersion" => "v1",
       "kind" => "Secret",
       "metadata" => { "name" => "test" },
-      "data" => { "foo" => "YmFy" }
+      "data" => { "foo" => "YmFy" },
     }
 
     result = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]) do |fixtures|
@@ -178,7 +178,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "Invalid template: yaml-error.yml",
       "mapping values are not allowed in this context",
       "> Template content:",
-      "datapoint1: value1:"
+      "datapoint1: value1:",
     ], in_order: true)
   end
 
@@ -194,7 +194,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "> Template content:",
       "containers:",
       "- name: invalid-container",
-      "notField: notval:"
+      "notField: notval:",
     ], in_order: true)
 
     # make sure we're not displaying duplicate errors
@@ -227,7 +227,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "> Error message:",
       %r{Could not find partial 'does-not-exist' in any of .*fixture_dir[^/]*/partials:.*/partials},
       "> Template content:",
-      "<%= partial 'does-not-exist' %>"
+      "<%= partial 'does-not-exist' %>",
     ], in_order: true)
   end
 
@@ -245,17 +245,17 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       "error validating data: ValidationError(ConfigMap.metadata): \
 unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "> Template content:",
-      "      myKey: uhOh"
+      "      myKey: uhOh",
     ], in_order: true)
   end
 
   def test_dynamic_erb_collection_works
-    assert_deploy_success deploy_raw_fixtures("collection-with-erb",
-      bindings: { binding_test_a: 'foo', binding_test_b: 'bar' })
+    assert_deploy_success(deploy_raw_fixtures("collection-with-erb",
+      bindings: { binding_test_a: 'foo', binding_test_b: 'bar' }))
 
     deployments = v1beta1_kubeclient.get_deployments(namespace: @namespace)
-    assert_equal 3, deployments.size
-    assert_equal ["web-one", "web-three", "web-two"], deployments.map { |d| d.metadata.name }.sort
+    assert_equal(3, deployments.size)
+    assert_equal(["web-one", "web-three", "web-two"], deployments.map { |d| d.metadata.name }.sort)
   end
 
   # The next three tests reproduce a k8s bug
@@ -285,7 +285,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "> Error message:",
       /Error from server \(Invalid\): error when creating.*Service "web" is invalid/,
       "> Template content:",
-      "        targetPort: http_test_is_really_long_and_invalid_chars"
+      "        targetPort: http_test_is_really_long_and_invalid_chars",
     ], in_order: true)
   end
 
@@ -300,7 +300,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
       "Unidentified error(s):",
       '    The Service "web" is invalid:',
-      'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"'
+      'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"',
     ], in_order: true)
   end
 
@@ -313,7 +313,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Failed to deploy 1 priority resource",
       %r{Pod\/unmanaged-pod-\w+-\w+: FAILED},
-      "hello-cloud: Failed to pull image"
+      "hello-cloud: Failed to pull image",
     ], in_order: true)
 
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
@@ -336,7 +336,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Failed to deploy 1 priority resource",
       "Pod status: Failed. The following containers encountered errors:",
-      "> hello-cloud: Failed to start (exit 127):"
+      "> hello-cloud: Failed to start (exit 127):",
     ], in_order: true)
   end
 
@@ -356,7 +356,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Deployment/web: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
       /app: Failed to generate container configuration: secrets? \"monitoring-token\" not found/,
-      "Final status: 3 replicas, 3 updatedReplicas, 3 unavailableReplicas"
+      "Final status: 3 replicas, 3 updatedReplicas, 3 unavailableReplicas",
     ], in_order: true)
 
     assert_logs_match("The following containers are in a state that is unlikely to be recoverable", 1) # no duplicates
@@ -374,7 +374,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Deployment/cannot-run: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
       "container-cannot-run: Failed to pull image some-invalid-image:badtag.",
-      "Did you wait for it to be built and pushed to the registry before deploying?"
+      "Did you wait for it to be built and pushed to the registry before deploying?",
     ], in_order: true)
   end
 
@@ -384,7 +384,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Deployment/init-crash: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
       "init-crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
-      "this is a log from the crashing init container"
+      "this is a log from the crashing init container",
     ], in_order: true)
   end
 
@@ -396,7 +396,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Deployment/crash-loop: FAILED",
       "The following containers are in a state that is unlikely to be recoverable:",
       "crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
-      "this is a log from the crashing container"
+      "this is a log from the crashing container",
     ], in_order: true)
   end
 
@@ -409,7 +409,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "The following containers are in a state that is unlikely to be recoverable:",
       %r{container-cannot-run: Failed to start \(exit 127\): .*/some/bad/path},
       "Logs from container 'successful-init'",
-      "Log from successful init container"
+      "Log from successful init container",
     ], in_order: true)
     assert_logs_match("no such file or directory")
   end
@@ -424,7 +424,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Failed to deploy 1 priority resource",
       %r{Pod\/unmanaged-pod-\w+-\w+: FAILED},
       "The following containers encountered errors:",
-      "hello-cloud: Failed to pull image hello-world:thisImageIsBad"
+      "hello-cloud: Failed to pull image hello-world:thisImageIsBad",
     ])
   end
 
@@ -442,7 +442,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Successfully deployed 1 resource and timed out waiting for 1 resource to deploy",
       'Deployment/undying: TIMED OUT (progress deadline: 10s)',
-      'Timeout reason: ProgressDeadlineExceeded'
+      'Timeout reason: ProgressDeadlineExceeded',
     ])
   end
 
@@ -455,7 +455,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Result: SUCCESS",
       "Deployed 3 resources",
-      "Deploy result verification is disabled for this deploy."
+      "Deploy result verification is disabled for this deploy.",
     ], in_order: true)
   end
 
@@ -465,8 +465,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(result)
 
     map = kubeclient.get_config_map('extra-binding', @namespace).data
-    assert_equal 'binding_test_a', map['BINDING_TEST_A']
-    assert_equal 'binding_test_b', map['BINDING_TEST_B']
+    assert_equal('binding_test_a', map['BINDING_TEST_A'])
+    assert_equal('binding_test_b', map['BINDING_TEST_B'])
   end
 
   def test_deploy_fails_if_required_binding_not_present
@@ -478,7 +478,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "> Error message:",
       "undefined local variable or method `binding_test_a'",
       "> Template content:",
-      'BINDING_TEST_A: "<%= binding_test_a %>"'
+      'BINDING_TEST_A: "<%= binding_test_a %>"',
     ], in_order: true)
   end
 
@@ -544,7 +544,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Pruning secret unused-secret",
       "Pruning secret catphotoscom",
-      "Pruning secret monitoring-token"
+      "Pruning secret monitoring-token",
     ])
 
     ejson_cloud.refute_resource_exists('secret', 'unused-secret')
@@ -564,19 +564,19 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Successfully deployed 1 resource, timed out waiting for 2 resources to deploy, and failed to deploy 1 resource",
       "Successful resources",
-      %r{ConfigMap/test\s+Available}
+      %r{ConfigMap/test\s+Available},
     ], in_order: true)
 
     if kube_server_version < Gem::Version.new("1.10.0")
       start_bad_probe_logs = [
         %r{Deployment/bad-probe: TIMED OUT \(timeout: \d+s\)},
-        "Timeout reason: hard deadline for Deployment"
+        "Timeout reason: hard deadline for Deployment",
       ]
       end_bad_probe_logs = [/Unhealthy: Readiness probe failed:.*\(\d+ events\)/] # event
     else
       start_bad_probe_logs = [
         %r{Deployment/bad-probe: TIMED OUT \(progress deadline: \d+s\)},
-        "Timeout reason: ProgressDeadlineExceeded"
+        "Timeout reason: ProgressDeadlineExceeded",
       ]
       end_bad_probe_logs = ["Scaled up replica set bad-probe-"] # event
     end
@@ -608,7 +608,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "init-crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
       "Scaled up replica set init-crash-", # event
-      "this is a log from the crashing init container"
+      "this is a log from the crashing init container",
     ], in_order: true)
 
     # Excludes noisy events
@@ -655,7 +655,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Command failed: apply -f",
       "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
       "Unidentified error(s):",
-      /The Deployment "web" is invalid.*`selector` does not match template `labels`/
+      /The Deployment "web" is invalid.*`selector` does not match template `labels`/,
     ], in_order: true)
   end
 
@@ -688,7 +688,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       %r{Service/web\s+Selects at least 1 pod},
       %r{Deployment/web\s+1 replica, 1 updatedReplica, 1 availableReplica},
       %r{Service/web\s+Doesn't require any endpoint},
-      %r{Deployment/web\s+0 replicas}
+      %r{Deployment/web\s+0 replicas},
     ], in_order: true)
   end
 
@@ -700,11 +700,11 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(result)
 
     pods = kubeclient.get_pods(namespace: @namespace)
-    assert_equal 0, pods.length, "Pods were running from zero-replica deployment"
+    assert_equal(0, pods.length, "Pods were running from zero-replica deployment")
 
     assert_logs_match_all([
       %r{Service/web\s+Doesn't require any endpoint},
-      %r{Deployment/web\s+0 replicas}
+      %r{Deployment/web\s+0 replicas},
     ])
   end
 
@@ -717,19 +717,19 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       container = dep["spec"]["template"]["spec"]["containers"].first
       container["readinessProbe"] = {
         "exec" => { "command" => %w(sleep 5) },
-        "timeoutSeconds" => 6
+        "timeoutSeconds" => 6,
       }
     end
     assert_deploy_success(result)
 
     new_pods = kubeclient.get_pods(namespace: @namespace, label_selector: 'name=web,app=slow-cloud,sha=deploy2')
-    assert new_pods.length >= 1, "Expected at least one new pod, saw #{new_pods.length}"
+    assert(new_pods.length >= 1, "Expected at least one new pod, saw #{new_pods.length}")
 
     new_ready_pods = new_pods.select do |pod|
       pod.status.phase == "Running" &&
       pod.status.conditions.any? { |condition| condition["type"] == "Ready" && condition["status"] == "True" }
     end
-    assert_equal 1, new_ready_pods.length, "Expected exactly one new pod to be ready, saw #{new_ready_pods.length}"
+    assert_equal(1, new_ready_pods.length, "Expected exactly one new pod to be ready, saw #{new_ready_pods.length}")
   end
 
   def test_deploy_aborts_immediately_if_metadata_name_missing
@@ -743,7 +743,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Result: FAILURE",
       "Template is missing required field metadata.name",
       "Rendered template content:",
-      "kind: ConfigMap"
+      "kind: ConfigMap",
     ], in_order: true)
   end
 
@@ -758,7 +758,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Result: FAILURE",
       "Template is missing required field spec.containers",
       "Rendered template content:",
-      "kind: Pod"
+      "kind: Pod",
     ], in_order: true)
   end
 
@@ -797,7 +797,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Events (common success events excluded):",
       "BackOff: Back-off restarting failed container",
       "Logs from container 'crash-loop-back-off':",
-      "this is a log from the crashing container"
+      "this is a log from the crashing container",
     ], in_order: true)
   end
 
@@ -818,7 +818,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Events (common success events excluded):",
       %r{\[Pod/stateful-busybox-\d\]	BackOff: Back-off restarting failed container},
       "Logs from container 'app':",
-      "ls: /not-a-dir: No such file or directory"
+      "ls: /not-a-dir: No such file or directory",
     ], in_order: true)
   end
 
@@ -829,7 +829,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "WARNING: Your StatefulSet's updateStrategy is set to OnDelete",
       "Successful resources",
-      "StatefulSet/stateful-busybox"
+      "StatefulSet/stateful-busybox",
     ], in_order: true)
   end
 
@@ -843,7 +843,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Successfully deployed",
       "Successful resources",
-      %r{StatefulSet/stateful-busybox\s+2 replicas, 2 readyReplicas, 2 currentReplicas}
+      %r{StatefulSet/stateful-busybox\s+2 replicas, 2 readyReplicas, 2 currentReplicas},
     ], in_order: true)
   end
 
@@ -863,11 +863,11 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     ], in_order: true)
 
     rqs = kubeclient.get_resource_quotas(namespace: @namespace)
-    assert_equal 1, rqs.length
+    assert_equal(1, rqs.length)
 
     rq = rqs[0]
-    assert_equal "resource-quotas", rq["metadata"]["name"]
-    assert rq["spec"].present?
+    assert_equal("resource-quotas", rq["metadata"]["name"])
+    assert(rq["spec"].present?)
   end
 
   def test_ejson_secrets_respects_no_prune_flag
@@ -890,18 +890,18 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_partials
-    assert_deploy_success deploy_raw_fixtures("test-partials", bindings: { 'supports_partials' => 'true' })
+    assert_deploy_success(deploy_raw_fixtures("test-partials", bindings: { 'supports_partials' => 'true' }))
     assert_logs_match_all([
       "log from pod1",
       "log from pod2",
-      "Successfully deployed 6 resources"
+      "Successfully deployed 6 resources",
     ], in_order: false)
 
     map = kubeclient.get_config_map('config-for-pod1', @namespace).data
-    assert_equal 'true', map['supports_partials']
+    assert_equal('true', map['supports_partials'])
 
     map = kubeclient.get_config_map('independent-configmap', @namespace).data
-    assert_equal 'renderer test', map['value']
+    assert_equal('renderer test', map['value'])
   end
 
   def test_roll_back_a_bad_deploy
@@ -912,8 +912,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(result)
     original_rs = v1beta1_kubeclient.get_replica_sets(namespace: @namespace).first
     original_rs_uid = original_rs["metadata"]["uid"]
-    assert original_rs_uid.present?
-    assert_equal 2, original_rs["status"]["availableReplicas"]
+    assert(original_rs_uid.present?)
+    assert_equal(2, original_rs["status"]["availableReplicas"])
 
     # Bad deploy
     assert_deploy_failure(deploy_fixtures("invalid", subset: ["cannot_run.yml"], sha: "REVB"))
@@ -926,9 +926,9 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(result)
 
     all_rs = v1beta1_kubeclient.get_replica_sets(namespace: @namespace)
-    assert_equal 2, all_rs.length, "Test premise failure: Rollback created a new RS"
+    assert_equal(2, all_rs.length, "Test premise failure: Rollback created a new RS")
     original_rs = all_rs.find { |rs| rs["metadata"]["uid"] == original_rs_uid }
-    assert_equal 2, original_rs["status"]["availableReplicas"]
+    assert_equal(2, original_rs["status"]["availableReplicas"])
   end
 
   def test_deployment_with_recreate_strategy
@@ -963,7 +963,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Result: FAILURE",
       "Job/hello-job: FAILED",
       "Final status: Failed",
-      %r{\[Job/hello-job\]	DeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)}
+      %r{\[Job/hello-job\]	DeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)},
     ])
   end
 
@@ -996,7 +996,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "ConfigMap/test",
       "Deployment/cannot-run: FAILED",
       bad_probe_timeout,
-      "Deployment/missing-volumes: GLOBAL WATCH TIMEOUT (20 seconds)"
+      "Deployment/missing-volumes: GLOBAL WATCH TIMEOUT (20 seconds)",
     ])
   end
 
@@ -1014,7 +1014,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Successful resources",
       "Service/multi-replica",
       "Deployment/undying: GLOBAL WATCH TIMEOUT (5 seconds)",
-      "If you expected it to take longer than 5 seconds for your deploy to roll out, increase --max-watch-seconds."
+      "If you expected it to take longer than 5 seconds for your deploy to roll out, increase --max-watch-seconds.",
     ], in_order: true)
   end
 
@@ -1025,7 +1025,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Invalid template: wrong-extension-erb.yml",
       "Template is not a valid Kubernetes manifest",
       "> Template content:",
-      "<% (0..2).each do |n| %>"
+      "<% (0..2).each do |n| %>",
     ], in_order: true)
   end
 
@@ -1042,7 +1042,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "metadata:",
       "  name: test",
       "data:",
-      "  datapoint: value1"
+      "  datapoint: value1",
     ], in_order: true)
   end
 
@@ -1052,7 +1052,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Deploying resources:",
       "HorizontalPodAutoscaler/hello-hpa (timeout: 180s)",
-      %r{HorizontalPodAutoscaler/hello-hpa\s+Configured}
+      %r{HorizontalPodAutoscaler/hello-hpa\s+Configured},
     ])
   end
 
@@ -1061,7 +1061,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([
-      /The following resources were pruned: #{prune_matcher("horizontalpodautoscaler", "autoscaling", "hello-hpa")}/
+      /The following resources were pruned: #{prune_matcher("horizontalpodautoscaler", "autoscaling", "hello-hpa")}/,
     ])
   end
 
@@ -1070,7 +1070,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: %w(disruption-budgets.yml configmap-data.yml)))
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: %w(configmap-data.yml)))
     assert_logs_match_all([
-      /The following resources were pruned: #{pod_disruption_budget_matcher}/
+      /The following resources were pruned: #{pod_disruption_budget_matcher}/,
     ])
   end
 

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -6,8 +6,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   def test_restart_by_annotation
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
 
-    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
-    refute fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment"
+    refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
+    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
 
     restart = build_restart_task
     assert_restart_success(restart.perform)
@@ -19,12 +19,12 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       %r{Successfully restarted in \d+\.\d+s: Deployment/web},
       "Result: SUCCESS",
       "Successfully restarted 1 resource",
-      %r{Deployment/web.*1 availableReplica}
+      %r{Deployment/web.*1 availableReplica},
     ],
       in_order: true)
 
-    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
-    refute fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment"
+    assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
+    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
   end
 
   def test_restart_by_annotation_none_found
@@ -33,7 +33,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Configured to restart all deployments with the `shipit.shopify.io/restart` annotation",
       "Result: FAILURE",
-      %r{No deployments with the `shipit\.shopify\.io/restart` annotation found in namespace}
+      %r{No deployments with the `shipit\.shopify\.io/restart` annotation found in namespace},
     ],
       in_order: true)
   end
@@ -41,7 +41,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   def test_restart_named_deployments_twice
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
-    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+    refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
     restart = build_restart_task
     assert_restart_success(restart.perform(%w(web)))
@@ -53,26 +53,26 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       %r{Successfully restarted in \d+\.\d+s: Deployment/web},
       "Result: SUCCESS",
       "Successfully restarted 1 resource",
-      %r{Deployment/web.*1 availableReplica}
+      %r{Deployment/web.*1 availableReplica},
     ],
       in_order: true)
 
     first_restarted_at = fetch_restarted_at("web")
-    assert first_restarted_at, "RESTARTED_AT is present after first restart"
+    assert(first_restarted_at, "RESTARTED_AT is present after first restart")
 
     Timecop.freeze(1.second.from_now) do
       assert_restart_success(restart.perform(%w(web)))
     end
 
     second_restarted_at = fetch_restarted_at("web")
-    assert second_restarted_at, "RESTARTED_AT is present after second restart"
-    refute_equal first_restarted_at.value, second_restarted_at.value
+    assert(second_restarted_at, "RESTARTED_AT is present after second restart")
+    refute_equal(first_restarted_at.value, second_restarted_at.value)
   end
 
   def test_restart_with_same_resource_twice
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
-    refute fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment"
+    refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
     restart = build_restart_task
     assert_restart_success(restart.perform(%w(web web)))
@@ -82,11 +82,11 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       "Triggered `web` restart",
       "Result: SUCCESS",
       "Successfully restarted 1 resource",
-      %r{Deployment/web.*1 availableReplica}
+      %r{Deployment/web.*1 availableReplica},
     ],
       in_order: true)
 
-    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
+    assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
   end
 
   def test_restart_not_existing_deployment
@@ -95,22 +95,22 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       "Configured to restart deployments by name: web",
       "Result: FAILURE",
-      "Deployment `web` not found in namespace"
+      "Deployment `web` not found in namespace",
     ],
       in_order: true)
   end
 
   def test_restart_one_not_existing_deployment
-    assert deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"])
+    assert(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
     restart = build_restart_task
     assert_restart_failure(restart.perform(%w(walrus web)))
 
-    refute fetch_restarted_at("web"), "no RESTARTED_AT env after failed restart task"
+    refute(fetch_restarted_at("web"), "no RESTARTED_AT env after failed restart task")
     assert_logs_match_all([
       "Configured to restart deployments by name: walrus, web",
       "Result: FAILURE",
-      "Deployment `walrus` not found in namespace"
+      "Deployment `walrus` not found in namespace",
     ],
       in_order: true)
   end
@@ -120,7 +120,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_restart_failure(restart.perform([]))
     assert_logs_match_all([
       "Result: FAILURE",
-      "Configured to restart deployments by name, but list of names was blank"
+      "Configured to restart deployments by name, but list of names was blank",
     ],
       in_order: true)
   end
@@ -134,7 +134,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_restart_failure(restart.perform(%w(web)))
     assert_logs_match_all([
       "Result: FAILURE",
-      "`walrus` context must be configured in your kubeconfig file(s)"
+      "`walrus` context must be configured in your kubeconfig file(s)",
     ],
       in_order: true)
   end
@@ -148,7 +148,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert_restart_failure(restart.perform(%w(web)))
     assert_logs_match_all([
       "Result: FAILURE",
-      "Namespace `walrus` not found in context `#{TEST_CONTEXT}`"
+      "Namespace `walrus` not found in context `#{TEST_CONTEXT}`",
     ],
       in_order: true)
   end
@@ -166,9 +166,9 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
           "command" => [
             "/bin/sh",
             "-c",
-            "test $(env | grep -s RESTARTED_AT -c) -eq 0"
-          ]
-        }
+            "test $(env | grep -s RESTARTED_AT -c) -eq 0",
+          ],
+        },
       }
     end
     assert_deploy_success(success)
@@ -185,7 +185,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       "The following containers have not passed their readiness probes",
       "app must exit 0 from the following command",
       "Final status: 2 replicas, 1 updatedReplica, 1 availableReplica, 1 unavailableReplica",
-      "Unhealthy: Readiness probe failed"
+      "Unhealthy: Readiness probe failed",
     ],
       in_order: true)
   end
@@ -197,7 +197,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       container = web["spec"]["template"]["spec"]["containers"].first
       container["readinessProbe"] = {
         "exec" => { "command" => %w(sleep 5) },
-        "timeoutSeconds" => 6
+        "timeoutSeconds" => 6,
       }
     end
     assert_deploy_success(result)
@@ -209,15 +209,15 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     new_pods = pods.select do |pod|
       pod.spec.containers.any? { |c| c["name"] == "app" && c.env&.find { |n| n.name == "RESTARTED_AT" } }
     end
-    assert new_pods.length >= 1, "Expected at least one new pod, saw #{new_pods.length}"
+    assert(new_pods.length >= 1, "Expected at least one new pod, saw #{new_pods.length}")
 
     new_ready_pods = new_pods.select do |pod|
       pod.status.phase == "Running" &&
       pod.status.conditions.any? { |condition| condition["type"] == "Ready" && condition["status"] == "True" }
     end
-    assert_equal 1, new_ready_pods.length, "Expected exactly one new pod to be ready, saw #{new_ready_pods.length}"
+    assert_equal(1, new_ready_pods.length, "Expected exactly one new pod to be ready, saw #{new_ready_pods.length}")
 
-    assert fetch_restarted_at("web"), "RESTARTED_AT is present after the restart"
+    assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
   end
 
   private

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -8,7 +8,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     deploy_unschedulable_task_template
 
     task_runner = build_task_runner
-    assert_nil task_runner.pod_name
+    assert_nil(task_runner.pod_name)
     result = task_runner.run(run_params(verify_result: false))
     assert_task_run_success(result)
 
@@ -22,8 +22,8 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
 
     pods = kubeclient.get_pods(namespace: @namespace)
-    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
-    assert_equal task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run"
+    assert_equal(1, pods.length, "Expected 1 pod to exist, found #{pods.length}")
+    assert_equal(task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run")
   end
 
   def test_run_global_timeout_with_max_watch_seconds
@@ -37,7 +37,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "Result: TIMED OUT",
       "Timed out waiting for 1 resource to run",
       %r{Pod/task-runner-\w+: GLOBAL WATCH TIMEOUT \(5 seconds\)},
-      /Final status\: (Pending|Running)/
+      /Final status\: (Pending|Running)/,
     ], in_order: true)
   end
 
@@ -53,20 +53,20 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "/bin/sh: /not/a/command: not found",
       %r{Pod/task-runner-\w+ failed to run after \d+.\ds},
       "Result: FAILURE",
-      "Pod status: Failed"
+      "Pod status: Failed",
     ], in_order: true)
     refute_logs_match("Logs: None found")
 
     pods = kubeclient.get_pods(namespace: @namespace)
-    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
-    assert_equal task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run"
+    assert_equal(1, pods.length, "Expected 1 pod to exist, found #{pods.length}")
+    assert_equal(task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run")
   end
 
   def test_run_with_verify_result_success
     deploy_task_template
 
     task_runner = build_task_runner
-    assert_nil task_runner.pod_name
+    assert_nil(task_runner.pod_name)
     result = task_runner.run(run_params(log_lines: 8, log_interval: 0.25))
     assert_task_run_success(result)
 
@@ -84,8 +84,8 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       %r{Pod/task-runner-\w+\s+Succeeded},
     ])
     pods = kubeclient.get_pods(namespace: @namespace)
-    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
-    assert_equal task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run"
+    assert_equal(1, pods.length, "Expected 1 pod to exist, found #{pods.length}")
+    assert_equal(task_runner.pod_name, pods.first.metadata.name, "Pod name should be available after run")
   end
 
   def test_run_with_verify_result_fails_quickly_if_the_pod_is_deleted_out_of_band
@@ -99,7 +99,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
             kubeclient.delete_pod(task_runner.pod_name, @namespace)
             break
           rescue Kubeclient::ResourceNotFoundError
-            sleep 0.1
+            sleep(0.1)
             retry
           end
         end
@@ -154,7 +154,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "Phase 1: Initializing task",
       "Using template 'hello-cloud-template-runner'",
       "Changed Pod RestartPolicy from 'OnFailure' to 'Never'. Disable result verification to use 'OnFailure'.",
-      "Phase 2: Running pod"
+      "Phase 2: Running pod",
     ])
   end
 
@@ -171,11 +171,11 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "/bin/sh: /not/a/command: not found",
       %r{Pod/task-runner-\w+ failed to run after \d+.\ds},
       "Result: FAILURE",
-      "Pod status: Failed"
+      "Pod status: Failed",
     ], in_order: true)
 
     pods = kubeclient.get_pods(namespace: @namespace)
-    assert_equal 1, pods.length, "Expected 1 pod to exist, found #{pods.length}"
+    assert_equal(1, pods.length, "Expected 1 pod to exist, found #{pods.length}")
   end
 
   def test_run_fails_if_namespace_is_missing
@@ -187,7 +187,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "Validating configuration",
       "Result: FAILURE",
       "Configuration invalid",
-      "- Namespace was not found"
+      "- Namespace was not found",
     ], in_order: true)
   end
 
@@ -198,7 +198,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       "context `#{KubeclientHelper::TEST_CONTEXT}`"
     assert_logs_match_all([
       "Result: FAILURE",
-      message
+      message,
     ], in_order: true)
 
     assert_raises_message(KubernetesDeploy::RunnerTask::TaskTemplateMissingError, message) do
@@ -222,7 +222,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
 
     assert_logs_match_all([
       "Result: FAILURE",
-      message
+      message,
     ], in_order: true)
   end
 
@@ -240,7 +240,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
 
     assert_logs_match_all([
       "Streaming logs",
-      "The value is: MITTENS"
+      "The value is: MITTENS",
     ], in_order: true)
   end
 
@@ -251,8 +251,8 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
       way_too_fat = {
         "requests" => {
           "cpu" => 1000,
-          "memory" => "100Gi"
-        }
+          "memory" => "100Gi",
+        },
       }
       template = fixtures["template-runner.yml"]["PodTemplate"].first["template"]
       template["spec"]["containers"].first["resources"] = way_too_fat

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ if ENV["PROFILE"]
   require 'ruby-prof-flamegraph'
 end
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'kubernetes-deploy'
 require 'kubeclient'
 require 'timecop'
@@ -28,7 +28,7 @@ require 'webmock/minitest'
 require 'mocha/minitest'
 require 'minitest/parallel'
 require "minitest/reporters"
-include StatsD::Instrument::Assertions
+include(StatsD::Instrument::Assertions)
 
 Dir.glob(File.expand_path("../helpers/*.rb", __FILE__)).each { |file| require file }
 ENV["KUBECONFIG"] ||= "#{Dir.home}/.kube/config"
@@ -38,22 +38,22 @@ Mocha::Configuration.prevent(:stubbing_non_existent_method)
 Mocha::Configuration.prevent(:stubbing_non_public_method)
 
 if ENV["PARALLELIZE_ME"]
-  Minitest::Reporters.use! [
+  Minitest::Reporters.use!([
     Minitest::Reporters::ParallelizableReporter.new(
       fast_fail: ENV['VERBOSE'] == '1',
       slow_count: 10,
       detailed_skip: false,
       verbose: ENV['VERBOSE'] == '1'
-    )
-  ]
+    ),
+  ])
 else
-  Minitest::Reporters.use! [
+  Minitest::Reporters.use!([
     Minitest::Reporters::DefaultReporter.new(
       slow_count: 10,
       detailed_skip: false,
       verbose: ENV['VERBOSE'] == '1'
-    )
-  ]
+    ),
+  ])
 end
 
 module KubernetesDeploy
@@ -109,7 +109,7 @@ module KubernetesDeploy
     end
 
     def assert_deploy_failure(result, cause = nil)
-      assert_equal false, result, "Deploy succeeded when it was expected to fail.#{logs_message_if_captured}"
+      assert_equal(false, result, "Deploy succeeded when it was expected to fail.#{logs_message_if_captured}")
       logging_assertion do |logs|
         cause_string = cause == :timed_out ? "TIMED OUT" : "FAILURE"
         assert_match Regexp.new("Result: #{cause_string}"), logs,
@@ -120,7 +120,7 @@ module KubernetesDeploy
     alias_method :assert_task_run_failure, :assert_deploy_failure
 
     def assert_deploy_success(result)
-      assert_equal true, result, "Deploy failed when it was expected to succeed.#{logs_message_if_captured}"
+      assert_equal(true, result, "Deploy failed when it was expected to succeed.#{logs_message_if_captured}")
       logging_assertion do |logs|
         assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
       end
@@ -131,7 +131,7 @@ module KubernetesDeploy
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|
         unless times
-          assert_match regexp, logs, "'#{regexp}' not found in the following logs:\n#{logs}"
+          assert_match(regexp, logs, "'#{regexp}' not found in the following logs:\n#{logs}")
           return
         end
 
@@ -148,9 +148,9 @@ module KubernetesDeploy
           regex = entry.is_a?(Regexp) ? entry : Regexp.new(Regexp.escape(entry))
           if in_order
             failure_msg = "'#{entry}' not found in the expected sequence in the following logs:\n#{logs}"
-            assert scanner.scan_until(regex), failure_msg
+            assert(scanner.scan_until(regex), failure_msg)
           else
-            assert regex =~ logs, "'#{entry}' not found in the following logs:\n#{logs}"
+            assert(regex =~ logs, "'#{entry}' not found in the following logs:\n#{logs}")
           end
         end
       end
@@ -176,7 +176,7 @@ module KubernetesDeploy
 
     def assert_raises_message(exception_class, exception_message)
       exception = assert_raises(exception_class) { yield }
-      assert_match exception_message, exception.message
+      assert_match(exception_message, exception.message)
       exception
     end
 

--- a/test/unit/container_logs_test.rb
+++ b/test/unit/container_logs_test.rb
@@ -22,7 +22,7 @@ class ContainerLogsTest < KubernetesDeploy::TestCase
     @logs.sync
     @logs.sync
 
-    assert_equal generate_log_messages(1..15), @logs.lines
+    assert_equal(generate_log_messages(1..15), @logs.lines)
   end
 
   def test_sync_handles_cycles_where_no_new_logs_available
@@ -34,14 +34,14 @@ class ContainerLogsTest < KubernetesDeploy::TestCase
     @logs.sync
     @logs.sync
 
-    assert_equal generate_log_messages(1..10), @logs.lines
+    assert_equal(generate_log_messages(1..10), @logs.lines)
   end
 
   def test_empty_delegated_to_lines
     KubernetesDeploy::Kubectl.any_instance.stubs(:run).returns([logs_response_1, "", ""])
-    assert_predicate @logs, :empty?
+    assert_predicate(@logs, :empty?)
     @logs.sync
-    refute_predicate @logs, :empty?
+    refute_predicate(@logs, :empty?)
   end
 
   def test_print_latest_and_print_all_output_the_correct_chunks
@@ -74,7 +74,7 @@ class ContainerLogsTest < KubernetesDeploy::TestCase
     expected = [
       "[A]  Line 1",
       "[A]  Line 2",
-      "[A]  Line 3"
+      "[A]  Line 3",
     ]
     @logs.print_latest(prefix: true)
     assert_logs_match_all(expected, in_order: true)
@@ -96,7 +96,7 @@ class ContainerLogsTest < KubernetesDeploy::TestCase
       "Line 2",
       "Line 3",
       "No timestamp 2", # moved to start of batch 2
-      "Line 4"
+      "Line 4",
     ], in_order: true)
   end
 

--- a/test/unit/kubernetes-deploy/bindings_parser_test.rb
+++ b/test/unit/kubernetes-deploy/bindings_parser_test.rb
@@ -5,22 +5,22 @@ require 'json'
 class BindingsParserTest < ::Minitest::Test
   def test_parse_json
     expected = { "foo" => 42, "bar" => "hello" }
-    assert_equal expected, parse(expected.to_json)
+    assert_equal(expected, parse(expected.to_json))
   end
 
   def test_parse_json_file
     expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
-    assert_equal expected, parse("@test/fixtures/for_unit_tests/bindings.json")
+    assert_equal(expected, parse("@test/fixtures/for_unit_tests/bindings.json"))
   end
 
   def test_parse_yaml_file_with_yml_ext
     expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
-    assert_equal expected, parse("@test/fixtures/for_unit_tests/bindings.yml")
+    assert_equal(expected, parse("@test/fixtures/for_unit_tests/bindings.yml"))
   end
 
   def test_parse_yaml_file_with_yaml_ext
     expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
-    assert_equal expected, parse("@test/fixtures/for_unit_tests/bindings.yaml")
+    assert_equal(expected, parse("@test/fixtures/for_unit_tests/bindings.yaml"))
   end
 
   def test_parse_nonexistent_file
@@ -37,7 +37,7 @@ class BindingsParserTest < ::Minitest::Test
 
   def test_parse_complex_json
     expected = { "foo" => 42, "bar" => [1, 2, 3], "bla" => { "hello" => 17 } }
-    assert_equal expected, parse(expected.to_json)
+    assert_equal(expected, parse(expected.to_json))
   end
 
   def test_parse_json_not_hash
@@ -48,22 +48,22 @@ class BindingsParserTest < ::Minitest::Test
 
   def test_parse_csv
     expected = { "foo" => "42", "bar" => "17" }
-    assert_equal expected, parse("foo=42,bar=17")
+    assert_equal(expected, parse("foo=42,bar=17"))
   end
 
   def test_parse_csv_with_comma_in_values
     expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
-    assert_equal expected, parse('"foo=a,b,c",bar=d,"bla=e,f"')
+    assert_equal(expected, parse('"foo=a,b,c",bar=d,"bla=e,f"'))
   end
 
   def test_parse_csv_with_equality_sign
     expected = { "foo" => "1=2=3", "bar" => "3", "bla" => "4=7" }
-    assert_equal expected, parse("foo=1=2=3,bar=3,bla=4=7")
+    assert_equal(expected, parse("foo=1=2=3,bar=3,bla=4=7"))
   end
 
   def test_parse_csv_with_no_value
     expected = { "bla" => nil, "foo" => "" }
-    assert_equal expected, parse("bla,foo=")
+    assert_equal(expected, parse("bla,foo="))
   end
 
   def test_parse_csv_with_no_key

--- a/test/unit/kubernetes-deploy/concurrency_test.rb
+++ b/test/unit/kubernetes-deploy/concurrency_test.rb
@@ -57,10 +57,10 @@ class ConcurrencyTest < KubernetesDeploy::TestCase
   private
 
   def assert_work_distribution(all_work, expected)
-    assert all_work.all? { |w| w.worked_by_threads.length == 1 }, "Same work done by multiple threads somehow"
+    assert(all_work.all? { |w| w.worked_by_threads.length == 1 }, "Same work done by multiple threads somehow")
     thread_map = all_work.each_with_object(Hash.new { |hash, key| hash[key] = 0 }) do |w, threads|
       threads[w.worked_by_threads.first] += 1
     end
-    assert_equal thread_map.values.sort, expected.sort
+    assert_equal(thread_map.values.sort, expected.sort)
   end
 end

--- a/test/unit/kubernetes-deploy/deploy_task_test.rb
+++ b/test/unit/kubernetes-deploy/deploy_task_test.rb
@@ -5,7 +5,7 @@ class DeployTaskTest < KubernetesDeploy::TestCase
   include EnvTestHelper
 
   def test_that_it_has_a_version_number
-    refute_nil ::KubernetesDeploy::VERSION
+    refute_nil(::KubernetesDeploy::VERSION)
   end
 
   def test_error_message_when_kubeconfig_not_set

--- a/test/unit/kubernetes-deploy/duration_parser_test.rb
+++ b/test/unit/kubernetes-deploy/duration_parser_test.rb
@@ -3,24 +3,24 @@ require 'test_helper'
 
 class DurationParserTest < KubernetesDeploy::TestCase
   def test_parses_correct_iso_durations_with_prefixes
-    assert_equal 300, new_parser("PT300S").parse!
-    assert_equal 300, new_parser("PT5M").parse!
-    assert_equal 900, new_parser("PT0.25H").parse!
-    assert_equal 110839937, new_parser("P3Y6M4DT12H30M5S").parse!
+    assert_equal(300, new_parser("PT300S").parse!)
+    assert_equal(300, new_parser("PT5M").parse!)
+    assert_equal(900, new_parser("PT0.25H").parse!)
+    assert_equal(110839937, new_parser("P3Y6M4DT12H30M5S").parse!)
   end
 
   def test_parses_correct_iso_durations_without_prefixes
-    assert_equal 300, new_parser("300S").parse!
-    assert_equal 300, new_parser("5M").parse!
-    assert_equal 900, new_parser("0.25H").parse!
+    assert_equal(300, new_parser("300S").parse!)
+    assert_equal(300, new_parser("5M").parse!)
+    assert_equal(900, new_parser("0.25H").parse!)
     assert_equal(-60, new_parser("-1M").parse!)
   end
 
   def test_parse_is_case_insensitive
-    assert_equal 30, new_parser("30S").parse!
-    assert_equal 30, new_parser("30s").parse!
-    assert_equal 30, new_parser("pt30s").parse!
-    assert_equal 110839937, new_parser("p3y6M4dT12H30M5s").parse!
+    assert_equal(30, new_parser("30S").parse!)
+    assert_equal(30, new_parser("30s").parse!)
+    assert_equal(30, new_parser("pt30s").parse!)
+    assert_equal(110839937, new_parser("p3y6M4dT12H30M5s").parse!)
   end
 
   def test_parse_raises_expected_error_for_blank_values
@@ -33,7 +33,7 @@ class DurationParserTest < KubernetesDeploy::TestCase
   end
 
   def test_extra_whitespace_is_stripped_from_values
-    assert_equal 30, new_parser("  30S    ").parse!
+    assert_equal(30, new_parser("  30S    ").parse!)
   end
 
   def test_parse_raises_expected_error_when_value_is_invalid

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -5,8 +5,8 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def test_secret_changes_required_based_on_ejson_file_existence
     stub_kubectl_response("get", "secrets", resp: { items: [dummy_ejson_secret] })
 
-    refute build_provisioner(fixture_path('hello-cloud')).secret_changes_required?
-    assert build_provisioner(fixture_path('ejson-cloud')).secret_changes_required?
+    refute(build_provisioner(fixture_path('hello-cloud')).secret_changes_required?)
+    assert(build_provisioner(fixture_path('ejson-cloud')).secret_changes_required?)
   end
 
   def test_secret_changes_required_based_on_managed_secret_existence
@@ -14,7 +14,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
       "get", "secrets",
       resp: { items: [dummy_secret_hash(managed: true), dummy_ejson_secret] }
     )
-    assert build_provisioner(fixture_path('hello-cloud')).secret_changes_required?
+    assert(build_provisioner(fixture_path('hello-cloud')).secret_changes_required?)
   end
 
   def test_run_with_no_secrets_file_or_managed_secrets_no_ops
@@ -34,7 +34,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def test_run_with_ejson_keypair_mismatch
     wrong_public = {
       "2200e55f22dd0c93fac3832ba14842cc75fa5a99a2e01696daa30e188d465036" =>
-        "139d5c2a30901dd8ae186be582ccc0a882c16f8e0bb5429884dbc7296e80669e"
+        "139d5c2a30901dd8ae186be582ccc0a882c16f8e0bb5429884dbc7296e80669e",
     }
     stub_kubectl_response("get", "secret", "ejson-keys", resp: dummy_ejson_secret(wrong_public))
 
@@ -79,7 +79,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     stub_kubectl_response("get", "secret", "ejson-keys", resp: dummy_ejson_secret)
     new_content = {
       "_public_key" => fixture_public_key,
-      "kubernetes_secrets" => { "foobar" => {} }
+      "kubernetes_secrets" => { "foobar" => {} },
     }
 
     msg = "Ejson incomplete for secret foobar: secret type unspecified, no data provided"
@@ -94,7 +94,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def correct_ejson_key_secret_data
     {
-      fixture_public_key => "fedcc95132e9b399ee1f404364fdbc81bdbe4feb5b8292b061f1022481157d5a"
+      fixture_public_key => "fedcc95132e9b399ee1f404364fdbc81bdbe4feb5b8292b061f1022481157d5a",
     }
   end
 
@@ -125,9 +125,9 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
       'metadata' => {
         "name" => name,
         "labels" => { "name" => name },
-        "namespace" => 'test'
+        "namespace" => 'test',
       },
-      "data" => encoded_data
+      "data" => encoded_data,
     }
     if managed
       secret['metadata']['annotations'] = { KubernetesDeploy::EjsonSecretProvisioner::MANAGEMENT_ANNOTATION => true }

--- a/test/unit/kubernetes-deploy/google_friendly_config_test.rb
+++ b/test/unit/kubernetes-deploy/google_friendly_config_test.rb
@@ -21,13 +21,13 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
           "access_token" => "bearer_token",
           "token_type" => "Bearer",
           "expires_in" => 3600,
-          "id_token" => "identity_token"
+          "id_token" => "identity_token",
         }.to_json,
         status: 200
       )
 
     context = config.context("google")
-    assert_equal 'bearer_token', context.auth_options[:bearer_token]
+    assert_equal('bearer_token', context.auth_options[:bearer_token])
   end
 
   def test_auth_use_default_gcp_failure
@@ -50,29 +50,29 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
 
     context = config.context("minikube")
 
-    assert_equal 'test', context.auth_options[:password]
-    assert_equal 'admin', context.auth_options[:username]
+    assert_equal('test', context.auth_options[:password])
+    assert_equal('admin', context.auth_options[:username])
   end
 
   def kubeconfig
     {
       'apiVersion' => 'v1',
       'clusters' => [
-        { 'cluster' => { 'server' => 'https://192.168.64.3:8443' }, 'name' => 'test' }
+        { 'cluster' => { 'server' => 'https://192.168.64.3:8443' }, 'name' => 'test' },
       ],
       'contexts' => [
         {
           'context' => {
             'cluster' => 'test',
-            'user' => 'google'
+            'user' => 'google',
           },
-          'name' => 'google'
+          'name' => 'google',
         },
         {
           'context' => {
             'cluster' => 'test', 'user' => 'minikube'
           },
-          'name' => 'minikube'
+          'name' => 'minikube',
         },
       ],
       'users' => [
@@ -81,18 +81,18 @@ class GoogleFriendlyConfigTest < KubernetesDeploy::TestCase
           'user' => {
             'auth-provider' => {
               'name' => 'gcp',
-              'config' => { 'access_token' => 'test' }
-            }
-          }
+              'config' => { 'access_token' => 'test' },
+            },
+          },
         },
         {
           'name' => 'minikube',
           'user' => {
             'password' => 'test',
-            'username' => 'admin'
-          }
-        }
-      ]
+            'username' => 'admin',
+          },
+        },
+      ],
     }.stringify_keys
   end
 

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -25,8 +25,8 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
     # Build kubeclient for a context present in the dummy config succeeds
     context_name = "docker-for-desktop"
     client = build_v1_kubeclient(context_name)
-    assert !client.nil?, "Expected Kubeclient is built for context " \
-    	"#{context_name} with success."
+    assert(!client.nil?, "Expected Kubeclient is built for context " \
+    	"#{context_name} with success.")
   ensure
     ENV['KUBECONFIG'] = old_config
   end

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -26,9 +26,9 @@ class KubectlTest < KubernetesDeploy::TestCase
       resp: "{ items: [] }")
 
     out, err, st = build_kubectl.run("get", "pods", "-a", "--output=json")
-    assert st.success?
-    assert_equal "{ items: [] }", out
-    assert_equal "", err
+    assert(st.success?)
+    assert_equal("{ items: [] }", out)
+    assert_equal("", err)
   end
 
   def test_run_omits_context_flag_if_use_context_is_false
@@ -95,8 +95,8 @@ class KubectlTest < KubernetesDeploy::TestCase
       _out, _err, st = kubectl.run("get", "pods", attempts: 5)
       refute_predicate st, :success?
     end
-    assert_equal 5, metrics.length
-    assert_equal ["KubernetesDeploy.kubectl.error"], metrics.map(&:name).uniq
+    assert_equal(5, metrics.length)
+    assert_equal(["KubernetesDeploy.kubectl.error"], metrics.map(&:name).uniq)
   end
 
   def test_custom_timeout_is_used
@@ -112,24 +112,24 @@ class KubectlTest < KubernetesDeploy::TestCase
     stub_version_request(server: version_info(1, 7, 8), client: version_info(1, 7, 10))
     kubectl = build_kubectl
     expected_version_info = { server: Gem::Version.new('1.7.8'), client: Gem::Version.new('1.7.10') }
-    assert_equal expected_version_info, kubectl.version_info
+    assert_equal(expected_version_info, kubectl.version_info)
   end
 
   def test_client_version_and_server_version_return_the_correct_result
     stub_version_request(server: version_info(1, 7, 8), client: version_info(1, 7, 10))
 
     kubectl = build_kubectl
-    assert_equal "1.7.10", kubectl.client_version.to_s
-    assert_equal "1.7.8", kubectl.server_version.to_s
+    assert_equal("1.7.10", kubectl.client_version.to_s)
+    assert_equal("1.7.8", kubectl.server_version.to_s)
   end
 
   def test_version_comparisons_are_accurate
     stub_version_request(server: version_info(1, 7, 8), client: version_info(1, 7, 8))
     kubectl = build_kubectl
-    assert_equal kubectl.server_version, kubectl.client_version
-    assert kubectl.server_version < Gem::Version.new('1.7.10')
-    assert kubectl.server_version > Gem::Version.new('1.7.1')
-    assert kubectl.server_version < Gem::Version.new('1.8.0')
+    assert_equal(kubectl.server_version, kubectl.client_version)
+    assert(kubectl.server_version < Gem::Version.new('1.7.10'))
+    assert(kubectl.server_version > Gem::Version.new('1.7.1'))
+    assert(kubectl.server_version < Gem::Version.new('1.8.0'))
   end
 
   def test_version_methods_work_with_gke_versions
@@ -140,9 +140,9 @@ class KubectlTest < KubernetesDeploy::TestCase
 
     kubectl = build_kubectl
     expected_version_info = { client: Gem::Version.new('1.7.10'), server: Gem::Version.new('1.7.6') }
-    assert_equal expected_version_info, kubectl.version_info
-    assert_equal "1.7.10", kubectl.client_version.to_s
-    assert_equal "1.7.6", kubectl.server_version.to_s
+    assert_equal(expected_version_info, kubectl.version_info)
+    assert_equal("1.7.10", kubectl.client_version.to_s)
+    assert_equal("1.7.6", kubectl.server_version.to_s)
   end
 
   def test_version_info_raises_if_command_fails

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -7,7 +7,7 @@ class DaemonSetTest < KubernetesDeploy::TestCase
   def test_deploy_not_successful_when_updated_available_does_not_match
     ds_template = build_ds_template
     ds = build_synced_ds(template: ds_template)
-    refute_predicate ds, :deploy_succeeded?
+    refute_predicate(ds, :deploy_succeeded?)
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_status
@@ -19,14 +19,14 @@ class DaemonSetTest < KubernetesDeploy::TestCase
     }
     ds_template = build_ds_template(status: status)
     ds = build_synced_ds(template: ds_template)
-    refute_predicate ds, :deploy_succeeded?
+    refute_predicate(ds, :deploy_succeeded?)
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
     ds_template = build_ds_template(status: { "observedGeneration": 1 })
     ds = build_synced_ds(template: ds_template)
     ds.stubs(:pods).returns([stub(deploy_failed?: true)])
-    refute_predicate ds, :deploy_failed?
+    refute_predicate(ds, :deploy_failed?)
   end
 
   def test_deploy_passes_when_updated_available_does_match
@@ -40,7 +40,7 @@ class DaemonSetTest < KubernetesDeploy::TestCase
 
     ds_template = build_ds_template(status: status)
     ds = build_synced_ds(template: ds_template)
-    assert_predicate ds, :deploy_succeeded?
+    assert_predicate(ds, :deploy_succeeded?)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -9,18 +9,18 @@ class DeploymentTest < KubernetesDeploy::TestCase
       "replicas" => 3,
       "updatedReplicas" => 1,
       "unavailableReplicas" => 1,
-      "availableReplicas" => 0
+      "availableReplicas" => 0,
     }
 
     rs_status = {
       "replicas" => 3,
       "availableReplicas" => 0,
-      "readyReplicas" => 0
+      "readyReplicas" => 0,
     }
     dep_template = build_deployment_template(status: deployment_status, rollout: 'none',
       strategy: 'RollingUpdate', max_unavailable: 1)
     deploy = build_synced_deployment(template: dep_template, replica_sets: [build_rs_template(status: rs_status)])
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
   end
 
   def test_deploy_succeeded_is_false_with_none_annotation_before_new_rs_created
@@ -28,13 +28,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
       "replicas" => 3,
       "updatedReplicas" => 3,
       "unavailableReplicas" => 0,
-      "availableReplicas" => 3
+      "availableReplicas" => 3,
     }
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'none'),
       replica_sets: []
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
   end
 
   def test_deploy_succeeded_with_max_unavailable
@@ -42,13 +42,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
       "replicas" => 3, # one terminating in old rs, one starting in new rs, one up in new rs
       "updatedReplicas" => 2,
       "unavailableReplicas" => 2,
-      "availableReplicas" => 1
+      "availableReplicas" => 1,
     }
 
     rs_status = {
       "replicas" => 2,
       "availableReplicas" => 1,
-      "readyReplicas" => 1
+      "readyReplicas" => 1,
     }
     replica_sets = [build_rs_template(status: rs_status)]
 
@@ -56,25 +56,25 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: 3),
       replica_sets: replica_sets
     )
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: 2),
       replica_sets: replica_sets
     )
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: 1),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: 0),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
   end
 
   def test_deploy_succeeded_with_annotation_as_percent
@@ -82,13 +82,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
       "replicas" => 3, # one terminating in old rs, one starting in new rs, one up in new rs
       "updatedReplicas" => 2,
       "unavailableReplicas" => 2,
-      "availableReplicas" => 1
+      "availableReplicas" => 1,
     }
 
     rs_status = {
       "replicas" => 2,
       "availableReplicas" => 1,
-      "readyReplicas" => 1
+      "readyReplicas" => 1,
     }
     replica_sets = [build_rs_template(status: rs_status)]
 
@@ -96,25 +96,25 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(status: deployment_status, rollout: '0%'),
       replica_sets: replica_sets
     )
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: '33%'),
       replica_sets: replica_sets
     )
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: '34%'),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: '100%'),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
   end
 
   def test_deploy_succeeded_with_max_unavailable_as_percent
@@ -122,40 +122,40 @@ class DeploymentTest < KubernetesDeploy::TestCase
       "replicas" => 3,
       "updatedReplicas" => 2,
       "unavailableReplicas" => 2,
-      "availableReplicas" => 1
+      "availableReplicas" => 1,
     }
 
     rs_status = {
       "replicas" => 2,
       "availableReplicas" => 1,
-      "readyReplicas" => 1
+      "readyReplicas" => 1,
     }
     replica_sets = [build_rs_template(status: rs_status)]
 
     dep_template = build_deployment_template(status: deployment_status,
       rollout: 'maxUnavailable', max_unavailable: '100%')
     deploy = build_synced_deployment(template: dep_template, replica_sets: replica_sets)
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     # rounds up to two max
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: '67%'),
       replica_sets: replica_sets
     )
-    assert deploy.deploy_succeeded?
+    assert(deploy.deploy_succeeded?)
 
     # rounds down to one max
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: '66%'),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
 
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'maxUnavailable', max_unavailable: '0%'),
       replica_sets: replica_sets
     )
-    refute deploy.deploy_succeeded?
+    refute(deploy.deploy_succeeded?)
   end
 
   def test_deploy_succeeded_raises_with_invalid_rollout_annotation
@@ -175,13 +175,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
     kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
-    refute deploy.validate_definition(kubectl)
+    refute(deploy.validate_definition(kubectl))
 
     expected = <<~STRING.strip
       super failed
       '#{KubernetesDeploy::Deployment::REQUIRED_ROLLOUT_ANNOTATION}: bad' is invalid. Acceptable values: #{KubernetesDeploy::Deployment::REQUIRED_ROLLOUT_TYPES.join(', ')}
     STRING
-    assert_equal expected, deploy.validation_error_msg
+    assert_equal(expected, deploy.validation_error_msg)
   end
 
   def test_validation_with_percent_rollout_annotation
@@ -189,8 +189,8 @@ class DeploymentTest < KubernetesDeploy::TestCase
     kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
-    assert deploy.validate_definition(kubectl)
-    assert_empty deploy.validation_error_msg
+    assert(deploy.validate_definition(kubectl))
+    assert_empty(deploy.validation_error_msg)
   end
 
   def test_validation_with_number_rollout_annotation
@@ -199,12 +199,12 @@ class DeploymentTest < KubernetesDeploy::TestCase
       ["", "super failed", SystemExit.new(1)]
     )
 
-    refute deploy.validate_definition(kubectl)
+    refute(deploy.validate_definition(kubectl))
     expected = <<~STRING.strip
       super failed
       '#{KubernetesDeploy::Deployment::REQUIRED_ROLLOUT_ANNOTATION}: 10' is invalid. Acceptable values: #{KubernetesDeploy::Deployment::REQUIRED_ROLLOUT_TYPES.join(', ')}
     STRING
-    assert_equal expected, deploy.validation_error_msg
+    assert_equal(expected, deploy.validation_error_msg)
   end
 
   def test_validation_fails_with_invalid_mix_of_annotation
@@ -215,13 +215,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
     kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
-    refute deploy.validate_definition(kubectl)
+    refute(deploy.validate_definition(kubectl))
 
     expected = <<~STRING.strip
       super failed
       '#{KubernetesDeploy::Deployment::REQUIRED_ROLLOUT_ANNOTATION}: maxUnavailable' is incompatible with strategy 'Recreate'
     STRING
-    assert_equal expected, deploy.validation_error_msg
+    assert_equal(expected, deploy.validation_error_msg)
   end
 
   def test_validation_works_with_no_strategy_and_max_unavailable_annotation
@@ -232,7 +232,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
     kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
-    assert deploy.validate_definition(kubectl)
+    assert(deploy.validate_definition(kubectl))
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_status_data
@@ -255,7 +255,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       replica_sets: [build_rs_template(status: rs_status)],
       expect_pod_get: false
     )
-    refute_predicate deploy, :deploy_succeeded?
+    refute_predicate(deploy, :deploy_succeeded?)
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
@@ -264,7 +264,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       replica_sets: [build_rs_template]
     )
     KubernetesDeploy::ReplicaSet.any_instance.stubs(:pods).returns([stub(deploy_failed?: true)])
-    refute_predicate deploy, :deploy_failed?
+    refute_predicate(deploy, :deploy_failed?)
   end
 
   def test_deploy_timed_out_with_hard_timeout
@@ -292,8 +292,8 @@ class DeploymentTest < KubernetesDeploy::TestCase
           "type" => "Progressing",
           "status" => 'False',
           "lastUpdateTime" => Time.now.utc - 10.seconds,
-          "reason" => "ProgressDeadlineExceeded"
-        }]
+          "reason" => "ProgressDeadlineExceeded",
+        }],
       }
       deploy = build_synced_deployment(
         template: build_deployment_template(status: deployment_status),
@@ -316,8 +316,8 @@ class DeploymentTest < KubernetesDeploy::TestCase
           "type" => "Progressing",
           "status" => 'False',
           "lastUpdateTime" => Time.now.utc - 10.seconds,
-          "reason" => "ProgressDeadlineExceeded"
-        }]
+          "reason" => "ProgressDeadlineExceeded",
+        }],
       }
       deploy = build_synced_deployment(
         template: build_deployment_template(status: deployment_status),

--- a/test/unit/kubernetes-deploy/kubernetes_resource/job_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/job_test.rb
@@ -17,29 +17,29 @@ class JobTest < KubernetesDeploy::TestCase
         }],
         failed: 2,
         startTime: "2018-10-12T19:49:28Z",
-      }
+      },
     }
     job = build_synced_job(job_spec.merge(status).deep_stringify_keys)
 
-    assert_predicate job, :deploy_failed?
+    assert_predicate(job, :deploy_failed?)
 
     expected_msg = "BackoffLimitExceeded (Job has reached the specified backoff limit)"
-    assert_equal expected_msg, job.failure_message
+    assert_equal(expected_msg, job.failure_message)
   end
 
   def test_job_fails_without_failed_status_condition
     definition = {
       spec: {
-        backoffLimit: 1
+        backoffLimit: 1,
       },
       status: {
         failed: 2,
         startTime: "2018-10-12T19:49:28Z",
-      }
+      },
     }
     job = build_synced_job(job_spec.merge(definition).deep_stringify_keys)
 
-    assert_predicate job, :deploy_failed?
+    assert_predicate(job, :deploy_failed?)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_disruption_budget_test.rb
@@ -7,13 +7,13 @@ class PodDisruptionBudgetTest < KubernetesDeploy::TestCase
   def test_deploy_succeeded_is_true_as_soon_as_controller_observes_new_version
     template = build_pdb_template(status: { "observedGeneration": 2 })
     pdb = build_synced_pdb(template: template)
-    assert_predicate pdb, :deploy_succeeded?
+    assert_predicate(pdb, :deploy_succeeded?)
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_status
     template = build_pdb_template(status: { "observedGeneration": 1 })
     pdb = build_synced_pdb(template: template)
-    refute_predicate pdb, :deploy_succeeded?
+    refute_predicate(pdb, :deploy_succeeded?)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -9,18 +9,18 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "rpc error: code = 2 desc = Error: image library/some-invalid-image not found",
-          "reason" => "ImagePullBackOff"
-        }
-      }
+          "reason" => "ImagePullBackOff",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
 
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_missing_tag_error
@@ -29,18 +29,18 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => message,
-          "reason" => "ErrImagePull"
-        }
-      }
+          "reason" => "ErrImagePull",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
 
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_false_for_intermittent_image_error
@@ -48,14 +48,14 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "Failed to pull image 'gcr.io/*': rpc error: code = 2 desc = net/http: request canceled",
-          "reason" => "ImagePullBackOff"
-        }
-      }
+          "reason" => "ImagePullBackOff",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    refute pod.deploy_failed?
-    assert_nil pod.failure_message
+    refute(pod.deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_image_pull_backoff
@@ -63,18 +63,18 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "Back-off pulling image 'docker.io/library/hello-world'",
-          "reason" => "ImagePullBackOff"
-        }
-      }
+          "reason" => "ImagePullBackOff",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_container_config_error_post_18
@@ -82,40 +82,40 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "The reason it failed",
-          "reason" => "CreateContainerConfigError"
-        }
-      }
+          "reason" => "CreateContainerConfigError",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to generate container configuration: The reason it failed
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_crash_loop_backoffs
     container_state = {
       "lastState" => {
-        "terminated" => { "exitCode" => 1 }
+        "terminated" => { "exitCode" => 1 },
       },
       "state" => {
         "waiting" => {
           "message" => "Back-off 10s restarting failed container=init-crash-loop-back-off pod=init-crash-74b6dfcdc5",
-          "reason" => "CrashLoopBackOff"
-        }
-      }
+          "reason" => "CrashLoopBackOff",
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Crashing repeatedly (exit 1). See logs for more information.
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_container_cannot_run_error
@@ -124,18 +124,18 @@ class PodTest < KubernetesDeploy::TestCase
         "terminated" => {
           "message" => "/not/a/command: no such file or directory",
           "reason" => "ContainerCannotRun",
-          "exitCode" => 127
-        }
-      }
+          "exitCode" => 127,
+        },
+      },
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    assert pod.deploy_failed?
+    assert(pod.deploy_failed?)
     expected_msg = <<~STRING
       The following containers encountered errors:
       > hello-cloud: Failed to start (exit 127): /not/a/command: no such file or directory
     STRING
-    assert_equal expected_msg.strip, pod.failure_message
+    assert_equal(expected_msg.strip, pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_evicted_unmanaged_pods
@@ -144,13 +144,13 @@ class PodTest < KubernetesDeploy::TestCase
         "message" => "The node was low on resource: nodefsInodes.",
         "phase" => "Failed",
         "reason" => "Evicted",
-        "startTime" => "2018-04-13T22:43:23Z"
+        "startTime" => "2018-04-13T22:43:23Z",
       }
     )
     pod = build_synced_pod(template)
 
-    assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Failed (Reason: Evicted).", pod.failure_message
+    assert_predicate(pod, :deploy_failed?)
+    assert_equal("Pod status: Failed (Reason: Evicted).", pod.failure_message)
   end
 
   def test_deploy_failed_is_false_for_evicted_managed_pods
@@ -159,13 +159,13 @@ class PodTest < KubernetesDeploy::TestCase
         "message" => "The node was low on resource: nodefsInodes.",
         "phase" => "Failed",
         "reason" => "Evicted",
-        "startTime" => "2018-04-13T22:43:23Z"
+        "startTime" => "2018-04-13T22:43:23Z",
       }
     )
     pod = build_synced_pod(template, parent: mock)
 
-    refute_predicate pod, :deploy_failed?
-    assert_nil pod.failure_message
+    refute_predicate(pod, :deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_preempted_unmanaged_pods
@@ -174,13 +174,13 @@ class PodTest < KubernetesDeploy::TestCase
         "message" => "Preempted in order to admit critical pod",
         "phase" => "Failed",
         "reason" => "Preempting",
-        "startTime" => "2018-04-13T22:43:23Z"
+        "startTime" => "2018-04-13T22:43:23Z",
       }
     )
     pod = build_synced_pod(template)
 
-    assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Failed (Reason: Preempting).", pod.failure_message
+    assert_predicate(pod, :deploy_failed?)
+    assert_equal("Pod status: Failed (Reason: Preempting).", pod.failure_message)
   end
 
   def test_deploy_failed_is_false_for_preempted_managed_pods
@@ -189,13 +189,13 @@ class PodTest < KubernetesDeploy::TestCase
         "message" => "Preempted in order to admit critical pod",
         "phase" => "Failed",
         "reason" => "Preempting",
-        "startTime" => "2018-04-13T22:43:23Z"
+        "startTime" => "2018-04-13T22:43:23Z",
       }
     )
     pod = build_synced_pod(template, parent: mock)
 
-    refute_predicate pod, :deploy_failed?
-    assert_nil pod.failure_message
+    refute_predicate(pod, :deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_terminating_unmanaged_pods
@@ -203,9 +203,9 @@ class PodTest < KubernetesDeploy::TestCase
     template["metadata"]["deletionTimestamp"] = "2018-04-13T22:43:23Z"
     pod = build_synced_pod(template)
 
-    assert_predicate pod, :terminating?
-    assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Terminating.", pod.failure_message
+    assert_predicate(pod, :terminating?)
+    assert_predicate(pod, :deploy_failed?)
+    assert_equal("Pod status: Terminating.", pod.failure_message)
   end
 
   def test_deploy_failed_is_false_for_terminating_managed_pods
@@ -213,9 +213,9 @@ class PodTest < KubernetesDeploy::TestCase
     template["metadata"]["deletionTimestamp"] = "2018-04-13T22:43:23Z"
     pod = build_synced_pod(template, parent: mock)
 
-    assert_predicate pod, :terminating?
-    refute_predicate pod, :deploy_failed?
-    assert_nil pod.failure_message
+    assert_predicate(pod, :terminating?)
+    refute_predicate(pod, :deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_disappeared_unmanaged_pods
@@ -226,9 +226,9 @@ class PodTest < KubernetesDeploy::TestCase
     cache.expects(:get_instance).raises(KubernetesDeploy::Kubectl::ResourceNotFoundError)
     pod.sync(cache)
 
-    assert_predicate pod, :disappeared?
-    assert_predicate pod, :deploy_failed?
-    assert_equal "Pod status: Disappeared.", pod.failure_message
+    assert_predicate(pod, :disappeared?)
+    assert_predicate(pod, :deploy_failed?)
+    assert_equal("Pod status: Disappeared.", pod.failure_message)
   end
 
   def test_deploy_failed_is_false_for_disappeared_managed_pods
@@ -239,9 +239,9 @@ class PodTest < KubernetesDeploy::TestCase
     cache.expects(:get_instance).raises(KubernetesDeploy::Kubectl::ResourceNotFoundError)
     pod.sync(cache)
 
-    assert_predicate pod, :disappeared?
-    refute_predicate pod, :deploy_failed?
-    assert_nil pod.failure_message
+    assert_predicate(pod, :disappeared?)
+    refute_predicate(pod, :deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   private
@@ -269,9 +269,9 @@ class PodTest < KubernetesDeploy::TestCase
             "state" => {},
             "name" => "hello-cloud",
             "ready" => false,
-            "restartCount" => 0
-          }.merge(container_state)
-        ]
+            "restartCount" => 0,
+          }.merge(container_state),
+        ],
       }
     )
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -7,20 +7,20 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
   def test_deploy_succeeded_is_true_when_generation_and_replica_counts_match
     template = build_rs_template(status: { "observedGeneration": 2 })
     rs = build_synced_rs(template: template)
-    assert_predicate rs, :deploy_succeeded?
+    assert_predicate(rs, :deploy_succeeded?)
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_status
     template = build_rs_template(status: { "observedGeneration": 1 })
     rs = build_synced_rs(template: template)
-    refute_predicate rs, :deploy_succeeded?
+    refute_predicate(rs, :deploy_succeeded?)
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
     template = build_rs_template(status: { "observedGeneration": 1, "readyReplicas": 0, "availableReplicas": 0 })
     rs = build_synced_rs(template: template)
     rs.stubs(:pods).returns([stub(deploy_failed?: true)])
-    refute_predicate rs, :deploy_failed?
+    refute_predicate(rs, :deploy_failed?)
   end
 
   def test_sync_does_not_request_pods_if_we_already_know_they_are_fine

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -10,15 +10,15 @@ class ServiceTest < KubernetesDeploy::TestCase
 
     stub_kind_get("Service", items: [])
     svc.sync(build_resource_cache)
-    refute svc.exists?
-    refute svc.deploy_succeeded?
-    assert_equal "Not found", svc.status
+    refute(svc.exists?)
+    refute(svc.deploy_succeeded?)
+    assert_equal("Not found", svc.status)
 
     stub_kind_get("Service", items: [svc_def])
     svc.sync(build_resource_cache)
-    assert svc.exists?
-    assert svc.deploy_succeeded?
-    assert_equal "Doesn't require any endpoints", svc.status
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status)
   end
 
   def test_selectorless_cluster_ip_svc
@@ -27,16 +27,16 @@ class ServiceTest < KubernetesDeploy::TestCase
 
     stub_kind_get("Service", items: [svc_def])
     svc.sync(build_resource_cache)
-    assert svc.exists?
-    assert svc.deploy_succeeded?
-    assert_equal "Doesn't require any endpoints", svc.status # TODO: this is not strictly correct
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status) # TODO: this is not strictly correct
   end
 
   def test_status_not_found_for_all_types_before_exist
     all_services = [
       build_service(service_fixture('external-name')),
       build_service(service_fixture('standard')),
-      build_service(service_fixture('zero-replica'))
+      build_service(service_fixture('zero-replica')),
     ]
 
     stub_kind_get("Service", items: [])
@@ -60,18 +60,18 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Pod", items: [])
     svc.sync(build_resource_cache)
 
-    assert svc.exists?
-    refute svc.deploy_succeeded?
-    assert_equal "Selects 0 pods", svc.status
+    assert(svc.exists?)
+    refute(svc.deploy_succeeded?)
+    assert_equal("Selects 0 pods", svc.status)
 
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: deployment_fixtures)
     stub_kind_get("Pod", items: pod_fixtures)
     svc.sync(build_resource_cache)
 
-    assert svc.exists?
-    assert svc.deploy_succeeded?
-    assert_equal "Selects at least 1 pod", svc.status
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Selects at least 1 pod", svc.status)
   end
 
   def test_assumes_endpoints_required_when_related_deployment_not_found
@@ -83,9 +83,9 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Pod", items: [])
     svc.sync(build_resource_cache)
 
-    assert svc.exists?
-    refute svc.deploy_succeeded?
-    assert_equal "Selects 0 pods", svc.status
+    assert(svc.exists?)
+    refute(svc.deploy_succeeded?)
+    assert_equal("Selects 0 pods", svc.status)
   end
 
   def test_services_for_zero_replica_deployments_do_not_require_endpoints
@@ -97,9 +97,9 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Pod", items: [])
     svc.sync(build_resource_cache)
 
-    assert svc.exists?
-    assert svc.deploy_succeeded?
-    assert_equal "Doesn't require any endpoints", svc.status
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status)
   end
 
   private

--- a/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/stateful_set_test.rb
@@ -7,13 +7,13 @@ class StatefulSetTest < KubernetesDeploy::TestCase
   def test_deploy_succeeded_is_true_when_revision_and_replica_counts_match
     template = build_ss_template(status: { "observedGeneration": 2 })
     ss = build_synced_ss(template: template)
-    assert_predicate ss, :deploy_succeeded?
+    assert_predicate(ss, :deploy_succeeded?)
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
     template = build_ss_template(status: { "observedGeneration": 1 })
     ss = build_synced_ss(template: template)
-    refute_predicate ss, :deploy_succeeded?
+    refute_predicate(ss, :deploy_succeeded?)
   end
 
   def test_deploy_failed_not_fooled_by_stale_status
@@ -24,7 +24,7 @@ class StatefulSetTest < KubernetesDeploy::TestCase
     template = build_ss_template(status: status)
     ss = build_synced_ss(template: template)
     ss.stubs(:pods).returns([stub(deploy_failed?: true)])
-    refute_predicate ss, :deploy_failed?
+    refute_predicate(ss, :deploy_failed?)
   end
 
   private

--- a/test/unit/kubernetes-deploy/logger_test.rb
+++ b/test/unit/kubernetes-deploy/logger_test.rb
@@ -4,16 +4,16 @@ require 'test_helper'
 class FormattedLoggerTest < KubernetesDeploy::TestCase
   def test_build
     new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
-    assert new_logger.is_a?(::Logger)
-    assert_equal ::Logger::INFO, new_logger.level
-    refute_nil new_logger.formatter
+    assert(new_logger.is_a?(::Logger))
+    assert_equal(::Logger::INFO, new_logger.level)
+    refute_nil(new_logger.formatter)
   end
 
   def test_debug_log_level_from_env
     original_env = ENV["DEBUG"]
     ENV["DEBUG"] = "lol"
     new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
-    assert_equal ::Logger::DEBUG, new_logger.level
+    assert_equal(::Logger::DEBUG, new_logger.level)
   ensure
     ENV["DEBUG"] = original_env
   end
@@ -22,7 +22,7 @@ class FormattedLoggerTest < KubernetesDeploy::TestCase
     original_env = ENV["LEVEL"]
     ENV["LEVEL"] = "warn"
     new_logger = KubernetesDeploy::FormattedLogger.build('test-ns', 'minikube', @logger_stream)
-    assert_equal ::Logger::WARN, new_logger.level
+    assert_equal(::Logger::WARN, new_logger.level)
   ensure
     ENV["LEVEL"] = original_env
   end
@@ -59,7 +59,7 @@ class FormattedLoggerTest < KubernetesDeploy::TestCase
       /^\[WARN\].*\]\t$/,
       /^\[ERROR\].*\]\tError$/,
       /^\[FATAL\].*\]\t$/,
-      /^\[FATAL\].*\]\tFatal$/
+      /^\[FATAL\].*\]\tFatal$/,
     ]
     assert_logs_match_all(entries, in_order: true)
   end

--- a/test/unit/kubernetes-deploy/renderer_test.rb
+++ b/test/unit/kubernetes-deploy/renderer_test.rb
@@ -39,7 +39,7 @@ class RendererTest < KubernetesDeploy::TestCase
     actual = YAML.load_stream(render("partials_test.yaml.erb")).map do |t|
       YAML.dump(t)
     end.join
-    assert_equal expected, actual
+    assert_equal(expected, actual)
   end
 
   def test_invalid_partial_raises
@@ -47,9 +47,9 @@ class RendererTest < KubernetesDeploy::TestCase
       render('broken-partial-inclusion.yaml.erb')
     end
     included_from = "partial included from: broken-partial-inclusion.yaml.erb -> broken.yml.erb"
-    assert_match "undefined local variable or method `foo'", err.message
-    assert_match %r{.*/partials/simple.yaml.erb \(#{included_from}\)}, err.filename
-    assert_equal "c: c3\nd: d4\nfoo: <%= foo %>\n", err.content
+    assert_match("undefined local variable or method `foo'", err.message)
+    assert_match(%r{.*/partials/simple.yaml.erb \(#{included_from}\)}, err.filename)
+    assert_equal("c: c3\nd: d4\nfoo: <%= foo %>\n", err.content)
   end
 
   def test_non_existent_partial_raises
@@ -57,9 +57,9 @@ class RendererTest < KubernetesDeploy::TestCase
       render('including-non-existent-partial.yaml.erb')
     end
     base = "Could not find partial 'foobarbaz' in any of"
-    assert_match %r{#{base} .*/fixtures/for_unit_tests/partials:.*/fixtures/partials}, err.message
-    assert_equal "including-non-existent-partial.yaml.erb", err.filename
-    assert_equal "---\n<%= partial 'foobarbaz' %>\n", err.content
+    assert_match(%r{#{base} .*/fixtures/for_unit_tests/partials:.*/fixtures/partials}, err.message)
+    assert_equal("including-non-existent-partial.yaml.erb", err.filename)
+    assert_equal("---\n<%= partial 'foobarbaz' %>\n", err.content)
   end
 
   def test_nesting_fields
@@ -71,9 +71,9 @@ class RendererTest < KubernetesDeploy::TestCase
         foo: bar
       EOY
     actual = YAML.dump(YAML.load(render('nest-as-rhs.yaml.erb')))
-    assert_equal expected, actual
+    assert_equal(expected, actual)
     actual = YAML.dump(YAML.load(render('nest-indented.yaml.erb')))
-    assert_equal expected, actual
+    assert_equal(expected, actual)
   end
 
   private

--- a/test/unit/kubernetes-deploy/resource_watcher_test.rb
+++ b/test/unit/kubernetes-deploy/resource_watcher_test.rb
@@ -21,7 +21,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
     assert_logs_match_all([
       /Successfully deployed in \d.\ds: web-pod/,
       "Successfully deployed 1 resource",
-      /web-pod\s+success \(1 hits\)/
+      /web-pod\s+success \(1 hits\)/,
     ], in_order: true)
   end
 
@@ -48,7 +48,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       /web-pod failed to deploy after \d\.\ds/,
       "Result: FAILURE",
       "Failed to deploy 1 resource",
-      "Something went wrong"
+      "Something went wrong",
     ], in_order: true)
   end
 
@@ -77,7 +77,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       /Continuing to wait for: third, fourth/,
       /third failed to deploy after \d.\ds/,
       /Continuing to wait for: fourth/,
-      /Successfully deployed in \d.\ds: fourth/
+      /Successfully deployed in \d.\ds: fourth/,
     ], in_order: true)
   end
 
@@ -92,7 +92,7 @@ class ResourceWatcherTest < KubernetesDeploy::TestCase
       /Successfully deployed in \d.\ds: first/,
       /Continuing to wait for: second, third/,
       /Still waiting for: second, third/,
-      /Successfully deployed in \d.\ds: second, third/
+      /Successfully deployed in \d.\ds: second, third/,
     ], in_order: true)
     assert_logs_match(/Continuing to wait for: second, third/, 1) # only once
   end

--- a/test/unit/kubernetes-deploy/runner_task_test.rb
+++ b/test/unit/kubernetes-deploy/runner_task_test.rb
@@ -10,7 +10,7 @@ class RunnerTaskUnitTest < KubernetesDeploy::TestCase
       logger: logger,
     )
 
-    refute task_runner.run(task_template: nil, entrypoint: nil, args: nil)
+    refute(task_runner.run(task_template: nil, entrypoint: nil, args: nil))
     assert_logs_match(/Task template name can't be nil/)
     assert_logs_match(/Namespace can't be empty/)
     assert_logs_match(/Args can't be nil/)

--- a/test/unit/kubernetes-deploy/statsd_test.rb
+++ b/test/unit/kubernetes-deploy/statsd_test.rb
@@ -71,34 +71,34 @@ class StatsDTest < KubernetesDeploy::TestCase
   end
 
   def test_measure_method_does_not_change_the_return_value
-    assert_equal 123, TestMeasureClass.new.thing_to_measure
+    assert_equal(123, TestMeasureClass.new.thing_to_measure)
   end
 
   def test_measure_method_uses_expected_name_and_tags
     metrics = capture_statsd_calls do
       TestMeasureClass.new.thing_to_measure
     end
-    assert_predicate metrics, :one?, "Expected 1 metric, got #{metrics.length}"
-    assert_equal "KubernetesDeploy.thing_to_measure.duration", metrics.first.name
-    assert_equal ["test:true"], metrics.first.tags
+    assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
+    assert_equal("KubernetesDeploy.thing_to_measure.duration", metrics.first.name)
+    assert_equal(["test:true"], metrics.first.tags)
   end
 
   def test_measure_method_with_custom_metric_name
     metrics = capture_statsd_calls do
       TestMeasureClass.new.measure_with_custom_metric
     end
-    assert_predicate metrics, :one?, "Expected 1 metric, got #{metrics.length}"
-    assert_equal "KubernetesDeploy.customized", metrics.first.name
-    assert_equal ["test:true"], metrics.first.tags
+    assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
+    assert_equal("KubernetesDeploy.customized", metrics.first.name)
+    assert_equal(["test:true"], metrics.first.tags)
   end
 
   def test_measure_method_with_statsd_tags_undefined
     metrics = capture_statsd_calls do
       TestMeasureNoTags.new.thing_to_measure
     end
-    assert_predicate metrics, :one?, "Expected 1 metric, got #{metrics.length}"
-    assert_equal "KubernetesDeploy.thing_to_measure.duration", metrics.first.name
-    assert_empty metrics.first.tags
+    assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
+    assert_equal("KubernetesDeploy.thing_to_measure.duration", metrics.first.name)
+    assert_empty(metrics.first.tags)
   end
 
   def test_measure_method_that_raises_with_hash_tags
@@ -109,9 +109,9 @@ class StatsDTest < KubernetesDeploy::TestCase
         tester.measured_method_raises
       end
     end
-    assert_predicate metrics, :one?, "Expected 1 metric, got #{metrics.length}"
-    assert_equal "KubernetesDeploy.measured_method_raises.duration", metrics.first.name
-    assert_equal ["test:true", "error:true"], metrics.first.tags
+    assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
+    assert_equal("KubernetesDeploy.measured_method_raises.duration", metrics.first.name)
+    assert_equal(["test:true", "error:true"], metrics.first.tags)
   end
 
   def test_measure_method_that_raises_with_array_tags
@@ -122,8 +122,8 @@ class StatsDTest < KubernetesDeploy::TestCase
         tester.measured_method_raises
       end
     end
-    assert_predicate metrics, :one?, "Expected 1 metric, got #{metrics.length}"
-    assert_equal "KubernetesDeploy.measured_method_raises.duration", metrics.first.name
-    assert_equal ["test:true", "error:true"], metrics.first.tags
+    assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
+    assert_equal("KubernetesDeploy.measured_method_raises.duration", metrics.first.name)
+    assert_equal(["test:true", "error:true"], metrics.first.tags)
   end
 end

--- a/test/unit/remotes_logs_test.rb
+++ b/test/unit/remotes_logs_test.rb
@@ -47,7 +47,7 @@ class RemoteLogsTest < KubernetesDeploy::TestCase
       "Line A",
       "Line B",
       "Line C",
-      "Line D"
+      "Line D",
     ], in_order: true)
   end
 
@@ -67,7 +67,7 @@ class RemoteLogsTest < KubernetesDeploy::TestCase
       "Line A",
       "Line B",
       "Line C",
-      "Line D"
+      "Line D",
     ], in_order: true)
   end
 

--- a/test/unit/resource_cache_test.rb
+++ b/test/unit/resource_cache_test.rb
@@ -12,8 +12,8 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
   def test_get_instance_populates_the_cache_and_returns_instance_hash
     pods = build_fake_pods(2)
     stub_kind_get("FakePod", items: pods.map(&:kubectl_response), times: 1)
-    assert_equal pods[0].kubectl_response, @cache.get_instance("FakePod", pods[0].name)
-    assert_equal pods[1].kubectl_response, @cache.get_instance("FakePod", pods[1].name)
+    assert_equal(pods[0].kubectl_response, @cache.get_instance("FakePod", pods[0].name))
+    assert_equal(pods[1].kubectl_response, @cache.get_instance("FakePod", pods[1].name))
   end
 
   def test_get_instance_returns_empty_hash_if_pod_not_found
@@ -33,7 +33,7 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
   def test_get_all_populates_cache_and_returns_array_of_instance_hashes
     configmaps = build_fake_config_maps(6)
     stub_kind_get("Configmap", items: configmaps.map(&:kubectl_response), times: 1)
-    assert_equal configmaps.map(&:kubectl_response), @cache.get_all("Configmap")
+    assert_equal(configmaps.map(&:kubectl_response), @cache.get_all("Configmap"))
   end
 
   def test_if_kubectl_error_then_empty_result_returned_but_not_cached
@@ -41,8 +41,8 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
       success: false, resp: { "items" => [] }, err: 'no', times: 4)
 
     # All of these calls should attempt the request again (see the 'times' arg above)
-    assert_equal [], @cache.get_all('FakeConfigMap')
-    assert_equal [], @cache.get_all('FakeConfigMap', "fake" => "false", "type" => "fakeconfigmap")
+    assert_equal([], @cache.get_all('FakeConfigMap'))
+    assert_equal([], @cache.get_all('FakeConfigMap', "fake" => "false", "type" => "fakeconfigmap"))
     assert_equal({}, @cache.get_instance('FakeConfigMap', build_fake_config_maps(1).first.name))
     assert_equal({}, @cache.get_instance('FakeConfigMap', build_fake_config_maps(1).first.name))
   end
@@ -52,14 +52,14 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
     stub_kind_get('FakeConfigMap', items: all_cm.map(&:kubectl_response), times: 1)
 
     maps = @cache.get_all('FakeConfigMap', "name" => all_cm[2].name)
-    assert_equal 1, maps.length
-    assert_equal all_cm[2].kubectl_response, maps.first
+    assert_equal(1, maps.length)
+    assert_equal(all_cm[2].kubectl_response, maps.first)
 
     maps = @cache.get_all('FakeConfigMap', "fake" => "true", "type" => "fakeconfigmap")
-    assert_equal 3, maps.length
+    assert_equal(3, maps.length)
 
     maps = @cache.get_all('FakeConfigMap', "fake" => "false", "type" => "fakeconfigmap")
-    assert_equal 0, maps.length
+    assert_equal(0, maps.length)
   end
 
   def test_concurrently_syncing_huge_numbers_of_resources_makes_exactly_one_kubectl_call_per_kind
@@ -75,7 +75,7 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
     stub_kind_get("FakeConfigMap", items: pods.map(&:kubectl_response), times: 1)
 
     KubernetesDeploy::Concurrency.split_across_threads(all_resources) { |r| r.sync(@cache) }
-    assert all_resources.all?(&:synced?)
+    assert(all_resources.all?(&:synced?))
   end
 
   private
@@ -125,9 +125,9 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
           "labels" => {
             "name" => @name,
             "fake" => "true",
-            "type" => type.downcase
-          }
-        }
+            "type" => type.downcase,
+          },
+        },
       }
     end
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Follow the Shopify styleguide more closely. I recently added a new exception for the `MethodCallWithArgsParentheses` because it first came into effect on an already-approved PR. We could commit the rubocop cache file to prevent that in the future, but then we'd need to periodically delete that file to pick up updates.

**How is this accomplished?** 
Disabling rule exemptions and running `rubocop -a`.

**What could go wrong?**
The new parentheses-heavy style recently adopted could annoy external contributors?


@Shopify/cloudx 