### PR TITLE
prevent invalid const errors from lowercase resource kind

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -36,8 +36,8 @@ module KubernetesDeploy
                  statsd_tags: statsd_tags }
         if definition["kind"].blank?
           raise InvalidTemplateError.new("Template missing 'Kind'", content: definition.to_yaml)
-        elsif KubernetesDeploy.const_defined?(definition["kind"])
-          klass = KubernetesDeploy.const_get(definition["kind"])
+        elsif KubernetesDeploy.const_defined?(definition["kind"].capitalize)
+          klass = KubernetesDeploy.const_get(definition["kind"].capitalize)
           klass.new(**opts)
         else
           inst = new(**opts)

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -36,14 +36,19 @@ module KubernetesDeploy
                  statsd_tags: statsd_tags }
         if definition["kind"].blank?
           raise InvalidTemplateError.new("Template missing 'Kind'", content: definition.to_yaml)
-        elsif KubernetesDeploy.const_defined?(definition["kind"].capitalize)
-          klass = KubernetesDeploy.const_get(definition["kind"].capitalize)
-          klass.new(**opts)
-        else
-          inst = new(**opts)
-          inst.type = definition["kind"]
-          inst
         end
+
+        begin
+          if KubernetesDeploy.const_defined?(definition["kind"])
+            klass = KubernetesDeploy.const_get(definition["kind"])
+            return klass.new(**opts)
+          end
+        rescue NameError
+        end
+
+        inst = new(**opts)
+        inst.type = definition["kind"]
+        inst
       end
 
       def timeout

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -288,13 +288,13 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     refute_predicate(dummy, :disappeared?)
   end
 
-  def test_custom_resource_kind
+  def test_lowercase_custom_resource_kind_does_not_raise
     definition = { "kind" => "foobar", "metadata" => { "name" => "test" } }
     KubernetesDeploy::KubernetesResource.build(
       namespace: 'test',
       context: 'test',
       definition: definition,
-      logger: ::Logger.new($stderr),
+      logger: logger,
       statsd_tags: []
     )
   end

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -288,6 +288,17 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
     refute_predicate(dummy, :disappeared?)
   end
 
+  def test_custom_resource_kind
+    definition = { "kind" => "foobar", "metadata" => { "name" => "test" } }
+    KubernetesDeploy::KubernetesResource.build(
+      namespace: 'test',
+      context: 'test',
+      definition: definition,
+      logger: ::Logger.new($stderr),
+      statsd_tags: []
+    )
+  end
+
   private
 
   def kubectl


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix errors that occur if one attempts to deploy a resource that has a kind with a lowercase first letter. This is not the case for any of the standard k8s kinds, but custom resources may use lowercase kinds.

```
NameError: wrong constant name foobar
    lib/kubernetes-deploy/kubernetes_resource.rb:39:in `const_defined?'
    lib/kubernetes-deploy/kubernetes_resource.rb:39:in `build'
```

**How is this accomplished?**
~Capitalize the string before checking for a const. This seemed like the simplest change that wouldn't impact the existing logic.
This would also allow these resource types to have custom resources classes added, in the capitalized form.~

Rescue the NameError and fallback to the generic class. This is safer than changing the string and catches any other edge cases we haven't thought about.

**What could go wrong?**
I can't really think of anything.
