### PR TITLE
Add driver installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,9 @@ If you work for Shopify, just run `dev up`, but otherwise:
 
 1. [Install kubectl version 1.10.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) and make sure it is in your path
 2. [Install minikube](https://kubernetes.io/docs/getting-started-guides/minikube/#installation) (required to run the test suite)
-3. Check out the repo
-4. Run `bin/setup` to install dependencies
+3. [Install any required minikube drivers](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md) (on OS X, you may need the [hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver)
+4. Check out the repo
+5. Run `bin/setup` to install dependencies
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/dev.yml
+++ b/dev.yml
@@ -6,6 +6,10 @@ up:
   - homebrew:
     - Caskroom/cask/minikube
   - custom:
+      name: Install the minikube fork of driver-hyperkit
+      met?: command -v docker-machine-driver-hyperkit
+      meet: curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit && sudo install -o root -g wheel -m 4755 docker-machine-driver-hyperkit /usr/local/bin/ && rm ./docker-machine-driver-hyperkit
+  - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Correctly Configured')
       meet: minikube start --kubernetes-version=v1.11.6 --vm-driver=hyperkit


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Running `dev up` didn't install everything I needed, and this now allows me to clone this repo fresh and get everything running. Additionally, external contributors may want clearer instructions around additional minikube drivers

**How is this accomplished?**
- Adding a step to `dev.yml` checking for the existence of the hyperkit driver. If it doesn't exist, install it.
- Adding a link to the driver installation page

**What could go wrong?**
- I'm not sure what drivers are needed on non OS X systems. I haven't tested this on any other environment.
- The permissions in that command feel kinda heavy
- I'm not sure if there's a better way to download, install and clean up when doing that as a one-liner: if anyone has a better way I'd love to know about it
