### PR TITLE
[Bug fix] Support multiple files in kubeconfig env var

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -518,10 +518,7 @@ module KubernetesDeploy
     end
 
     def confirm_context_exists
-      found = kubectl.find_config_for_context(@context, raise_on_missing: false)
-      unless found
-        raise FatalDeploymentError, "Context #{@context} is not available."
-      end
+      kubectl.config_for_context(@context) # Raises if context not found
       confirm_cluster_reachable
       @logger.info("Context #{@context} found")
     end

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -518,13 +518,9 @@ module KubernetesDeploy
     end
 
     def confirm_context_exists
-      out, err, st = kubectl.run("config", "get-contexts", "-o", "name",
-        use_namespace: false, use_context: false, log_failure: false)
-      available_contexts = out.split("\n")
-      if !st.success?
-        raise FatalDeploymentError, err
-      elsif !available_contexts.include?(@context)
-        raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
+      found = kubectl.find_config_for_context(@context, raise_on_missing: false)
+      unless found
+        raise FatalDeploymentError, "Context #{@context} is not available."
       end
       confirm_cluster_reachable
       @logger.info("Context #{@context} found")

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -119,14 +119,18 @@ module KubernetesDeploy
       errors
     end
 
+    def find_config_for_context(context, raise_on_missing: true)
+      # Find a context defined in kube conf files that matches the input context by name
+      configs = config_files.map { |f| [f, KubeConfig.read(f)] }
+      config = configs.find { |_, c| c.contexts.include?(context) }
+      raise ContextMissingError.new(context, kubeconfig) if raise_on_missing && config.nil?
+      config
+    end
+
     private
 
     def build_kubeclient(api_version:, context:, endpoint_path: nil)
