### PR TITLE
Do not fail eagerly on ImagePullBackoff

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -210,7 +210,7 @@ module KubernetesDeploy
         elsif limbo_reason == "CrashLoopBackOff"
           exit_code = @status.dig('lastState', 'terminated', 'exitCode')
           "Crashing repeatedly (exit #{exit_code}). See logs for more information."
-        elsif %w(ErrImagePull ImagePullBackOff).include?(limbo_reason) && limbo_message.match(/not found/i)
+        elsif limbo_reason == "ErrImagePull" && limbo_message.match(/not found/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
         elsif limbo_reason == "CreateContainerConfigError"

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -210,8 +210,7 @@ module KubernetesDeploy
         elsif limbo_reason == "CrashLoopBackOff"
           exit_code = @status.dig('lastState', 'terminated', 'exitCode')
           "Crashing repeatedly (exit #{exit_code}). See logs for more information."
-        elsif %w(ImagePullBackOff ErrImagePull).include?(limbo_reason) &&
-          limbo_message.match(/(?:not found)|(?:back-off)/i)
+        elsif %w(ErrImagePull ImagePullBackOff).include?(limbo_reason) && limbo_message.match(/not found/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
         elsif limbo_reason == "CreateContainerConfigError"

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -26,8 +26,7 @@ module FixtureSetAssertions
 
     def assert_unmanaged_pod_statuses(status, count = 2)
       pods = kubeclient.get_pods(namespace: namespace, label_selector: "type=unmanaged-pod,app=#{app_name}")
-      assert_equal(count, pods.size, "Expected to find #{count} unmanaged pod(s), found #{pods.size}")
-      assert(pods.all? { |pod| pod.status.phase == status })
+      assert_equal(count, pods.count { |pod| pod.status.phase == status })
     end
 
     def refute_unmanaged_pod_exists

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -58,26 +58,7 @@ class PodTest < KubernetesDeploy::TestCase
     assert_nil(pod.failure_message)
   end
 
-  def test_deploy_failed_is_true_for_image_pull_backoff_with_specific_error
-    container_state = {
-      "state" => {
-        "waiting" => {
-          "message" => "rpc error: code = 2 desc = Error: image library/some-invalid-image not found",
-          "reason" => "ImagePullBackOff",
-        },
-      },
-    }
-    pod = build_synced_pod(build_pod_template(container_state: container_state))
-    assert(pod.deploy_failed?)
-
-    expected_msg = <<~STRING
-      The following containers encountered errors:
-      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
-    STRING
-    assert_equal(expected_msg.strip, pod.failure_message)
-  end
-
-  def test_deploy_failed_is_false_for_image_pull_backoff_without_specific_error
+  def test_deploy_failed_is_false_for_image_pull_backoff
     # Backoffs start quickly enough that failing eagerly on this basis alone (without further error details)
     # leads to many incorrect failure judgements at scale
     container_state = {

--- a/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/pod_test.rb
@@ -9,7 +9,7 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "rpc error: code = 2 desc = Error: image library/some-invalid-image not found",
-          "reason" => "ImagePullBackOff",
+          "reason" => "ErrImagePull",
         },
       },
     }
@@ -48,7 +48,7 @@ class PodTest < KubernetesDeploy::TestCase
       "state" => {
         "waiting" => {
           "message" => "Failed to pull image 'gcr.io/*': rpc error: code = 2 desc = net/http: request canceled",
-          "reason" => "ImagePullBackOff",
+          "reason" => "ErrImagePull",
         },
       },
     }
@@ -58,7 +58,28 @@ class PodTest < KubernetesDeploy::TestCase
     assert_nil(pod.failure_message)
   end
 
-  def test_deploy_failed_is_true_for_image_pull_backoff
+  def test_deploy_failed_is_true_for_image_pull_backoff_with_specific_error
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "rpc error: code = 2 desc = Error: image library/some-invalid-image not found",
+          "reason" => "ImagePullBackOff",
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+    assert(pod.deploy_failed?)
+
+    expected_msg = <<~STRING
+      The following containers encountered errors:
+      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
+    STRING
+    assert_equal(expected_msg.strip, pod.failure_message)
+  end
+
+  def test_deploy_failed_is_false_for_image_pull_backoff_without_specific_error
+    # Backoffs start quickly enough that failing eagerly on this basis alone (without further error details)
+    # leads to many incorrect failure judgements at scale
     container_state = {
       "state" => {
         "waiting" => {
@@ -69,12 +90,8 @@ class PodTest < KubernetesDeploy::TestCase
     }
     pod = build_synced_pod(build_pod_template(container_state: container_state))
 
-    assert(pod.deploy_failed?)
-    expected_msg = <<~STRING
-      The following containers encountered errors:
-      > hello-cloud: Failed to pull image busybox. Did you wait for it to be built and pushed to the registry before deploying?
-    STRING
-    assert_equal(expected_msg.strip, pod.failure_message)
+    refute(pod.deploy_failed?)
+    assert_nil(pod.failure_message)
   end
 
   def test_deploy_failed_is_true_for_container_config_error_post_18


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

At Shopify, our largest apps are seeing many deploys failing because of transient registry errors. Kubernetes (well, the container runtime) is doing the right thing and retrying until the image is successfully pulled, usually within a couple minutes, but because kubernetes-deploy declares a resource failed as soon as it observes `ImagePullBackoff`, our developers are being overexposed to these transient errors. 

`ErrImagePull`'s messages give us enough information to determine whether the image actually isn't in the registry, which is the case we were trying to catch. `ImagePullBackoff` does not. Given how quickly the former turns into the latter regardless of the underlying error reason, our assumption that we can use `ImagePullBackoff` to fail the deploy is breaking down at scale.

**How is this accomplished?**

Always requiring "not found" to be part of the error message, which in reality I believe is only the case for initial `ErrImagePull` messages at this time.

**What could go wrong?**

* We will catch cases where developers actually did not push their image before deploying (or did not wait for automation to do so) much less often. Basically we have to get really lucky and observe the pod between the first and second errors being thrown k8s-side.
* The experience of accidentally deploying a missing image will be inconsistent as a result of the above--sometimes it'll fail fast, and sometimes it'll hang until a timeout.
* This helps administrators paper over registry problems.

@Shopify/cloudx 