### PR TITLE
Streams deployment task logs if there is only one task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `kubernetes-deploy` and `kubernetes-render` now support reading templates from STDIN. ([#415](https://github.com/Shopify/kubernetes-deploy/pull/415))
 - Support for specifying a `--selector`, a label with which all deployed resources are expected to have, and by which prunable resources will be filtered. This permits sharing a namespace with resources managed by third-parties, including other kubernetes-deploy deployments. ([#439](https://github.com/Shopify/kubernetes-deploy/pull/439))
 - Lists of resources printed during deployments will now be sorted alphabetically. ([#441](https://github.com/Shopify/kubernetes-deploy/pull/441))
+- Bare / unmanaged pods run as pre-deployment tasks will now stream logs if there is only one of them. ([#436](https://github.com/Shopify/kubernetes-deploy/pull/436))
 
 *Features*
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ To run a task in your cluster at the beginning of every deploy, simply include a
 
 A simple example can be found in the test fixtures: test/fixtures/hello-cloud/unmanaged-pod.yml.erb.
 
-The logs of all pods run in this way will be printed inline.
+The logs of all pods run in this way will be printed inline. If there is only one pod, the logs will be streamed in real-time. If there are multiple, they will be fetched when the pod terminates.
 
 ![migrate-logs](screenshots/migrate-logs.png)
 

--- a/lib/kubernetes-deploy/container_logs.rb
+++ b/lib/kubernetes-deploy/container_logs.rb
@@ -13,6 +13,7 @@ module KubernetesDeploy
       @logger = logger
       @lines = []
       @next_print_index = 0
+      @printed_latest = false
     end
 
     def sync
@@ -33,10 +34,15 @@ module KubernetesDeploy
       end
 
       @next_print_index = lines.length
+      @printed_latest = true
     end
 
     def print_all
       lines.each { |line| @logger.info("\t#{line}") }
+    end
+
+    def printing_started?
+      @printed_latest
     end
 
     private

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -207,6 +207,11 @@ module KubernetesDeploy
     end
 
     def predeploy_priority_resources(resource_list)
+      bare_pods = resource_list.select { |resource| resource.is_a?(Pod) }
+      if bare_pods.count == 1
+        bare_pods.first.stream_logs = true
+      end
+
       predeploy_sequence.each do |resource_type|
         matching_resources = resource_list.select { |r| r.type == resource_type }
         next if matching_resources.empty?

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -9,6 +9,8 @@ module KubernetesDeploy
       Preempting
     )
 
+    attr_accessor :stream_logs
+
     def initialize(namespace:, context:, definition:, logger:,
       statsd_tags: nil, parent: nil, deploy_started_at: nil, stream_logs: false)
       @parent = parent

--- a/lib/kubernetes-deploy/remote_logs.rb
+++ b/lib/kubernetes-deploy/remote_logs.rb
@@ -28,7 +28,12 @@ module KubernetesDeploy
     end
 
     def print_latest
-      @container_logs.each { |cl| cl.print_latest(prefix: @container_logs.length > 1) }
+      @container_logs.each do |cl|
+        unless cl.printing_started?
+          @logger.info("Streaming logs from #{@parent_id} container '#{cl.container_name}':")
+        end
+        cl.print_latest(prefix: @container_logs.length > 1)
+      end
     end
 
     def print_all(prevent_duplicate: true)

--- a/test/fixtures/hello-cloud/unmanaged-pod-1.yml.erb
+++ b/test/fixtures/hello-cloud/unmanaged-pod-1.yml.erb
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unmanaged-pod-1-<%= deployment_id %>
+  annotations:
+    kubernetes-deploy.shopify.io/timeout-override: "60s"
+  labels:
+    type: unmanaged-pod
+    name: unmanaged-pod-1-<%= deployment_id %>
+    app: hello-cloud
+spec:
+  activeDeadlineSeconds: 60
+  restartPolicy: Never
+  containers:
+    - name: hello-cloud
+      image: busybox
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "echo 'Hello from the command runner!' && test 1 -eq 1"]
+      env:
+      - name: CONFIG
+        valueFrom:
+          configMapKeyRef:
+            name: hello-cloud-configmap-data
+            key: datapoint2

--- a/test/fixtures/hello-cloud/unmanaged-pod-2.yml.erb
+++ b/test/fixtures/hello-cloud/unmanaged-pod-2.yml.erb
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: unmanaged-pod-<%= deployment_id %>
+  name: unmanaged-pod-2-<%= deployment_id %>
   annotations:
     kubernetes-deploy.shopify.io/timeout-override: "60s"
   labels:
     type: unmanaged-pod
-    name: unmanaged-pod-<%= deployment_id %>
+    name: unmanaged-pod-2-<%= deployment_id %>
     app: hello-cloud
 spec:
   activeDeadlineSeconds: 60
@@ -15,7 +15,7 @@ spec:
     - name: hello-cloud
       image: busybox
       imagePullPolicy: IfNotPresent
-      command: ["sh", "-c", "echo 'Hello from the command runner!' && test 1 -eq 1"]
+      command: ["sh", "-c", "echo 'Hello from the second command runner!' && test 1 -eq 1"]
       env:
       - name: CONFIG
         valueFrom:

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -24,7 +24,7 @@ module FixtureSetAssertions
       assert_secret_created
     end
 
-    def assert_unmanaged_pod_statuses(status, count = 1)
+    def assert_unmanaged_pod_statuses(status, count = 2)
       pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
       assert_equal(count, pods.size, "Expected to find #{count} unmanaged pod(s), found #{pods.size}")
       assert(pods.all? { |pod| pod.status.phase == status })

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -32,7 +32,7 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     SecureRandom.expects(:hex).with(4).returns('aaaa')
     SecureRandom.expects(:hex).with(6).returns('bbbbbb')
     render = build_render_task(fixture_path('hello-cloud'))
-    assert_render_success(render.run(mock_output_stream, ['configmap-data.yml', 'unmanaged-pod.yml.erb']))
+    assert_render_success(render.run(mock_output_stream, ['configmap-data.yml', 'unmanaged-pod-1.yml.erb']))
 
     stdout_assertion do |output|
       assert_equal output, <<~RENDERED
@@ -51,12 +51,12 @@ class RenderTaskTest < KubernetesDeploy::TestCase
         apiVersion: v1
         kind: Pod
         metadata:
-          name: unmanaged-pod-kbbbbbb-aaaa
+          name: unmanaged-pod-1-kbbbbbb-aaaa
           annotations:
             kubernetes-deploy.shopify.io/timeout-override: 60s
           labels:
             type: unmanaged-pod
-            name: unmanaged-pod-kbbbbbb-aaaa
+            name: unmanaged-pod-1-kbbbbbb-aaaa
             app: hello-cloud
         spec:
           activeDeadlineSeconds: 60


### PR DESCRIPTION
Closes #346 

I have not attempted any sort of implementation for the case where multiple tasks exist in a deployment, but even with the simple case of a single task, I'm unsure how this would be tested. I'd appreciate it if someone would point me in the right direction.

The best idea I've had so far is to use a fixture where the pod prints some output over several seconds, and assert that the logs reflect this in the timestamps at the beginning of each line. Indeed, if I do this and run the test with `PRINT_LOGS=1`, I can see that it works. Anyone have a better idea?