### PR TITLE
Don't fail if pod took 10s

### DIFF
--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -53,7 +53,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     hello_cloud.assert_unmanaged_pod_statuses("Succeeded", 1)
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
-      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-.*},
+      %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-.*},
     ], in_order: true)
   end
 
@@ -80,7 +80,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: Role/role},
       %r{Successfully deployed in \d.\ds: RoleBinding/role-binding},
-      %r{Successfully deployed in \d.\ds: Pod/unmanaged-pod-1-.*},
+      %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-1-.*},
     ], in_order: true)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix this test flake: https://buildkite.com/shopify/kubernetes-deploy-gem/builds/1710#9d4541af-5226-4d55-89ef-48155787d4d3/659-723

**How is this accomplished?**
Relaxing an assertion that effectively meant the pod had to succeed in under 10s. Admittedly it is weird that it took longer, but that is almost certainly test infra-related.

**What could go wrong?**
We cause a bug that makes us always take 10+s to detect pod rollout, which we would have noticed before this change and won't now. Seems unlikely.
