### PR TITLE
Update release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,14 +144,11 @@ To see the full-color output of a specific integration test, you can use `PRINT_
 
 ## Releasing a new version (Shopify employees)
 
-1. Make sure all merged PRs are reflected in the changelog before creating the commit for the new version.
-2. Update the version number in `version.rb` and commit that change with message "Version x.y.z". Don't push yet or you'll confuse Shipit.
-3. Tag the version with `git tag vx.y.z -a -m "Version x.y.z"`
-4. Push both your bump commit and its tag simultaneously with `git push origin master --follow-tags` (note that you can set `git config --global push.followTags true` to turn this flag on by default)
-5. Use the [Shipit Stack](https://shipit.shopify.io/shopify/kubernetes-deploy/rubygems) to build the `.gem` file and upload to [rubygems.org](https://rubygems.org/gems/kubernetes-deploy).
-
-If you push your commit and the tag separately, Shipit usually fails with `You need to create the v0.7.9 tag first.`. To make it find your tag, go to `Settings` > `Resynchronize this stack` > `Clear git cache`.
-
+1. On a new branch, create a new heading in CHANGELOG.md for your version and move the entries from "Next" under it. Leave the "Next" heading in the file (this helps with the diff for rebases after the release).
+1. Make sure CHANGELOG.md includes all user-facing changes since the last release. Things like test changes or refactors do not need to be included.
+1. Update the version number in `version.rb`.
+1. Commit your changes with message "Version x.y.z" and open a PR.
+1. When your PR merges, use the [Shipit Stack](https://shipit.shopify.io/shopify/kubernetes-deploy/rubygems) to build the `.gem` file and upload to [rubygems.org](https://rubygems.org/gems/kubernetes-deploy).
 
 ## CI (External contributors)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ To see the full-color output of a specific integration test, you can use `PRINT_
 1. Make sure CHANGELOG.md includes all user-facing changes since the last release. Things like test changes or refactors do not need to be included.
 1. Update the version number in `version.rb`.
 1. Commit your changes with message "Version x.y.z" and open a PR.
-1. When your PR merges, use the [Shipit Stack](https://shipit.shopify.io/shopify/kubernetes-deploy/rubygems) to build the `.gem` file and upload to [rubygems.org](https://rubygems.org/gems/kubernetes-deploy).
+1. After merging your PR, deploy via [Shipit](https://shipit.shopify.io/shopify/kubernetes-deploy/rubygems). Shipit will automatically tag the release and upload the gem to [rubygems.org](https://rubygems.org/gems/kubernetes-deploy).
 
 ## CI (External contributors)
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Update the release instructions. It turns out manual tagging has not been required since https://github.com/Shopify/shipit-engine/pull/801.

**How is this accomplished?**
Changing the markdown file.

**What could go wrong?**
The new instructions are confusing or misleading and a release goes out in a non-standard way.

@dturn 
