### PR TITLE
Improve kubectl retries

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -552,7 +552,7 @@ module KubernetesDeploy
     end
 
     def confirm_namespace_exists
-      raise FatalDeploymentError, "Failed to find namespace. #{err}" unless namespace_definition.present?
+      raise FatalDeploymentError, "Namespace #{@namespace} not found" unless namespace_definition.present?
       @logger.info("Namespace #{@namespace} found")
     end
 

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -63,7 +63,8 @@ module KubernetesDeploy
         secrets.map do |secret_name, secret_spec|
           validate_secret_spec(secret_name, secret_spec)
           resource = generate_secret_resource(secret_name, secret_spec["_type"], secret_spec["data"])
-          unless resource.validate_definition(@kubectl)
+          resource.validate_definition(@kubectl)
+          if resource.validation_failed?
             raise EjsonSecretError, "Resulting resource Secret/#{secret_name} failed validation"
           end
           resource

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -95,8 +95,11 @@ module KubernetesDeploy
     end
 
     def retriable_err?(err, retry_whitelist)
-      return retry_whitelist.any? { |retriable| err.match(retriable) } if retry_whitelist
-      !err.match(ERROR_MATCHERS[:not_found])
+      return !err.match(ERROR_MATCHERS[:not_found]) if retry_whitelist.nil?
+      retry_whitelist.any? do |retriable|
+        raise NotImplementedError, "No matcher defined for #{retriable.inspect}" unless ERROR_MATCHERS.key?(retriable)
+        err.match(ERROR_MATCHERS[retriable])
+      end
     end
 
     def extract_version_info_from_kubectl_response(response)

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -2,9 +2,11 @@
 
 module KubernetesDeploy
   class Kubectl
+    ERROR_MATCHERS = {
+      not_found: /NotFound/,
+      client_timeout: /Client\.Timeout exceeded while awaiting headers/,
+    }
     DEFAULT_TIMEOUT = 15
-    NOT_FOUND_ERROR_TEXT = 'NotFound'
-    CLIENT_TIMEOUT_ERROR_MATCHER = /Client\.Timeout exceeded while awaiting headers/
     MAX_RETRY_DELAY = 16
 
     class ResourceNotFoundError < StandardError; end
@@ -23,33 +25,37 @@ module KubernetesDeploy
     end
 
     def run(*args, log_failure: nil, use_context: true, use_namespace: true, output: nil,
-      raise_if_not_found: false, attempts: 1, output_is_sensitive: nil)
+      raise_if_not_found: false, attempts: 1, output_is_sensitive: nil, retry_whitelist: nil)
       log_failure = @log_failure_by_default if log_failure.nil?
       output_is_sensitive = @output_is_sensitive_default if output_is_sensitive.nil?
       cmd = build_command_from_options(args, use_namespace, use_context, output)
-      current_attempt = 1
+      out, err, st = nil
 
-      while current_attempt <= attempts
+      (1..attempts).to_a.each do |current_attempt|
         @logger.debug("Running command (attempt #{current_attempt}): #{cmd.join(' ')}")
         out, err, st = Open3.capture3(*cmd)
         @logger.debug("Kubectl out: " + out.gsub(/\s+/, ' ')) unless output_is_sensitive
 
         break if st.success?
-        raise(ResourceNotFoundError, err) if err.match(NOT_FOUND_ERROR_TEXT) && raise_if_not_found
-
-        attempts += 1 if err.match(CLIENT_TIMEOUT_ERROR_MATCHER) && retry_timeout?(current_attempt, attempts)
+        raise(ResourceNotFoundError, err) if err.match(ERROR_MATCHERS[:not_found]) && raise_if_not_found
 
         if log_failure
-          escaped_cmd = Shellwords.join(cmd)
-          @logger.warn("The following command failed (attempt #{current_attempt}/#{attempts}): #{escaped_cmd}")
+          warning = if current_attempt == attempts
+            "The following command failed (attempt #{current_attempt}/#{attempts})"
+          elsif retriable_err?(err, retry_whitelist)
+            "The following command failed and will be retried (attempt #{current_attempt}/#{attempts})"
+          else
+            "The following command failed and cannot be retried"
+          end
+          @logger.warn("#{warning}: #{Shellwords.join(cmd)}")
           @logger.warn(err) unless output_is_sensitive
         else
           @logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}")
         end
         StatsD.increment('kubectl.error', 1, tags: { context: @context, namespace: @namespace, cmd: cmd[1] })
 
-        sleep(retry_delay(current_attempt)) unless current_attempt == attempts
-        current_attempt += 1
+        break unless retriable_err?(err, retry_whitelist) && current_attempt < attempts
+        sleep(retry_delay(current_attempt))
       end
 
       [out.chomp, err.chomp, st]
@@ -88,8 +94,9 @@ module KubernetesDeploy
       cmd
     end
 
-    def retry_timeout?(current_attempt, attempts)
-      current_attempt == 1 && attempts == 1
+    def retriable_err?(err, retry_whitelist)
+      return retry_whitelist.any? { |retriable| err.match(retriable) } if retry_whitelist
+      !err.match(ERROR_MATCHERS[:not_found])
     end
 
     def extract_version_info_from_kubectl_response(response)

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -6,7 +6,6 @@ module KubernetesDeploy
     NOT_FOUND_ERROR_TEXT = 'NotFound'
     CLIENT_TIMEOUT_ERROR_MATCHER = /Client\.Timeout exceeded while awaiting headers/
     MAX_RETRY_DELAY = 16
