### PR TITLE
Do not fetch pods when we do not need them

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -60,8 +60,10 @@ module KubernetesDeploy
     def check_pods?
       # We're only using pods in deploy_failed? to check that they aren't ALL bad,
       # so if we can already tell that from the RS data, don't bother looking at (or expensively fetching) them
-      return false if !exists? || stale_status?
-      ready_replicas < [2, desired_replicas].min
+      return false unless exists?
+      return false if stale_status?
+      return false if desired_replicas == 0
+      ready_replicas < 2
     end
 
     def rollout_data

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -252,7 +252,8 @@ class DeploymentTest < KubernetesDeploy::TestCase
     }
     deploy = build_synced_deployment(
       template: build_deployment_template(status: deployment_status, rollout: 'full', max_unavailable: 1),
-      replica_sets: [build_rs_template(status: rs_status)]
+      replica_sets: [build_rs_template(status: rs_status)],
+      expect_pod_get: false
     )
     refute_predicate deploy, :deploy_succeeded?
   end
@@ -366,12 +367,13 @@ class DeploymentTest < KubernetesDeploy::TestCase
     result
   end
 
-  def build_synced_deployment(template:, replica_sets:)
+  def build_synced_deployment(template:, replica_sets:, expect_pod_get: nil)
     deploy = KubernetesDeploy::Deployment.new(namespace: "test", context: "nope", logger: logger, definition: template)
     stub_kind_get("Deployment", items: [template])
     stub_kind_get("ReplicaSet", items: replica_sets)
 
-    if replica_sets.present?
+    expect_pod_get = replica_sets.present? if expect_pod_get.nil?
+    if expect_pod_get
       stub_kind_get("Pod", items: [])
     end
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -17,10 +17,30 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
-    template = build_rs_template(status: { "observedGeneration": 1 })
+    template = build_rs_template(status: { "observedGeneration": 1, "readyReplicas": 0, "availableReplicas": 0 })
     rs = build_synced_rs(template: template)
     rs.stubs(:pods).returns([stub(deploy_failed?: true)])
     refute_predicate rs, :deploy_failed?
+  end
+
+  def test_sync_does_not_request_pods_if_we_already_know_they_are_fine
+    should_fetch = build_rs_template(status: { "readyReplicas": 1 })
+    should_not_fetch = build_rs_template(status: { "readyReplicas": 2 })
+
+    rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: should_fetch)
+    stub_kind_get("ReplicaSet", items: [should_fetch])
+    stub_kind_get("Pod", items: [])
+    rs.sync(build_resource_cache)
+
+    stub_kind_get("ReplicaSet", items: [should_not_fetch])
+    rs.sync(build_resource_cache)
+  end
+
+  def test_sync_does_not_request_pods_if_desired_replicas_is_zero
+    template = build_rs_template
+    template["status"] = {}
+    template["spec"]["replicas"] = 0
+    build_synced_rs(template: template) # does not stub pod get
   end
 
   private
@@ -32,7 +52,6 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
   def build_synced_rs(template:)
     rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     stub_kind_get("ReplicaSet", items: [template])
-    stub_kind_get("Pod", items: [])
     rs.sync(build_resource_cache)
     rs
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/replica_set_test.rb
@@ -24,8 +24,8 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
   end
 
   def test_sync_does_not_request_pods_if_we_already_know_they_are_fine
-    should_fetch = build_rs_template(status: { "readyReplicas": 1 })
-    should_not_fetch = build_rs_template(status: { "readyReplicas": 2 })
+    should_fetch = build_rs_template(status: { "readyReplicas": 1, "observedGeneration": 2 })
+    should_not_fetch = build_rs_template(status: { "readyReplicas": 2, "observedGeneration": 2 })
 
     rs = KubernetesDeploy::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: should_fetch)
     stub_kind_get("ReplicaSet", items: [should_fetch])
@@ -38,7 +38,7 @@ class ReplicaSetTest < KubernetesDeploy::TestCase
 
   def test_sync_does_not_request_pods_if_desired_replicas_is_zero
     template = build_rs_template
-    template["status"] = {}
+    template["status"] = { "observedGeneration": 2 }
     template["spec"]["replicas"] = 0
     build_synced_rs(template: template) # does not stub pod get
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
On large clusters, `get pods` is really expensive. Try to do it less often.

**How is this accomplished?**
The main time we have a problem with this is while watching a large set of huge Deployment objects that are steadily rolling out. The reason we fetch pods in that watch is for eager failure detection, i.e. `pods.all?(&:deploy_failed?)` in `ReplicaSet`. The thing is, once the rollout has progressed a little, there's no real possibility of that condition becoming true. This PR check ReplicaSet's status, and if it shows that some pods are ready, we infer that `pods.all?(&:deploy_failed?)` would not be true if we fetched the pods, and bypass that fetch.

The same cannot be done for DS or SS because they use a `.any?` condition.

**What could go wrong?**
This is added complexity that could cause trouble in the future, e.g. if ReplicaSet starts doing something new with `@pods` that expects it to always be populated.