### PR TITLE
Removes the risk of sending decrypted EJSON secrets to output.

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -74,7 +74,7 @@ module KubernetesDeploy
         prune_count += 1
         out, err, st = @kubectl.run("delete", "secret", secret_name)
         @logger.debug(out)
-        raise EjsonSecretError, err unless st.success?
+        raise EjsonSecretError, "Failed to prune secrets" unless st.success?
       end
       @logger.summary.add_action("pruned #{prune_count} #{'secret'.pluralize(prune_count)}") if prune_count > 0
     end
@@ -121,7 +121,7 @@ module KubernetesDeploy
 
       out, err, st = @kubectl.run("apply", "--filename=#{file.path}")
       @logger.debug(out)
-      raise EjsonSecretError, err unless st.success?
+      raise EjsonSecretError, "Failed to create or update secrets" unless st.success?
     ensure
       file&.unlink
     end
@@ -181,7 +181,7 @@ module KubernetesDeploy
       raise EjsonSecretError, out_err unless st.success?
       JSON.parse(out_err)
     rescue JSON::ParserError => e
-      raise EjsonSecretError, "Failed to parse decrypted ejson:\n  #{e}"
+      raise EjsonSecretError, "Failed to parse decrypted ejson"
     end
 
     def fetch_private_key_from_secret


### PR DESCRIPTION
**NB: This addresses a security issue with application secrets**

**What are you trying to accomplish with this PR?**
Presently, if a 'kubectl apply' fails when updating EJSON secrets, it's
possible that the decrypted secrets payload can be output as part of the
error message. 

This should be avoided since it can expose all secrets of your application.

For e.g, GKE had an [incident](https://status.cloud.google.com/incident/container-engine/19004) on February 26th which caused
intermittent errors when calling `kubectl`. We happened to see a failure
at the step when secrets are updated. Because `kubectl  apply` failed, the 
exception was bubbled up and logged to output. 

**How is this accomplished?**
This change takes a simple approach by not including the error message in
commands where it is possible to display the payload. The 'Kubectl' class
does not log messages if the sensitive flag is set to true, however the
EjsonSecretProvisioner class raises EjsonSecretError which is logged
further up the stack. 

**What could go wrong?**
The error that is displayed is generic and will not show specific error information
returned from `kubectl`. This might be problematic.

We would like some feedback on this PR specifically whether this is the best approach.
Either way, this addresses a significant security risk that should be looked at ASAP.

Pinging @dturn on the advice of a colleague who formerly worked at Shopify.