### PR TITLE
Additional safeguards against printing Secret content

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Refer to `kubernetes-deploy --help` for the authoritative set of options.
 resource to deploy.
 - `--selector`: Instructs kubernetes-deploy to only prune resources which match the specified label selector, such as `environment=staging`. If you use this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
 
+> **NOTICE**: Deploy Secret resources at your own risk. Although we will fix any reported leak vectors with urgency, we cannot guarantee that sensitive information will never be logged.
+
 ### Sharing a namespace
 
 By default, kubernetes-deploy will prune any resources in the target namespace which have the `kubectl.kubernetes.io/last-applied-configuration` annotation and are not a result of the current deployment process, on the assumption that there is a one-to-one relationship between application deployment and namespace, and that a deployment provisions all relevant resources in the namespace.

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -62,7 +62,11 @@ module KubernetesDeploy
 
         secrets.map do |secret_name, secret_spec|
           validate_secret_spec(secret_name, secret_spec)
-          generate_secret_resource(secret_name, secret_spec["_type"], secret_spec["data"])
+          resource = generate_secret_resource(secret_name, secret_spec["_type"], secret_spec["data"])
+          unless resource.validate_definition(@kubectl)
+            raise EjsonSecretError, "Resulting resource Secret/#{secret_name} failed validation"
+          end
+          resource
         end
       end
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/secret.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/secret.rb
@@ -2,7 +2,7 @@
 module KubernetesDeploy
   class Secret < KubernetesResource
     TIMEOUT = 30.seconds
-    KUBECTL_OUTPUT_IS_SENSITIVE = true
+    SENSITIVE_TEMPLATE_CONTENT = true
 
     def status
       exists? ? "Available" : "Not Found"

--- a/lib/kubernetes-deploy/resource_cache.rb
+++ b/lib/kubernetes-deploy/resource_cache.rb
@@ -51,7 +51,7 @@ module KubernetesDeploy
 
     def fetch_by_kind(kind)
       resource_class = KubernetesResource.class_for_kind(kind)
-      output_is_sensitive = resource_class.nil? ? false : resource_class::KUBECTL_OUTPUT_IS_SENSITIVE
+      output_is_sensitive = resource_class.nil? ? false : resource_class::SENSITIVE_TEMPLATE_CONTENT
       raw_json, _, st = @kubectl.run("get", kind, "--chunk-size=0", attempts: 5, output: "json",
          output_is_sensitive: output_is_sensitive)
       raise KubectlError unless st.success?

--- a/test/fixtures/invalid-resources/bad_binding_secret.yml.erb
+++ b/test/fixtures/invalid-resources/bad_binding_secret.yml.erb
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hello-secret
+type: Opaque
+data:
+  username: <%= some_value_i_forgot %>
+  password: cGFzc3dvcmQ=

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -364,7 +364,7 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
   # to recreate such a condition
   def test_apply_failure_with_sensitive_resources_hides_template_content
     logger.level = 0
-    KubernetesDeploy::Deployment.any_instance.expects(:kubectl_output_is_sensitive?).returns(true).at_least_once
+    KubernetesDeploy::Deployment.any_instance.expects(:sensitive_template_content?).returns(true).at_least_once
     result = deploy_fixtures("hello-cloud", subset: ["web.yml.erb"]) do |fixtures|
       bad_port_name = "http_test_is_really_long_and_invalid_chars"
       svc = fixtures["web.yml.erb"]["Service"].first

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -39,7 +39,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
   end
 
   class DummySensitiveResource < DummyResource
-    KUBECTL_OUTPUT_IS_SENSITIVE = true
+    SENSITIVE_TEMPLATE_CONTENT = true
   end
 
   def test_unusual_timeout_output


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Further reduce the likelihood that we'll accidentally print the content of sensitive resources (i.e. Secrets) when something goes wrong. Now that we officially support the Secret resource and push our EJSON secrets through that code path, this is super important.

**How is this accomplished?**
These are the ways I thought of that secrets could get logged:
- They come from a regular template, and rendering it fails
- They are missing critical data, and we raise during resource instance instantiation
- They fail validation (i.e. dry run)
- The apply they are part of fails, whether because of them or not

I added tests for the three additional cases (test_apply_failure_with_sensitive_resources_hides_raw_output covers the last one already) and tried to fix them as solidly as I could think to. `record_invalid_template` is a bit of a choke point for these problems, so in addition to fixing the specific cases, I made that method do a blunt scan of the content it is about to log and replace it if it contains `kind: Secret`.

I also made the ejson secret provisioner proactively validate the resulting resources and raise its own error if it isn't valid. This is duplicated effort, but it gives us stronger guarantees that nothing will go wrong further down the path. 

~Note that this is based on https://github.com/Shopify/kubernetes-deploy/pull/473 to avoid linter noise.~

**What could go wrong?**
It's still possible there's a code path that I haven't thought of that will still log secret content on error. It is also possible someone will add a new way for this to go wrong in the future, and nothing will stand in their way (note that our contributor's guide does warn about this: `We handle Kubernetes secrets, so it is critical that changes do not cause the contents of any secrets in the template set to be logged.`).

An alternative / additional safeguard could be to have our logger class scan every single string we give it for `kind: Secret`. However, that is very heavy-handed and arguably not effective, since not all strings with that text contain sensitive data, and not all secrets have that string (e.g. they could be invalid, or the string could be a partial resource).

If we don't think we can get to Good Enough here, we could revert Secret support. I would rather not though--the community asked for it, and deploying them always actually worked even before we made it official. Even if we took it a step further and prevented Secrets from being deployed with this gem, that still doesn't prevent this gem from _handling_ them.

Another thing that occurred to me is that CRs could contain sensitive data for all we know. We should consider letting administrators tell us this in our CRD annotations. I'll open an issue about this.

@Shopify/cloudx 