### PR TITLE
Relax oj dependency

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", '~> 2.3', '>= 2.3.2')
-  spec.add_dependency("oj", "~> 3.7")
+  spec.add_dependency("oj", "~> 3.0")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
   spec.add_dependency("jsonpath", "~> 0.9.6")
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Relax our dependency on the oj gem. The repo history doesn't show a particular reason for needing `3.7`, so let's just pin to the major version. This came to my attention because Shopify Core depends on `oj 3.6`.

**How is this accomplished?**
Change the gemspec.

**What could go wrong?**
Something between 3.0 and 3.7 turns out to be important, and we get a bug report that our dependency is incorrectly specified. I did read through https://github.com/ohler55/oj/blob/master/CHANGELOG.md and nothing jumped out at me given our super basic usage of this gem.

@Shopify/cloudx 
