### PR TITLE
Fix: Undefined method "merge" on LabelSelector

### DIFF
--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/string/inflections'

--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -106,7 +106,7 @@ module KubernetesDeploy
       end
 
       labels = { "name" => secret_name }
-      labels.reverse_merge!(@selector) if @selector
+      labels.reverse_merge!(@selector.to_h) if @selector
 
       secret = {
         'kind' => 'Secret',

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -101,6 +101,16 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     refute_logs_match("Secret")
   end
 
+  def test_run_with_selector_does_not_raise_exception
+    stub_ejson_keys_get_request
+    stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
+    provisioner = build_provisioner(
+      fixture_path('ejson-cloud'),
+      selector: KubernetesDeploy::LabelSelector.new("app" => "yay")
+    )
+    refute_empty(provisioner.resources)
+  end
+
   private
 
   def stub_ejson_keys_get_request
@@ -162,14 +172,15 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
     secret
   end
 
-  def build_provisioner(dir = nil)
+  def build_provisioner(dir = nil, selector: nil)
     dir ||= fixture_path('ejson-cloud')
     KubernetesDeploy::EjsonSecretProvisioner.new(
       namespace: 'test',
       context: KubeclientHelper::TEST_CONTEXT,
       template_dir: dir,
       logger: logger,
-      statsd_tags: []
+      statsd_tags: [],
+      selector: selector,
     )
   end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
When deploying with a `--selector`, fix exceptions:
- `undefined method "merge"` on `LabelSelector` and
- `undefined method `reverse_merge!` on `Hash`

**How is this accomplished?**
- convert LabelSelector to hash before merging
- require ActiveSupport's `reverse_merge` lib

**What could go wrong?**
Not sure - it's already busted now