### PR TITLE
Bump metric server

### DIFF
--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -71,9 +71,9 @@ class TestProvisioner
 
       # The service is often slow to start leading to randomly failed HPA tests
       3.times do |round|
-        service = kubectl.run("-n", "kube-system", "get", "APIService", "v1beta1.metrics.k8s.io", "-o", "json")
-        if service.last.success?
-          service = JSON.parse(service.first)
+        service, _, status = kubectl.run("-n", "kube-system", "get", "APIService", "v1beta1.metrics.k8s.io", "-o", "json")
+        if status.success?
+          service = JSON.parse(service)
           available = service.dig("status", "conditions")&.detect { |s| s["type"] == "Available" }
           break if available["status"] == "True"
         end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -71,13 +71,14 @@ class TestProvisioner
 
       # The service is often slow to start leading to randomly failed HPA tests
       3.times do |round|
-        service, _, status = kubectl.run("-n", "kube-system", "get", "APIService", "v1beta1.metrics.k8s.io", "-o", "json")
+        service, _, status = kubectl.run("-n", "kube-system", "-o", "json",
+          "get", "APIService", "v1beta1.metrics.k8s.io")
         if status.success?
           service = JSON.parse(service)
           available = service.dig("status", "conditions")&.detect { |s| s["type"] == "Available" }
           break if available["status"] == "True"
         end
-        sleep(2**(round + 1))
+        sleep(3**(round + 1))
       end
     end
   end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -65,6 +65,11 @@ class TestProvisioner
         logger: logger, log_failure_by_default: true, default_timeout: '5s')
 
       Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").map do |resource|
+        if kubectl.server_version < Gem::Version.new('1.11.0') && resource =~ /metrics-server-deployment.yaml/
+          next
+        elsif kubectl.server_version >= Gem::Version.new('1.11.0') && resource =~ /metrics-server-deployment_021.yaml/
+          next
+        end
         found = kubectl.run("get", "-f", resource, log_failure: false).last.success?
         kubectl.run("create", "-f", resource) unless found
       end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -79,7 +79,7 @@ class TestProvisioner
           service = JSON.parse(service)
           available = service.dig("status", "conditions")&.detect { |s| s["type"] == "Available" }
           if available["status"] == "True"
-            metrics, _, status = kubectl.run(*raw_metrics_command)
+            _, _, status = kubectl.run(*raw_metrics_command)
             break if status.success?
           end
         end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -77,7 +77,7 @@ class TestProvisioner
           available = service.dig("status", "conditions")&.detect { |s| s["type"] == "Available" }
           break if available["status"] == "True"
         end
-        sleep(2 ** (round+1))
+        sleep(2**(round + 1))
       end
     end
   end

--- a/test/helpers/test_provisioner.rb
+++ b/test/helpers/test_provisioner.rb
@@ -64,14 +64,14 @@ class TestProvisioner
       kubectl = KubernetesDeploy::Kubectl.new(namespace: "kube-system", context: KubeclientHelper::TEST_CONTEXT,
         logger: logger, log_failure_by_default: true, default_timeout: '5s')
 
-      Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").map do |resource|
+      Dir.glob("test/setup/metrics-server/*.{yml,yaml}*").each do |resource|
         if kubectl.server_version < Gem::Version.new('1.11.0') && resource =~ /metrics-server-deployment.yaml/
           next
         elsif kubectl.server_version >= Gem::Version.new('1.11.0') && resource =~ /metrics-server-deployment_021.yaml/
           next
         end
         found = kubectl.run("get", "-f", resource, log_failure: false).last.success?
-        kubectl.run("create", "-f", resource) unless found
+        kubectl.run("create", "-f", resource, log_failure: true) unless found
       end
     end
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1047,8 +1047,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_successful
-    # Too flakey on minikube CI
-    skip if kube_server_version < Gem::Version.new('1.11.0')
+    skip if kube_server_version < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_logs_match_all([
       "Deploying resources:",
@@ -1058,8 +1057,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_pruned
-    # Too flakey on minikube CI
-    skip if kube_server_version < Gem::Version.new('1.11.0')
+    skip if kube_server_version < Gem::Version.new('1.9.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1047,7 +1047,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_successful
-    skip if kube_server_version < Gem::Version.new('1.9.0')
+    # Too flakey on minikube CI
+    skip if kube_server_version < Gem::Version.new('1.11.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_logs_match_all([
       "Deploying resources:",
@@ -1057,7 +1058,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_hpa_can_be_pruned
-    skip if kube_server_version < Gem::Version.new('1.9.0')
+    # Too flakey on minikube CI
+    skip if kube_server_version < Gem::Version.new('1.11.0')
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([

--- a/test/setup/metrics-server/metrics-server-deployment.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment.yaml
@@ -23,10 +23,15 @@ spec:
         k8s-app: metrics-server
     spec:
       serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
-        command:
-        - /metrics-server
-        - --source=kubernetes.summary_api:''
+        args: ["--kubelet-insecure-tls"]
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp

--- a/test/setup/metrics-server/metrics-server-deployment_021.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment_021.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      containers:
+      - name: metrics-server
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        imagePullPolicy: Always
+        command:
+        - /metrics-server
+        - --source=kubernetes.summary_api:''


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
The HPA tests often fail due to the metric server not being avilable
fix: https://github.com/Shopify/kubernetes-deploy/issues/373

**How is this accomplished?**
Bump the metric server version. The original version of this pr 
checked if the service is up and if not slept a few times. However, that didn't actually fix the problem. It appeared the issue was the metric server didn't have the requested metrics, see a comment further down in this pr.

**What could go wrong?**
Its still flakey, though I've run it a few times and hasn't failed yet.