### PR TITLE
Add CustomResourceDefinition to predeploy sequence

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -46,6 +46,7 @@ module KubernetesDeploy
     extend KubernetesDeploy::StatsD::MeasureMethods
 
     PREDEPLOY_SEQUENCE = %w(
+      CustomResourceDefinition
       ResourceQuota
       Cloudsql
       Redis

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -162,7 +162,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
       "Phase 1: Initializing deploy",
       "Detected non-namespaced resources which will never be pruned:",
       " - CustomResourceDefinition/mail.stable.example.io",
-      "Phase 3: Deploying all resources",
+      "Phase 4: Deploying all resources",
       "CustomResourceDefinition/mail.stable.example.io (timeout: 120s)",
       %r{CustomResourceDefinition/mail.stable.example.io\s+Names accepted}
     ])


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Apps such as cert-manager-private use custom resources. Kubernetes-deploy should deploy the custom resource definitions as early as possible. 
