### PR TITLE
Fix compatibility with kubectl 1.14

### DIFF
--- a/lib/kubernetes-deploy/cluster_resource_discovery.rb
+++ b/lib/kubernetes-deploy/cluster_resource_discovery.rb
@@ -19,7 +19,7 @@ module KubernetesDeploy
     private
 
     def fetch_crds
-      raw_json, _, st = kubectl.run("get", "CustomResourceDefinition", "-a", output: "json", attempts: 5)
+      raw_json, _, st = kubectl.run("get", "CustomResourceDefinition", output: "json", attempts: 5)
       if st.success?
         JSON.parse(raw_json)["items"]
       else

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -32,7 +32,7 @@ class KubectlTest < KubernetesDeploy::TestCase
       resp: "{ items: [] }"
     )
 
-    out, err, st = build_kubectl.run("get", "pods", "-a", "--output=json")
+    out, err, st = build_kubectl.run("get", "pods", "--output=json")
     assert(st.success?)
     assert_equal("{ items: [] }", out)
     assert_equal("", err)
@@ -43,7 +43,7 @@ class KubectlTest < KubernetesDeploy::TestCase
       %W(kubectl get pods -a --output=json --kubeconfig=#{kubeconfig_in_use}) +
       %W(--namespace=testn --request-timeout=#{timeout}),
       resp: "{ items: [] }")
-    build_kubectl.run("get", "pods", "-a", "--output=json", use_context: false)
+    build_kubectl.run("get", "pods", "--output=json", use_context: false)
   end
 
   def test_run_omits_namespace_flag_if_use_namespace_is_false
@@ -51,7 +51,7 @@ class KubectlTest < KubernetesDeploy::TestCase
       %W(kubectl get pods -a --output=json --kubeconfig=#{kubeconfig_in_use}) +
       %W(--context=testc --request-timeout=#{timeout}),
       resp: "{ items: [] }")
-    build_kubectl.run("get", "pods", "-a", "--output=json", use_namespace: false)
+    build_kubectl.run("get", "pods", "--output=json", use_namespace: false)
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_unspecified

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -27,7 +27,7 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_run_constructs_the_expected_command_and_returns_the_correct_values
     stub_open3(
-      %W(kubectl get pods -a --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
       resp: "{ items: [] }"
     )
@@ -40,7 +40,7 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_run_omits_context_flag_if_use_context_is_false
     stub_open3(
-      %W(kubectl get pods -a --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
       %W(--namespace=testn --request-timeout=#{timeout}),
       resp: "{ items: [] }")
     build_kubectl.run("get", "pods", "--output=json", use_context: false)
@@ -48,7 +48,7 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_run_omits_namespace_flag_if_use_namespace_is_false
     stub_open3(
-      %W(kubectl get pods -a --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
       %W(--context=testc --request-timeout=#{timeout}),
       resp: "{ items: [] }")
     build_kubectl.run("get", "pods", "--output=json", use_namespace: false)

--- a/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
@@ -7,7 +7,7 @@ class HorizontalPodAutoscalerTest < KubernetesDeploy::TestCase
   # We can't get integration coverage for HPA right now because the metrics server just isn't reliable enough on our CI
   def test_hpa_is_whitelisted_for_pruning
     KubernetesDeploy::Kubectl.any_instance.expects("run")
-      .with("get", "CustomResourceDefinition", "-a", output: "json", attempts: 5)
+      .with("get", "CustomResourceDefinition", output: "json", attempts: 5)
       .returns(['{ "items": [] }', "", SystemExit.new(0)])
     task = KubernetesDeploy::DeployTask.new(namespace: 'test', context: KubeclientHelper::TEST_CONTEXT,
       current_sha: 'foo', template_dir: '', logger: logger)


### PR DESCRIPTION
Remove use of deprecated -a option. The —show-all option was deprecated in Kubernetes 1.10, and removed in 1.14.

The -a option was deprecated in kubectl 1.10. As 1.9 and older are not supported, this should not cause any issues.

https://github.com/kubernetes/kubernetes/pull/69255