### PR TITLE
Add 1.9 to deprecation chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 * Each app must have a deploy directory containing its Kubernetes templates (see [Templates](#using-templates-and-variables))
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our
-offical compatibility chart below.
+official compatibility chart below.
 
 | Kubernetes version | Last officially supported in gem version |
 | :----------------: | :-------------------: |
@@ -80,6 +80,7 @@ offical compatibility chart below.
 |        1.6         |        0.15.2         |
 |        1.7         |        0.20.6         |
 |        1.8         |        0.21.1         |
+|        1.9         |        0.24.0         |
 
 ## Installation
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Add 1.9 to the deprecation chart. The commit that removed support can be seen here: https://github.com/Shopify/kubernetes-deploy/commit/731700237b64b228a4df2792e1a2c6b6ce17d895.

**How is this accomplished?**
Markdown edits.

**What could go wrong?**
I could be mistaken about the version number I guess.
