### PR TITLE
kubectl --kubeconfig cannot merge multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## next
 
+## 0.26.3
+
 *Bug fixes*
-- Fixes a bug introduced in 0.26.2 where kubernetes-render started adding YAML headers to empty render results
+- Fixes a bug introduced in 0.26.0 where listing multiple files in the $KUBECONFIG environment variable would throw an error ([#468](https://github.com/Shopify/kubernetes-deploy/pull/468))
+- Fixes a bug introduced in 0.26.2 where kubernetes-render started adding YAML headers to empty render results ([#467](https://github.com/Shopify/kubernetes-deploy/pull/467))
 
 ## 0.26.2
 
@@ -10,7 +13,7 @@
 through a yaml parser. ([#454](https://github.com/Shopify/kubernetes-deploy/pull/454))
 
 *Bug fixes*
-- Remove use of deprecated feature preventing use with Kuberentes 1.14 ([#460](https://github.com/Shopify/kubernetes-deploy/pull/460))
+- Remove use of deprecated feature preventing use with Kubernetes 1.14 ([#460](https://github.com/Shopify/kubernetes-deploy/pull/460))
 
 ## 0.26.1
 

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -9,7 +9,6 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, logger:, log_failure_by_default:, default_timeout: DEFAULT_TIMEOUT,
       output_is_sensitive_default: false)
-      @kubeconfig = KubeclientBuilder.kubeconfig
       @namespace = namespace
       @context = context
       @logger = logger
@@ -27,7 +26,6 @@ module KubernetesDeploy
       output_is_sensitive = @output_is_sensitive_default if output_is_sensitive.nil?
 
       args = args.unshift("kubectl")
-      args.push("--kubeconfig=#{@kubeconfig}")
       args.push("--namespace=#{@namespace}") if use_namespace
       args.push("--context=#{@context}")     if use_context
       args.push("--output=#{output}") if output

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  VERSION = "0.26.2"
+  VERSION = "0.26.3"
 end

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -14,11 +14,11 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
     assert(builder.validate_config_files, "Kube config not found at #{config_file}")
   end
 
-  def test_bad_file_ignored_when_client_built_without_validating
+  def test_build_runs_config_validation
     config_file = File.join(__dir__, '../../fixtures/kube-config/unknown_config.yml')
     kubeclient_builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: config_file)
 
-    expected_err = /No kubeconfig files found in .*unknown_config.yml/
+    expected_err = /Kube config not found at .*unknown_config.yml/
     assert_raises_message(KubernetesDeploy::TaskConfigurationError, expected_err) do
       kubeclient_builder.build_v1_kubeclient('test-context')
     end

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -9,9 +9,19 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
   end
 
   def test_config_validation_missing_file
-    config_file = File.join(__dir__, '../fixtures/kube-config/unknown_config.yml')
+    config_file = File.join(__dir__, '../../fixtures/kube-config/unknown_config.yml')
     builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: config_file)
     assert(builder.validate_config_files, "Kube config not found at #{config_file}")
+  end
+
+  def test_bad_file_ignored_when_client_built_without_validating
+    config_file = File.join(__dir__, '../../fixtures/kube-config/unknown_config.yml')
+    kubeclient_builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: config_file)
+
+    expected_err = /No kubeconfig files found in .*unknown_config.yml/
+    assert_raises_message(KubernetesDeploy::TaskConfigurationError, expected_err) do
+      kubeclient_builder.build_v1_kubeclient('test-context')
+    end
   end
 
   def test_multiple_configuration_files
@@ -19,22 +29,22 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
     assert(builder.validate_config_files, "Kube config file name(s) not set in $KUBECONFIG")
 
     default_config = "#{Dir.home}/.kube/config"
-    extra_config = File.join(__dir__, '../fixtures/kube-config/dummy_config.yml')
+    extra_config = File.join(__dir__, '../../fixtures/kube-config/dummy_config.yml')
     builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: "#{default_config}:#{extra_config}")
-    assert(builder.validate_config_files, [])
+    assert_empty(builder.validate_config_files)
   end
 
   def test_build_client_from_multiple_config_files
     Kubeclient::Client.any_instance.stubs(:discover)
-    # Set KUBECONFIG to include multiple config files
+    default_config = "#{Dir.home}/.kube/config"
     dummy_config = File.join(__dir__, '../../fixtures/kube-config/dummy_config.yml')
-    kubeconfig = "#{ENV['KUBECONFIG']}:#{dummy_config}"
-    kubeclient_builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: kubeconfig)
+
+    kubeclient_builder = KubernetesDeploy::KubeclientBuilder.new(kubeconfig: "#{default_config}:#{dummy_config}")
     # Build kubeclient for an unknown context fails
     context_name = "unknown_context"
     assert_raises_message(KubernetesDeploy::KubeclientBuilder::ContextMissingError,
       "`#{context_name}` context must be configured in your KUBECONFIG file(s) " \
-      "(#{kubeconfig}).") do
+      "(#{default_config}, #{dummy_config})") do
       kubeclient_builder.build_v1_kubeclient(context_name)
     end
     # Build kubeclient for a context present in the dummy config succeeds

--- a/test/unit/kubernetes-deploy/kubectl_test.rb
+++ b/test/unit/kubernetes-deploy/kubectl_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 
 class KubectlTest < KubernetesDeploy::TestCase
   include StatsDHelper
+  include EnvTestHelper
+
   def setup
     super
     KubernetesDeploy::Kubectl.any_instance.unstub(:run)
@@ -21,13 +23,9 @@ class KubectlTest < KubernetesDeploy::TestCase
     end
   end
 
-  def kubeconfig_in_use
-    KubernetesDeploy::KubeclientBuilder.kubeconfig
-  end
-
   def test_run_constructs_the_expected_command_and_returns_the_correct_values
     stub_open3(
-      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods --output=json) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
       resp: "{ items: [] }"
     )
@@ -40,76 +38,84 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_run_omits_context_flag_if_use_context_is_false
     stub_open3(
-      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods --output=json) +
       %W(--namespace=testn --request-timeout=#{timeout}),
-      resp: "{ items: [] }")
+      resp: "{ items: [] }"
+    )
     build_kubectl.run("get", "pods", "--output=json", use_context: false)
   end
 
   def test_run_omits_namespace_flag_if_use_namespace_is_false
     stub_open3(
-      %W(kubectl get pods --output=json --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods --output=json) +
       %W(--context=testc --request-timeout=#{timeout}),
-      resp: "{ items: [] }")
+      resp: "{ items: [] }"
+    )
     build_kubectl.run("get", "pods", "--output=json", use_namespace: false)
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_unspecified
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: true).run("get", "pods")
     assert_logs_match("[WARN]", 2)
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_true_and_override_is_also_true
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: true)
     assert_logs_match("[WARN]", 2)
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_true_and_override_is_false
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: true).run("get", "pods", log_failure: false)
     refute_logs_match("[WARN]")
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_unspecified
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: false).run("get", "pods")
     refute_logs_match("[WARN]")
   end
 
   def test_run_does_not_log_failures_when_log_failure_by_default_is_false_and_override_is_also_false
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: false)
     refute_logs_match("[WARN]")
   end
 
   def test_run_logs_failures_when_log_failure_by_default_is_false_and_override_is_true
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: true)
     assert_logs_match("[WARN]", 2)
   end
 
   def test_run_with_multiple_attempts_retries_and_emits_failure_metrics
