### PR TITLE
Fix forward method signature

### DIFF
--- a/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
@@ -7,7 +7,7 @@ class HorizontalPodAutoscalerTest < KubernetesDeploy::TestCase
   # We can't get integration coverage for HPA right now because the metrics server just isn't reliable enough on our CI
   def test_hpa_is_whitelisted_for_pruning
     KubernetesDeploy::Kubectl.any_instance.expects("run")
-      .with("get", "CustomResourceDefinition", "-a", "--output=json", attempts: 5)
+      .with("get", "CustomResourceDefinition", "-a", output: "json", attempts: 5)
       .returns(['{ "items": [] }', "", SystemExit.new(0)])
     task = KubernetesDeploy::DeployTask.new(namespace: 'test', context: KubeclientHelper::TEST_CONTEXT,
       current_sha: 'foo', template_dir: '', logger: logger)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix regression in test suite introduced by #447, in which we changed the signature of `Kubectl#run` to accept a keyword arg `output`, instead of passing that in as a string.

**How is this accomplished?**
Fix the missed change

**What could go wrong?**
Not much, this was just from a change merged after the last rebase of #447 

**Observed error**
```

Failure:
--
  | HorizontalPodAutoscalerTest#test_hpa_is_whitelisted_for_pruning [/usr/src/app/lib/kubernetes-deploy/cluster_resource_discovery.rb:22]
  | Minitest::Assertion: unexpected invocation: #<AnyInstance:KubernetesDeploy::Kubectl>.run("get", "CustomResourceDefinition", "-a", {:output => "json", :attempts => 5})
  | unsatisfied expectations:
  | - expected exactly once, not yet invoked: #<AnyInstance:KubernetesDeploy::Kubectl>.run("get", "CustomResourceDefinition", "-a", "--output=json", {:attempts => 5})
  | - expected never, invoked once: #<AnyInstance:KubernetesDeploy::Kubectl>.run(any_parameters)
  |  
```