### PR TITLE
Support for deploying only secrets.ejson 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug fixes*
+- Attempting to deploy from a directory that only contains `secrets.ejson` will no longer fail deploy ([#416](https://github.com/Shopify/kubernetes-deploy/pull/416))
+
 ## 0.24.0
 
 *Features*
@@ -14,9 +17,6 @@
 
 *Other*
 - Kubernetes 1.9 is no longer officially supported as of this version
-
-*Bug fixes*
-- Attempting to deploy from a directory that only contains `secrets.ejson` will no longer fail deploy ([#416](https://github.com/Shopify/kubernetes-deploy/pull/416))
 
 ## 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 *Other*
 - Kubernetes 1.9 is no longer officially supported as of this version
 
+*Bug fixes*
+- Attempting to deploy from a directory that only contains `secrets.ejson` will no longer fail deploy ([#416](https://github.com/Shopify/kubernetes-deploy/pull/416))
+
 ## 0.23.0
 
 *Features*

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -324,7 +324,7 @@ module KubernetesDeploy
 
       if !File.directory?(@template_dir)
         errors << "Template directory `#{@template_dir}` doesn't exist"
-      elsif Dir.entries(@template_dir).none? { |file| file =~ /(\.ya?ml(\.erb)?)|(secrets\.ejson)$/ }
+      elsif Dir.entries(@template_dir).none? { |file| file =~ /(\.ya?ml(\.erb)?)$|(secrets\.ejson)$/ }
         errors << "`#{@template_dir}` doesn't contain valid templates (secrets.ejson or postfix .yml, .yml.erb)"
       end
 

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -325,7 +325,7 @@ module KubernetesDeploy
       if !File.directory?(@template_dir)
         errors << "Template directory `#{@template_dir}` doesn't exist"
       elsif Dir.entries(@template_dir).none? { |file| file =~ /(\.ya?ml(\.erb)?)|(secrets\.ejson)$/ }
-        errors << "`#{@template_dir}` doesn't contain valid templates (postfix .yml, .yml.erb, or secrets.ejson)"
+        errors << "`#{@template_dir}` doesn't contain valid templates (secrets.ejson or postfix .yml, .yml.erb)"
       end
 
       if @namespace.blank?

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -324,8 +324,8 @@ module KubernetesDeploy
 
       if !File.directory?(@template_dir)
         errors << "Template directory `#{@template_dir}` doesn't exist"
-      elsif Dir.entries(@template_dir).none? { |file| file =~ /\.ya?ml(\.erb)?$/ }
-        errors << "`#{@template_dir}` doesn't contain valid templates (postfix .yml or .yml.erb)"
+      elsif Dir.entries(@template_dir).none? { |file| file =~ /(\.ya?ml(\.erb)?)|(secrets\.ejson)$/ }
+        errors << "`#{@template_dir}` doesn't contain valid templates (postfix .yml, .yml.erb, or secrets.ejson)"
       end
 
       if @namespace.blank?

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -567,6 +567,17 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     ejson_cloud.refute_resource_exists('secret', 'monitoring-token')
   end
 
+  def test_can_deploy_template_dir_with_only_secrets_ejson
+    ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
+    ejson_cloud.create_ejson_keys_secret
+    assert_deploy_success(deploy_fixtures("ejson-cloud", subset: ["secrets.ejson"]))
+    assert_logs_match_all([
+      "Deploying kubernetes secrets from secrets.ejson",
+      "Result: SUCCESS",
+      %r{Created/updated \d+ secrets}
+    ], in_order: true)
+  end
+
   def test_deploy_result_logging_for_mixed_result_deploy
     subset = ["bad_probe.yml", "init_crash.yml", "missing_volumes.yml", "config_map.yml"]
     result = deploy_fixtures("invalid", subset: subset) do |f|

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -574,7 +574,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_logs_match_all([
       "Deploying kubernetes secrets from secrets.ejson",
       "Result: SUCCESS",
-      %r{Created/updated \d+ secrets}
+      %r{Created/updated \d+ secrets},
     ], in_order: true)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Closes #412 

Let users deploy directories that only contain `secrets.ejson`

**How is this accomplished?**
Add `secrets.ejson` to the regex that checks for valid templates

**What could go wrong?**
Not too much