-      # Find a context defined in kube conf files that matches the input context by name
-      configs = config_files.map { |f| KubeConfig.read(f) }
-      config = configs.find { |c| c.contexts.include?(context) }
-
-      raise ContextMissingError.new(context, kubeconfig) unless config
+      config = find_config_for_context(context)&.last
 
       kube_context = config.context(context)
       client = Kubeclient::Client.new(

--- a/lib/kubernetes-deploy/kubeclient_builder.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder.rb
@@ -119,18 +119,18 @@ module KubernetesDeploy
       errors
     end
 
-    def find_config_for_context(context, raise_on_missing: true)
+    def config_for_context(context)
       # Find a context defined in kube conf files that matches the input context by name
-      configs = config_files.map { |f| [f, KubeConfig.read(f)] }
-      config = configs.find { |_, c| c.contexts.include?(context) }
-      raise ContextMissingError.new(context, kubeconfig) if raise_on_missing && config.nil?
+      configs = config_files.map { |f| KubeConfig.read(f) }
+      config = configs.find { |c| c.contexts.include?(context) }
+      raise ContextMissingError.new(context, kubeconfig) unless config
       config
     end
 
     private
 
     def build_kubeclient(api_version:, context:, endpoint_path: nil)
-      config = find_config_for_context(context)&.last
+      config = config_for_context(context)
 
       kube_context = config.context(context)
       client = Kubeclient::Client.new(

--- a/lib/kubernetes-deploy/kubeclient_builder/kube_config.rb
+++ b/lib/kubernetes-deploy/kubeclient_builder/kube_config.rb
@@ -4,9 +4,12 @@ require 'googleauth'
 module KubernetesDeploy
   class KubeclientBuilder
     class KubeConfig < Kubeclient::Config
+      attr_accessor :filename
       def self.read(filename)
         parsed = YAML.safe_load(File.read(filename), [Date, Time])
-        new(parsed, File.dirname(filename))
+        config = new(parsed, File.dirname(filename))
+        config.filename = filename
+        config
       end
 
       def fetch_user_auth_options(user)

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -26,7 +26,7 @@ module KubernetesDeploy
       output_is_sensitive = @output_is_sensitive_default if output_is_sensitive.nil?
 
       args = args.unshift("kubectl")
-      args.push("--kubeconfig=#{find_config_for_context(@context)}")
+      args.push("--kubeconfig=#{config_for_context(@context)}")
       args.push("--namespace=#{@namespace}") if use_namespace
       args.push("--context=#{@context}")
       args.push("--output=#{output}") if output
@@ -78,11 +78,11 @@ module KubernetesDeploy
       version_info[:server]
     end
 
-    def find_config_for_context(context, raise_on_missing: true)
+    def config_for_context(context)
       @kubeclient ||= KubeclientBuilder.new
       @context_config_map ||= {}
       @context_config_map[context] ||=
-        @kubeclient.find_config_for_context(context, raise_on_missing: raise_on_missing)&.first
+        @kubeclient.config_for_context(context).filename
     end
 
     private

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -9,7 +9,6 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, logger:, log_failure_by_default:, default_timeout: DEFAULT_TIMEOUT,
       output_is_sensitive_default: false)
-      @kubeconfig = KubeclientBuilder.kubeconfig
       @namespace = namespace
       @context = context
       @logger = logger
@@ -21,15 +20,15 @@ module KubernetesDeploy
       raise ArgumentError, "context is required" if context.blank?
     end
 
-    def run(*args, log_failure: nil, use_context: true, use_namespace: true, output: nil,
+    def run(*args, log_failure: nil, use_namespace: true, output: nil,
       raise_if_not_found: false, attempts: 1, output_is_sensitive: nil)
       log_failure = @log_failure_by_default if log_failure.nil?
       output_is_sensitive = @output_is_sensitive_default if output_is_sensitive.nil?
 
       args = args.unshift("kubectl")
-      args.push("--kubeconfig=#{@kubeconfig}")
+      args.push("--kubeconfig=#{find_config_for_context(@context)}")
       args.push("--namespace=#{@namespace}") if use_namespace
-      args.push("--context=#{@context}")     if use_context
+      args.push("--context=#{@context}")
       args.push("--output=#{output}") if output
       args.push("--request-timeout=#{@default_timeout}") if @default_timeout
       out, err, st = nil
@@ -77,6 +76,11 @@ module KubernetesDeploy
 
     def server_version
       version_info[:server]
+    end
+
+    def find_config_for_context(context, raise_on_missing: true)
+      @kubeclient ||= KubeclientBuilder.new
+      @kubeclient.find_config_for_context(context, raise_on_missing: raise_on_missing)&.first
     end
 
     private

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -80,7 +80,9 @@ module KubernetesDeploy
 
     def find_config_for_context(context, raise_on_missing: true)
       @kubeclient ||= KubeclientBuilder.new
-      @kubeclient.find_config_for_context(context, raise_on_missing: raise_on_missing)&.first
+      @context_config_map ||= {}
+      @context_config_map[context] ||=
+        @kubeclient.find_config_for_context(context, raise_on_missing: raise_on_missing)&.first
     end
 
     private

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -22,7 +22,7 @@ class KubectlTest < KubernetesDeploy::TestCase
   end
 
   def kubeconfig_in_use
-    KubernetesDeploy::KubeclientBuilder.kubeconfig
+    '' # KubernetesDeploy::KubeclientBuilder.kubeconfig
   end
 
   def test_run_constructs_the_expected_command_and_returns_the_correct_values
@@ -36,14 +36,6 @@ class KubectlTest < KubernetesDeploy::TestCase
     assert(st.success?)
     assert_equal("{ items: [] }", out)
     assert_equal("", err)
-  end
-
-  def test_run_omits_context_flag_if_use_context_is_false
-    stub_open3(
-      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
-      %W(--namespace=testn --request-timeout=#{timeout}),
-      resp: "{ items: [] }")
-    build_kubectl.run("get", "pods", "--output=json", use_context: false)
   end
 
   def test_run_omits_namespace_flag_if_use_namespace_is_false

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -114,7 +114,7 @@ class KubectlTest < KubernetesDeploy::TestCase
   def test_custom_timeout_is_used
     custom_kubectl = KubernetesDeploy::Kubectl.new(namespace: 'testn', context: 'testc', logger: logger,
       log_failure_by_default: true, default_timeout: '5s')
-    custom_kubectl.expects(:find_config_for_context).with('testc').returns(kubeconfig_in_use)
+    custom_kubectl.expects(:config_for_context).with('testc').returns(kubeconfig_in_use)
     stub_open3(
       %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use} --namespace=testn --context=testc --request-timeout=5s),
       resp: "", err: "oops", success: false)
@@ -199,6 +199,14 @@ class KubectlTest < KubernetesDeploy::TestCase
     refute_logs_match("Kubectl out")
   end
 
+  def test_context_not_found
+    custom_kubectl = KubernetesDeploy::Kubectl.new(namespace: 'testc', context: 'fake', logger: logger,
+      log_failure_by_default: true)
+    assert_raises KubernetesDeploy::KubeclientBuilder::ContextMissingError do
+      custom_kubectl.run("get", "pods", log_failure: true)
+    end
+  end
+
   private
 
   def kubeconfig_in_use
@@ -229,7 +237,7 @@ class KubectlTest < KubernetesDeploy::TestCase
     context = 'testc'
     kubectl = KubernetesDeploy::Kubectl.new(namespace: 'testn', context: context, logger: logger,
       log_failure_by_default: log_failure_by_default)
-    kubectl.expects(:find_config_for_context).with(context).returns(kubeconfig_in_use)
+    kubectl.expects(:config_for_context).with(context).returns(kubeconfig_in_use)
     kubectl
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Right now having have multiple file via the `:` syntax in your kubeconfig env var doesn't work. It should.

fix: https://github.com/Shopify/kubernetes-deploy/issues/463

**How is this accomplished?**
Some refactoring to find the right file to pass to kubectl, apparently using the `--kubeconfig` flag only supports one file. 

**What could go wrong?**
Totally break using kubeconfig env var, but seems unlikely
