### PR TITLE
Easier ruby use

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -1,7 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'kubernetes-deploy'
+require 'kubernetes-deploy/deploy_task'
+require 'kubernetes-deploy/options_helper'
+require 'kubernetes-deploy/bindings_parser'
+require 'kubernetes-deploy/label_selector'
+
 require 'optparse'
 
 skip_wait = false

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -22,12 +22,10 @@ ARGV.options do |opts|
 end
 
 templates = ARGV
-logger = KubernetesDeploy::FormattedLogger.build(verbose_prefix: false)
 
 begin
   KubernetesDeploy::OptionsHelper.with_validated_template_dir(template_dir) do |dir|
     runner = KubernetesDeploy::RenderTask.new(
-      logger: logger,
       current_sha: ENV["REVISION"],
       template_dir: dir,
       bindings: bindings,

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'kubernetes-deploy'
 require 'kubernetes-deploy/render_task'
+require 'kubernetes-deploy/options_helper'
+require 'kubernetes-deploy/bindings_parser'
+
 require 'optparse'
 
 template_dir = nil

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -21,9 +21,8 @@ end
 
 namespace = ARGV[0]
 context = ARGV[1]
-logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
-restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context, logger: logger,
+restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context,
    max_watch_seconds: max_watch_seconds)
 begin
   restart.perform!(raw_deployments, selector: selector)

--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -3,8 +3,9 @@
 
 require 'optparse'
 
-require 'kubernetes-deploy'
 require 'kubernetes-deploy/restart_task'
+require 'kubernetes-deploy/options_helper'
+require 'kubernetes-deploy/label_selector'
 
 raw_deployments = nil
 max_watch_seconds = nil

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'kubernetes-deploy'
 require 'kubernetes-deploy/runner_task'
+require 'kubernetes-deploy/options_helper'
 require 'optparse'
 
 template = "task-runner-template"

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -25,12 +25,10 @@ end
 
 namespace = ARGV[0]
 context = ARGV[1]
-logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
 runner = KubernetesDeploy::RunnerTask.new(
   namespace: namespace,
   context: context,
-  logger: logger,
   max_watch_seconds: max_watch_seconds
 )
 

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -1,30 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/hash/reverse_merge'
-require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/string/inflections'
-require 'active_support/core_ext/string/strip'
-require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/array/conversions'
-require 'active_support/duration'
-require 'colorized_string'
-
-require 'kubernetes-deploy/version'
-require 'kubernetes-deploy/oj'
-require 'kubernetes-deploy/errors'
-require 'kubernetes-deploy/formatted_logger'
-require 'kubernetes-deploy/options_helper'
-require 'kubernetes-deploy/statsd'
 require 'kubernetes-deploy/deploy_task'
-require 'kubernetes-deploy/concurrency'
-require 'kubernetes-deploy/bindings_parser'
-require 'kubernetes-deploy/duration_parser'
-require 'kubernetes-deploy/resource_cache'
-require 'kubernetes-deploy/label_selector'
-
-module KubernetesDeploy
-  MIN_KUBE_VERSION = '1.10.0'
-  StatsD.build
-end
+require 'kubernetes-deploy/render_task'
+require 'kubernetes-deploy/restart_task'
+require 'kubernetes-deploy/runner_task'

--- a/lib/kubernetes-deploy/common.rb
+++ b/lib/kubernetes-deploy/common.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/hash/reverse_merge'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/numeric/time'
+require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/array/conversions'
+require 'colorized_string'
+
+require 'kubernetes-deploy/version'
+require 'kubernetes-deploy/oj'
+require 'kubernetes-deploy/errors'
+require 'kubernetes-deploy/formatted_logger'
+require 'kubernetes-deploy/statsd'
+
+module KubernetesDeploy
+  MIN_KUBE_VERSION = '1.10.0'
+  StatsD.build
+end

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'colorized_string'
+
 module KubernetesDeploy
   # Adds the methods kubernetes-deploy requires to your logger class.
   # These methods include helpers for logging consistent headings, as well as facilities for

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -109,14 +109,14 @@ module KubernetesDeploy
       kubectl.server_version
     end
 