-    JITTER_RANGE = [0, 0.1, 0.2, 0.3, 0.4, 0.5].freeze
 
     class ResourceNotFoundError < StandardError; end
 
@@ -58,7 +57,7 @@ module KubernetesDeploy
 
     def retry_delay(attempt)
       # exponential backoff starting at 1s with cap at 16s, offset by up to 0.5s
-      [2**(attempt - 1), MAX_RETRY_DELAY].min - JITTER_RANGE.sample
+      [2**(attempt - 1), MAX_RETRY_DELAY].min - Random.rand(0.5).round(1)
     end
 
     def version_info

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -426,7 +426,7 @@ module KubernetesDeploy
     def validate_spec_with_kubectl(kubectl)
       command = ["create", "-f", file_path, "--dry-run", "--output=name"]
       _, err, st = kubectl.run(*command, log_failure: false, output_is_sensitive: sensitive_template_content?,
-        retry_whitelist: [Kubectl::ERROR_MATCHERS[:client_timeout]], attempts: 3)
+        retry_whitelist: [:client_timeout], attempts: 3)
 
       return true if st.success?
       @validation_errors << if sensitive_template_content?

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -702,7 +702,10 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     original_ns = @namespace
     @namespace = 'this-certainly-should-not-exist'
     assert_deploy_failure(deploy_fixtures("hello-cloud", subset: ['configmap-data.yml']))
-    assert_logs_match(/Result: FAILURE.*namespaces "this-certainly-should-not-exist" not found/m)
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Namespace this-certainly-should-not-exist not found",
+    ], in_order: true)
   ensure
     @namespace = original_ns
   end

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -114,7 +114,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
       kwargs: {
         log_failure: false,
         output_is_sensitive: true,
-        retry_whitelist: [KubernetesDeploy::Kubectl::ERROR_MATCHERS[:client_timeout]],
+        retry_whitelist: [:client_timeout],
         attempts: 3,
       })
   end

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -4,9 +4,7 @@ require 'test_helper'
 class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def test_resources_based_on_ejson_file_existence
     stub_ejson_keys_get_request
-    stub_kubectl_response("create", "-f", anything, "--dry-run", "--output=name",
-      kwargs: { log_failure: false, output_is_sensitive: true }, resp: dummy_secret_hash, json: false).times(3)
-
+    stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
     assert_empty(build_provisioner(fixture_path('hello-cloud')).resources)
     refute_empty(build_provisioner(fixture_path('ejson-cloud')).resources)
   end
@@ -21,9 +19,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def test_resource_is_built_correctly
     stub_ejson_keys_get_request
-    stub_kubectl_response("create", "-f", anything, "--dry-run", "--output=name",
-      kwargs: { log_failure: false, output_is_sensitive: true }, resp: dummy_secret_hash, json: false).times(3)
-
+    stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
     refute_empty(resources)
 
@@ -96,7 +92,8 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def test_proactively_validates_resulting_resources_and_raises_without_logging
     stub_ejson_keys_get_request
-    KubernetesDeploy::Secret.any_instance.expects(:validate_definition).returns(false)
+    stub_dry_run_validation_request
+    KubernetesDeploy::Secret.any_instance.expects(:validation_failed?).returns(true)
     msg = "Generation of Kubernetes secrets from ejson failed: Resulting resource Secret/catphotoscom failed validation"
     assert_raises_message(KubernetesDeploy::EjsonSecretError, msg) do
       build_provisioner(fixture_path('ejson-cloud')).resources
@@ -110,6 +107,16 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     stub_kubectl_response("get", "secret", "ejson-keys",
       kwargs: { raise_if_not_found: true, attempts: 3, output_is_sensitive: true, log_failure: true },
       resp: dummy_ejson_secret)
+  end
+
+  def stub_dry_run_validation_request
+    stub_kubectl_response("create", "-f", anything, "--dry-run", "--output=name", resp: dummy_secret_hash, json: false,
+      kwargs: {
+        log_failure: false,
+        output_is_sensitive: true,
+        retry_whitelist: [KubernetesDeploy::Kubectl::ERROR_MATCHERS[:client_timeout]],
+        attempts: 3,
+      })
   end
 
   def correct_ejson_key_secret_data


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Make our kubectl use more resilient.

**How is this accomplished?**
* ~~Automatically retrying client timeouts specifically if the caller didn't ask us to retry errors in general.~~ EDIT: [Made `Kubectl#run` take a whitelist of error matchers that constrains retries, and used it to make validation calls retry client timeouts specifically.] We particularly saw the lack of client timeout retries affecting `apply --dry-run` validation in production, and we can't add generic retries on those (because validation failures should not be retried!). 
* Making our backoff delay more sophisticated. We believe our api servers are getting overloaded during our biggest deploys (because of the amount of churn they cause, not this gem's calls specifically). This is a small thing that I'm guessing could help, though I don't have evidence.

**What could go wrong?**
* The new retry backoff could slow down doomed deploys without actually helping the API server.
* An error in the retry logic could result in retrying things that are not safe to be retried.

@Shopify/cloudx 
