### PR TITLE
Retry HPA test only

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,11 +1,5 @@
-shared: &shared
-  retry:
-     automatic:
-       - exit_status: "*"
-         limit: 1
 steps:
   - name: 'Run Test Suite (:kubernetes: 1.13-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -13,7 +7,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.13-latest
   - name: 'Run Test Suite (:kubernetes: 1.12-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -21,7 +14,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.12-latest
   - name: 'Run Test Suite (:kubernetes: 1.11-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -29,7 +21,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.11-latest
   - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: minikube-ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,5 @@
-shared: &shared
-  retry:
-     automatic:
-       - exit_status: "*"
-         limit: 1
 steps:
   - name: 'Run Test Suite (:kubernetes: 1.13-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -13,7 +7,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.13-latest
   - name: 'Run Test Suite (:kubernetes: 1.12-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -21,7 +14,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.12-latest
   - name: 'Run Test Suite (:kubernetes: 1.11-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -29,7 +21,6 @@ steps:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.11-latest
   - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
-    <<: *shared
     command: bin/ci
     agents:
       queue: minikube-ci

--- a/test/fixtures/hpa/hpa.yml
+++ b/test/fixtures/hpa/hpa.yml
@@ -2,6 +2,8 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: hello-hpa
+  annotations:
+    kubernetes-deploy.shopify.io/timeout-override: 130s
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/test/helpers/add_retries_test_helper.rb
+++ b/test/helpers/add_retries_test_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Usage: Extend a descendant of Minitest::Test with this module
+# and then add "__Nretries" to the end of the names of the tests you want to retry up to N times if they fail
+module AddRetriesTestHelper
+  def run_one_method(klass, method_name, reporter)
+    match_data = method_name.match(/__(?<retries>\d+)retries$/)
+    return super unless match_data && match_data[:retries]
+    retries = match_data[:retries].to_i
+
+    (retries + 1).times do |i|
+      print(" Retry#{i}/#{retries}:") if i > 0 && !ENV["VERBOSE"]
+      result = Minitest.run_one_method(self, method_name)
+      reporter.record(result)
+      print(" (Retry #{i}/#{retries})") if i > 0 && ENV["VERBOSE"]
+      break if result.passed?
+    end
+  end
+end

--- a/test/helpers/add_retries_test_helper.rb
+++ b/test/helpers/add_retries_test_helper.rb
@@ -3,17 +3,31 @@
 # Usage: Extend a descendant of Minitest::Test with this module
 # and then add "__Nretries" to the end of the names of the tests you want to retry up to N times if they fail
 module AddRetriesTestHelper
+  # ENV["VERBOSE"] example:
+  #  KubernetesDeployTest#test_hpa_can_be_successful_and_gets_pruned__2retries 0.58 = F
+  #  KubernetesDeployTest#test_hpa_can_be_successful_and_gets_pruned__2retries (Retry 1/2) 0.53 = F
+  #  KubernetesDeployTest#test_hpa_can_be_successful_and_gets_pruned__2retries (Retry 2/2) 0.52 = F
+
+  # !ENV["VERBOSE"] example:
+  #   F Retry1/2:F Retry2/2:F
   def run_one_method(klass, method_name, reporter)
     match_data = method_name.match(/__(?<retries>\d+)retries$/)
     return super unless match_data && match_data[:retries]
     retries = match_data[:retries].to_i
+    result = nil
 
-    (retries + 1).times do |i|
-      print(" Retry#{i}/#{retries}:") if i > 0 && !ENV["VERBOSE"]
-      result = Minitest.run_one_method(self, method_name)
-      reporter.record(result)
-      print(" (Retry #{i}/#{retries})") if i > 0 && ENV["VERBOSE"]
-      break if result.passed?
+    (retries + 1).times do |retry_num|
+      result = Minitest.run_one_method(self, method_name) # The verbose reporter prints the test name here
+
+      if retry_num > 0
+        ENV["VERBOSE"] ? print("(Retry #{retry_num}/#{retries}) ") : print(" Retry#{retry_num}/#{retries}:")
+      end
+
+      break if result.passed? || retry_num == retries # the reporter will record the stuff below
+
+      ENV["VERBOSE"] ? print("#{result.time.round(2)} = \033[0;31mF\033[0m") : print("\033[0;31mF\033[0m")
     end
+
+    reporter.record(result)
   end
 end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -2,6 +2,8 @@
 require 'integration_test_helper'
 
 class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
+  extend AddRetriesTestHelper
+
   def test_full_hello_cloud_set_deploy_succeeds
     assert_deploy_success(deploy_fixtures("hello-cloud"))
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
@@ -1056,17 +1058,15 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     ], in_order: true)
   end
 
-  def test_hpa_can_be_successful
+  def test_hpa_can_be_successful_and_gets_pruned__2retries
     assert_deploy_success(deploy_fixtures("hpa"))
     assert_logs_match_all([
       "Deploying resources:",
-      "HorizontalPodAutoscaler/hello-hpa (timeout: 180s)",
+      "HorizontalPodAutoscaler/hello-hpa (timeout: 130s)",
       %r{HorizontalPodAutoscaler/hello-hpa\s+Configured},
     ])
-  end
 
-  def test_hpa_can_be_pruned
-    assert_deploy_success(deploy_fixtures("hpa"))
+    reset_logger
     assert_deploy_success(deploy_fixtures("hpa", subset: ["deployment.yml"]))
     assert_logs_match_all([
       /The following resources were pruned: #{prune_matcher("horizontalpodautoscaler", "autoscaling", "hello-hpa")}/,


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix https://github.com/Shopify/kubernetes-deploy/issues/420 without deleting the tests after all.

Here's how long the two tests in question took to pass on 50 recent successful runs (values are seconds, tics are occurrences of that length):

```
62: -
63: -
64: -
78: -
79: -
80: --
92: ------
93: -
95: ---
96: -
97: -
107: -
108: -
109: -
110: -
122: ----
123: -
124: ---
125: ----
126: -
127: -
137: --
140: --
152: --
153: -
154: -
155: -
169: -
182: -
184: -
185: -
```

The mode is 92. The mean is 117. 130s covers ~75% of runs.


**How is this accomplished?**

* Add a module you can extend a minitest class with to add retries based on the test name. Kinda sketchy? Yes. If you're aware of a better way, LMK.
* Merge the two HPA tests into one, shorten its timeout to 130s, and let it retry twice. 
* Disable the retry-all logic at the buildkite level. No other tests are flakey (or if they are, we're not finding out because we're hiding it!), and this is making us waste tons of time and compute when someone pushes a legitimate failure.


**What could go wrong?**

This could still not be enough, in which case we can try to tweak this or give up and convert to unit tests like we planned to. I'll retry on Buildkite several times before merging to test the validity of this solution.