### PR TITLE
Do a deep merge on bindings rather than a shallow

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -13,10 +13,9 @@ verbose_log_prefix = false
 max_watch_seconds = nil
 
 ARGV.options do |opts|
+  parser = KubernetesDeploy::BindingsParser.new
   opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
-    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") do |binds|
-    bindings.merge!(KubernetesDeploy::BindingsParser.parse(binds))
-  end
+    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") { |b| parser.add(b) }
 
   opts.on("--skip-wait", "Skip verification of non-priority-resource success (not recommended)") { skip_wait = true }
   prot_ns = KubernetesDeploy::DeployTask::PROTECTED_NAMESPACES.join(', ')
@@ -38,6 +37,7 @@ ARGV.options do |opts|
     exit
   end
   opts.parse!
+  bindings = parser.parse
 end
 
 namespace = ARGV[0]

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -9,12 +9,12 @@ template_dir = nil
 bindings = {}
 
 ARGV.options do |opts|
+  parser = KubernetesDeploy::BindingsParser.new
   opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
-    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") do |binds|
-    bindings.merge!(KubernetesDeploy::BindingsParser.parse(binds))
-  end
+    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") { |b| parser.add(b) }
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
   opts.parse!
+  bindings = parser.parse
 end
 
 templates = ARGV

--- a/lib/kubernetes-deploy/bindings_parser.rb
+++ b/lib/kubernetes-deploy/bindings_parser.rb
@@ -4,17 +4,29 @@ require 'yaml'
 require 'csv'
 
 module KubernetesDeploy
-  module BindingsParser
-    extend self
+  class BindingsParser
+    def self.parse(string)
+      new(string).parse
+    end
 
-    def parse(string)
-      bindings = parse_file(string) || parse_json(string) || parse_csv(string)
+    def initialize(initial_string = nil)
+      @raw_bindings = Array(initial_string)
+    end
 
-      unless bindings
-        raise ArgumentError, "Failed to parse bindings."
+    def add(string)
+      @raw_bindings << string
+    end
+
+    def parse
+      result = {}
+      @raw_bindings.each do |string|
+        bindings = parse_file(string) || parse_json(string) || parse_csv(string)
+        unless bindings
+          raise ArgumentError, "Failed to parse bindings."
+        end
+        result.deep_merge!(bindings)
       end
-
-      bindings
+      result
     end
 
     private

--- a/test/fixtures/for_unit_tests/bindings.yaml
+++ b/test/fixtures/for_unit_tests/bindings.yaml
@@ -2,3 +2,6 @@
 foo: a,b,c
 bar: d
 bla: e,f
+nes:
+  ted: foo
+  cats: awesome

--- a/test/fixtures/for_unit_tests/bindings.yml
+++ b/test/fixtures/for_unit_tests/bindings.yml
@@ -2,3 +2,5 @@
 foo: a,b,c
 bar: d
 bla: e,f
+nes:
+  ted: bar

--- a/test/unit/kubernetes-deploy/bindings_parser_test.rb
+++ b/test/unit/kubernetes-deploy/bindings_parser_test.rb
@@ -14,12 +14,12 @@ class BindingsParserTest < ::Minitest::Test
   end
 
   def test_parse_yaml_file_with_yml_ext
-    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
+    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f", "nes" => { "ted" => "bar" } }
     assert_equal(expected, parse("@test/fixtures/for_unit_tests/bindings.yml"))
   end
 
   def test_parse_yaml_file_with_yaml_ext
-    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f" }
+    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f", "nes" => { "cats" => "awesome", "ted" => "foo" } }
     assert_equal(expected, parse("@test/fixtures/for_unit_tests/bindings.yaml"))
   end
 
@@ -70,6 +70,15 @@ class BindingsParserTest < ::Minitest::Test
     assert_raises(ArgumentError) do
       parse("=17,foo=42")
     end
+  end
+
+  def test_parse_nested_values
+    expected = { "foo" => "a,b,c", "bar" => "d", "bla" => "e,f", "nes" => { "cats" => "awesome", "ted" => "bar" } }
+    bindings = KubernetesDeploy::BindingsParser.new
+    ["@test/fixtures/for_unit_tests/bindings.yaml", "@test/fixtures/for_unit_tests/bindings.yml"].each do |b|
+      bindings.add(b)
+    end
+    assert_equal(expected, bindings.parse)
   end
 
   private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Make it possible to have multiple overlapping configurations that will be deep merged to form one sane configuration.

Eg. lets say you have following configurations:

common.yaml:
```
common:
  registry: private-thingy
...
app:
  port: 4200
  name: cat-service
  lb_id: nonprod
....
```


and then you have environment specific one:

production.yaml:
```
app:
  lb_id: prod
```

Currently we only merge top level entries with `merge` so eg. if `lb_id` was on top this would be fine but for more complex configurations people tend to separate things in to nested entries. Another example could be eg. setting `resources` but overriding limits in certain env, think of:

```
  resources:
    limits:
      cpu: "3"
      memory: "1Gi"
    requests:
      cpu: "3"
      memory: "1Gi"
```

and then in `nonprod` you wanna override the `requests` for example.


**How is this accomplished?**
- Pull the bindings loop in to the parser
- do a `deep_merge!` instead of `merge!`
- profit

tl;dr `s/merge/deep_merge` but I thought its cleaner to pull the loop in to the parser too. Makes testing lot more easier and harder to screw up if doing changes in both deployer and renderer

**What could go wrong?**
Things dont get parsed, world blows up. 

Seriously though, if someone is relying on the wrong behaviour (shallow merge) this might cause a surprise, but technically doing so is wrong .. so :)