### PR TITLE
Make RenderTask to be loaded when kubernetes-deloy is required

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -21,6 +21,7 @@ require 'kubernetes-deploy/concurrency'
 require 'kubernetes-deploy/bindings_parser'
 require 'kubernetes-deploy/duration_parser'
 require 'kubernetes-deploy/resource_cache'
+require 'kubernetes-deploy/render_task'
 
 module KubernetesDeploy
   MIN_KUBE_VERSION = '1.10.0'


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Make `KubernetesDeploy::RenderTask` to be loaded when kubernetes-deploy is required

**How is this accomplished?**
add 'kubernetes-deploy/render_task' to require