-    command = %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+    command = %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout})
     Open3.expects(:capture3).with(*command).times(5).returns(["", "oops", stub(success?: false)])
     kubectl = build_kubectl
@@ -127,8 +133,9 @@ class KubectlTest < KubernetesDeploy::TestCase
     custom_kubectl = KubernetesDeploy::Kubectl.new(namespace: 'testn', context: 'testc', logger: logger,
     log_failure_by_default: true, default_timeout: '5s')
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use} --namespace=testn --context=testc --request-timeout=5s),
-      resp: "", err: "oops", success: false)
+      %w(kubectl get pods --namespace=testn --context=testc --request-timeout=5s),
+      resp: "", err: "oops", success: false
+    )
     custom_kubectl.run("get", "pods", log_failure: true)
     assert_logs_match("[WARN]", 2)
   end
@@ -172,7 +179,7 @@ class KubectlTest < KubernetesDeploy::TestCase
 
   def test_version_info_raises_if_command_fails
     stub_open3(
-      %W(kubectl version --kubeconfig=#{kubeconfig_in_use} --context=testc --request-timeout=#{timeout}),
+      %W(kubectl version --context=testc --request-timeout=#{timeout}),
       resp: '', err: 'bad', success: false
     )
     assert_raises_message(KubernetesDeploy::KubectlError, "Could not retrieve kubectl version info") do
@@ -183,9 +190,10 @@ class KubectlTest < KubernetesDeploy::TestCase
   def test_run_with_raise_if_not_found_raises_the_correct_thing
     err = 'Error from server (NotFound): pods "foobar" not found'
     stub_open3(
-      %W(kubectl get pod foobar --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pod foobar) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: err, success: false)
+      resp: "", err: err, success: false
+    )
     assert_raises_message(KubernetesDeploy::Kubectl::ResourceNotFoundError, err) do
       build_kubectl.run("get", "pod", "foobar", raise_if_not_found: true)
     end
@@ -194,17 +202,19 @@ class KubectlTest < KubernetesDeploy::TestCase
   def test_run_with_raise_if_not_found_does_not_raise_on_other_errors
     err = 'Error from server (TooManyRequests): Please try again later'
     stub_open3(
-      %W(kubectl get pod foobar --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pod foobar) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: err, success: false)
+      resp: "", err: err, success: false
+    )
     build_kubectl.run("get", "pod", "foobar", raise_if_not_found: true)
   end
 
   def test_run_output_is_sensitive_squashes_debug_logs
     stub_open3(
-      %W(kubectl get pods --kubeconfig=#{kubeconfig_in_use}) +
+      %w(kubectl get pods) +
       %W(--namespace=testn --context=testc --request-timeout=#{timeout}),
-      resp: "", err: "oops", success: false)
+      resp: "", err: "oops", success: false
+    )
     logger.level = 0
     build_kubectl(log_failure_by_default: false).run("get", "pods", log_failure: false, output_is_sensitive: true)
     refute_logs_match("Kubectl out")
@@ -217,7 +227,7 @@ class KubectlTest < KubernetesDeploy::TestCase
   end
 
   def stub_version_request(client:, server:)
-    stub_open3(%W(kubectl version --kubeconfig=#{kubeconfig_in_use} --context=testc --request-timeout=#{timeout}), resp:
+    stub_open3(%W(kubectl version --context=testc --request-timeout=#{timeout}), resp:
       <<~STRING
         Client Version: #{client}
         Server Version: #{server}


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Revert only the problematic part of https://github.com/Shopify/kubernetes-deploy/pull/428, i.e. https://github.com/Shopify/kubernetes-deploy/pull/428/files#diff-f5478b2ac59d4babc30470442f3a8656. I still like the Class refactor, but `--kubeconfig` cannot merge multiple files, so if we want to use it we'll need to be more clever about what we pass through. Ironically the test we removed would have caught this regression. I'm sorry I did not catch that. I added it back verbatim (after confirming it does reproduce the bug on master).

Fixes https://github.com/Shopify/kubernetes-deploy/issues/463

**How is this accomplished?**
Making the `kubectl` class go back to depending on the env var. ~~As a bonus, make it proactively validate this dependency.~~ after CI showed this broke default location support, I removed it to keep this PR the smallest viable fix.

I think there is a nicer way to deal with this, but I wasn't able to put together a proposal as quickly as I wanted to. I think we should merge something really simple like this so we have time to discuss the right refactor to do. 

**What could go wrong?**

If somebody consuming this project as a gem switched away from the environment variable, they'll need to switch back (it is still effectively mandatory for CLI usage).

@Shopify/cloudx 