### PR TITLE
Define Memcached and Redis as CustomResource

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -38,7 +38,11 @@ module KubernetesDeploy
         opts = { namespace: namespace, context: context, definition: definition, logger: logger,
                  statsd_tags: statsd_tags }
         if (klass = class_for_kind(definition["kind"]))
-          return klass.new(**opts)
+          if (klass <= CustomResource)
+            return klass.new(crd: crd, **opts)
+          else
+            return klass.new(**opts)
+          end
         end
         if crd
           CustomResource.new(crd: crd, **opts)

--- a/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  class Memcached < KubernetesResource
+  class Memcached < CustomResource
     TIMEOUT = 5.minutes
     CONFIGMAP_NAME = "memcached-url"
 
@@ -16,6 +16,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
+      return false unless super
       deployment_ready? && service_ready? && configmap_ready?
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  class Redis < KubernetesResource
+  class Redis < CustomResource
     TIMEOUT = 5.minutes
     UUID_ANNOTATION = "redis.stable.shopify.io/owner_uid"
 
@@ -19,6 +19,7 @@ module KubernetesDeploy
     end
 
     def deploy_succeeded?
+      return false unless super
       deployment_ready? && service_ready?
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Be able to validate the custom resource status for Redis and Memcached resources.

_Related PR:_ [cloudbuddies#1783](https://github.com/Shopify/cloudbuddies/pull/1783)

**How is this accomplished?**
Define `Memcached` and `Redis` as `CustomResource` and call the `deploy_succeeded` function to validate the status.

**What could go wrong?**
Nothing special, this is compatible with the existing CRDs
I tested with and without the `kubernetes-deploy.shopify.io/instance-rollout-conditions` annotation for both CRDs.