-    def initialize(namespace:, context:, current_sha:, template_dir:, logger:, kubectl_instance: nil, bindings: {},
+    def initialize(namespace:, context:, current_sha:, template_dir:, logger: nil, kubectl_instance: nil, bindings: {},
       max_watch_seconds: nil, selector: nil)
       @namespace = namespace
       @namespace_tags = []
       @context = context
       @current_sha = current_sha
       @template_dir = File.expand_path(template_dir)
-      @logger = logger
+      @logger = logger || KubernetesDeploy::FormattedLogger.build(namespace, context)
       @kubectl = kubectl_instance
       @max_watch_seconds = max_watch_seconds
       @renderer = KubernetesDeploy::Renderer.new(

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
-require 'open3'
 require 'yaml'
 require 'shellwords'
 require 'tempfile'
 require 'fileutils'
+
+require 'kubernetes-deploy/common'
+require 'kubernetes-deploy/concurrency'
+require 'kubernetes-deploy/resource_cache'
 require 'kubernetes-deploy/kubernetes_resource'
 %w(
   custom_resource

--- a/lib/kubernetes-deploy/duration_parser.rb
+++ b/lib/kubernetes-deploy/duration_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/duration'
+
 module KubernetesDeploy
   ##
   # This class is a less strict extension of ActiveSupport::Duration::ISO8601Parser.

--- a/lib/kubernetes-deploy/formatted_logger.rb
+++ b/lib/kubernetes-deploy/formatted_logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'logger'
+require 'colorized_string'
 require 'kubernetes-deploy/deferred_summary_logging'
 
 module KubernetesDeploy

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'open3'
 
 module KubernetesDeploy
   class Kubectl

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require 'json'
-require 'open3'
 require 'shellwords'
 
 require 'kubernetes-deploy/remote_logs'
+require 'kubernetes-deploy/duration_parser'
+require 'kubernetes-deploy/label_selector'
+require 'kubernetes-deploy/rollout_conditions'
 
 module KubernetesDeploy
   class KubernetesResource

--- a/lib/kubernetes-deploy/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/custom_resource_definition.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'kubernetes-deploy/rollout_conditions'
-
 module KubernetesDeploy
   class CustomResourceDefinition < KubernetesResource
     TIMEOUT = 2.minutes

--- a/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/deployment.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'kubernetes-deploy/kubernetes_resource/replica_set'
+
 module KubernetesDeploy
   class Deployment < KubernetesResource
     TIMEOUT = 7.minutes

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'kubernetes-deploy/kubernetes_resource/pod'
+
 module KubernetesDeploy
   class PodSetBase < KubernetesResource
     def failure_message

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'kubernetes-deploy/kubernetes_resource/pod_set_base'
+
 module KubernetesDeploy
   class ReplicaSet < PodSetBase
     TIMEOUT = 5.minutes

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'kubernetes-deploy/kubernetes_resource/pod'
+
 module KubernetesDeploy
   class Service < KubernetesResource
     TIMEOUT = 7.minutes

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -7,8 +7,8 @@ require 'kubernetes-deploy/template_discovery'
 
 module KubernetesDeploy
   class RenderTask
-    def initialize(logger:, current_sha:, template_dir:, bindings:)
-      @logger = logger
+    def initialize(logger: nil, current_sha:, template_dir:, bindings:)
+      @logger = logger || KubernetesDeploy::FormattedLogger.build
       @template_dir = template_dir
       @renderer = KubernetesDeploy::Renderer.new(
         current_sha: current_sha,

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'tempfile'
 
+require 'kubernetes-deploy/common'
 require 'kubernetes-deploy/renderer'
 require 'kubernetes-deploy/template_discovery'
 

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+
+require 'kubernetes-deploy/concurrency'
+require 'kubernetes-deploy/resource_cache'
+
 module KubernetesDeploy
   class ResourceWatcher
     extend KubernetesDeploy::StatsD::MeasureMethods

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -21,10 +21,10 @@ module KubernetesDeploy
     HTTP_OK_RANGE = 200..299
     ANNOTATION = "shipit.shopify.io/restart"
 
-    def initialize(context:, namespace:, logger:, max_watch_seconds: nil)
+    def initialize(context:, namespace:, logger: nil, max_watch_seconds: nil)
       @context = context
       @namespace = namespace
-      @logger = logger
+      @logger = logger || KubernetesDeploy::FormattedLogger.build(namespace, context)
       @max_watch_seconds = max_watch_seconds
     end
 

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require 'kubernetes-deploy/common'
+require 'kubernetes-deploy/kubernetes_resource'
+require 'kubernetes-deploy/kubernetes_resource/deployment'
 require 'kubernetes-deploy/kubeclient_builder'
 require 'kubernetes-deploy/resource_watcher'
 require 'kubernetes-deploy/kubectl'

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -15,8 +15,8 @@ module KubernetesDeploy
 
     attr_reader :pod_name
 
-    def initialize(namespace:, context:, logger:, max_watch_seconds: nil)
-      @logger = logger
+    def initialize(namespace:, context:, logger: nil, max_watch_seconds: nil)
+      @logger = logger || KubernetesDeploy::FormattedLogger.build(namespace, context)
       @namespace = namespace
       @context = context
       @max_watch_seconds = max_watch_seconds

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 require 'tempfile'
 
+require 'kubernetes-deploy/common'
 require 'kubernetes-deploy/kubeclient_builder'
 require 'kubernetes-deploy/kubectl'
+require 'kubernetes-deploy/resource_cache'
+require 'kubernetes-deploy/resource_watcher'
+require 'kubernetes-deploy/kubernetes_resource'
+require 'kubernetes-deploy/kubernetes_resource/pod'
 
 module KubernetesDeploy
   class RunnerTask

--- a/test/unit/kubernetes-deploy/bindings_parser_test.rb
+++ b/test/unit/kubernetes-deploy/bindings_parser_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 require 'json'
+require 'kubernetes-deploy/bindings_parser'
 
 class BindingsParserTest < ::Minitest::Test
   def test_parse_json

--- a/test/unit/kubernetes-deploy/options_helper_test.rb
+++ b/test/unit/kubernetes-deploy/options_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 require 'tempfile'
+require 'kubernetes-deploy/options_helper'
 
 class OptionsHelperTest < KubernetesDeploy::TestCase
   include EnvTestHelper


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Make it easier to use our Ruby interface, i.e. `DeployTask`, `RunnerTask`, `RenderTask` and `RestartTask` by:
- Moving `require`s around so that requiring a specific task (e.g. `require 'kubernetes-deploy/deploy_task'`) actually gets you the dependencies you need to run it (and not dependencies you don't need).
- Making all the tasks give you a logger out of the box if you don't pass one in. People rarely want to customize the logger (outside our tests), so making them construct one of our fancy loggers is unnecessary friction.
- Making `require kubernetes-deploy` require ALL the tasks so that it still has a purpose in the world where the correct way to require any specific task--including DeployTask--is `require kubernetes-deploy/TASK`.

cc @stefanmb 

**What could go wrong?**

The requires could be incomplete, causing the tasks to blow up in production when executing a line my manual tests didn't cover. I tried making the test files only require the code for their respective tasks, but in addition to being a bit of a mess, it was pointless because all but the RenderTask suite need to require DeployTask (i.e. most of the code) for setup purposes.

**Todo**

- [x] Look carefully about which files each task is losing access to
- [ ] ~~Investigate the OJ conflict with Rails apps and consider requiring that file from common~~ While a valid issue, this is not actually related to this PR.

After review but before shipping, test the tasks:
- [x] invoke each of the tasks from the command line with various options to make sure none are broken
- [x] invoke each of the tasks from a Ruby console session to make sure this PR works as stated
- [ ] use cumulus-cat's Shipit task to test this branch
