### PR TITLE
Do not add doc separator when render result is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug fixes*
+- Fixes a bug introduced in 0.26.2 where kubernetes-render started adding YAML headers to empty render results
+
 ## 0.26.2
 
 *Enhancements*

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -70,7 +70,7 @@ module KubernetesDeploy
       rendered_content = @renderer.render_template(filename, file_content)
       implicit = true
       YAML.parse_stream(rendered_content, "<rendered> #{filename}") { |d| implicit = d.implicit }
-      stream.puts "---\n" if implicit
+      stream.puts "---\n" if implicit && rendered_content.present?
       stream.puts rendered_content
       @logger.info("Rendered #{File.basename(filename)}")
     rescue Psych::SyntaxError => exception

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -65,14 +65,19 @@ module KubernetesDeploy
     end
 
     def render_filename(filename, stream)
-      @logger.info("Rendering #{File.basename(filename)} ...")
+      file_basename = File.basename(filename)
+      @logger.info("Rendering #{file_basename}...")
       file_content = File.read(File.join(@template_dir, filename))
       rendered_content = @renderer.render_template(filename, file_content)
       implicit = true
       YAML.parse_stream(rendered_content, "<rendered> #{filename}") { |d| implicit = d.implicit }
-      stream.puts "---\n" if implicit && rendered_content.present?
-      stream.puts rendered_content
-      @logger.info("Rendered #{File.basename(filename)}")
+      if rendered_content.present?
+        stream.puts "---\n" if implicit
+        stream.puts rendered_content
+        @logger.info("Rendered #{file_basename}")
+      else
+        @logger.warn("Rendered #{file_basename} successfully, but the result was blank")
+      end
     rescue Psych::SyntaxError => exception
       raise InvalidTemplateError.new("Template is not valid YAML. #{exception.message}", filename: filename)
     end

--- a/test/fixtures/collection-with-erb/effectively_empty.yml.erb
+++ b/test/fixtures/collection-with-erb/effectively_empty.yml.erb
@@ -1,0 +1,9 @@
+<%- if false -%>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: never-created
+data:
+  will_never: exist
+<%- end -%>

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -314,6 +314,7 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     stdout_assertion do |output|
       assert_equal "", output.strip
     end
+    assert_logs_match("Rendered effectively_empty.yml.erb successfully, but the result was blank")
   end
 
   private

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -308,6 +308,14 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     end
   end
 
+  def test_render_does_not_generate_extra_blank_documents_when_file_is_empty
+    renderer = build_render_task(fixture_path('collection-with-erb'))
+    assert_render_success(renderer.run(mock_output_stream, ['effectively_empty.yml.erb']))
+    stdout_assertion do |output|
+      assert_equal "", output.strip
+    end
+  end
+
   private
 
   def build_render_task(template_dir, bindings = {})


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix a regression from https://github.com/Shopify/kubernetes-deploy/pull/454. It is causing the template validator for my Web PR to fail because a file entire content is rendered conditionally. Before that PR, the render result was an empty file, which I think makes sense. Now it instead contains an empty YAML doc. We should not be adding that header.

**How is this accomplished?**
Add a regression test and a presence check on the render result.

**What could go wrong?**
There's a reason I'm not thinking of why having an extra header could be a good thing?

@Shopify/cloudx 
