### PR TITLE
Add more targets to prune whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+*Enhancements*
+
+- **[Breaking change]** Added ServiceAccount, PodTemplate, ReplicaSet, Role, and RoleBinding to the prune whitelist.
+  * To see what resources may be affected, run `kubectl get $RESOURCE -o jsonpath='{ range .items[*] }{.metadata.namespace}{ "\t" }{.metadata.name}{ "\t" }{.metadata.annotations}{ "\n" }{ end }' --all-namespaces | grep "last-applied"`
+  * To exclude a resource from kubernetes-deploy (and kubectl apply) management, remove the last-applied annotation `kubectl annotate $RESOURCE $SECRET_NAME kubectl.kubernetes.io/last-applied-configuration-`.
+
 ## 0.26.7
 
 *Other*

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -58,7 +58,6 @@ module KubernetesDeploy
     # core/v1/Endpoints -- managed by services
     # core/v1/PersistentVolumeClaim -- would delete data
     # core/v1/ReplicationController -- superseded by deployments/replicasets
-    # extensions/v1beta1/ReplicaSet -- managed by deployments
 
     def predeploy_sequence
       before_crs = %w(
@@ -85,7 +84,10 @@ module KubernetesDeploy
         core/v1/Service
         core/v1/ResourceQuota
         core/v1/Secret
+        core/v1/ServiceAccount
+        core/v1/PodTemplate
         batch/v1/Job
+        extensions/v1beta1/ReplicaSet
         extensions/v1beta1/DaemonSet
         extensions/v1beta1/Deployment
         extensions/v1beta1/Ingress
@@ -94,6 +96,8 @@ module KubernetesDeploy
         autoscaling/v1/HorizontalPodAutoscaler
         policy/v1beta1/PodDisruptionBudget
         batch/v1beta1/CronJob
+        rbac.authorization.k8s.io/v1/Role
+        rbac.authorization.k8s.io/v1/RoleBinding
       )
       wl + cluster_resource_discoverer.crds.select(&:prunable?).map(&:group_version_kind)
     end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -107,8 +107,13 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       prune_matcher("poddisruptionbudget", "policy", "test"),
       prune_matcher("networkpolicy", "networking.k8s.io", "allow-all-network-policy"),
       prune_matcher("secret", "", "hello-secret"),
+      prune_matcher("replicaset", "extensions", "bare-replica-set"),
+      prune_matcher("serviceaccount", "", "build-robot"),
+      prune_matcher("podtemplate", "", "hello-cloud-template-runner"),
+      prune_matcher("role", "rbac.authorization.k8s.io", "role"),
+      prune_matcher("rolebinding", "rbac.authorization.k8s.io", "role-binding"),
     ] # not necessarily listed in this order
-    expected_msgs = [/Pruned 13 resources and successfully deployed 6 resources/]
+    expected_msgs = [/Pruned 18 resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|
       expected_msgs << /The following resources were pruned:.*#{resource}/
     end
@@ -906,7 +911,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "StatefulSet/stateful-busybox: FAILED",
       "app: Crashing repeatedly (exit 1). See logs for more information.",
       "Events (common success events excluded):",
-      %r{\[Pod/stateful-busybox-\d\]	BackOff: Back-off restarting failed container},
+      %r{\[Pod/stateful-busybox-\d\]\tBackOff: Back-off restarting failed container},
       "Logs from container 'app':",
       "ls: /not-a-dir: No such file or directory",
     ], in_order: true)
@@ -1095,7 +1100,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Result: FAILURE",
       "Job/hello-job: FAILED",
       "Final status: Failed",
-      %r{\[Job/hello-job\]	DeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)},
+      %r{\[Job/hello-job\]\tDeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)},
     ])
   end
 

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -62,6 +62,6 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
     context_name = "docker-for-desktop"
     client = kubeclient_builder.build_v1_kubeclient(context_name)
     assert(!client.nil?, "Expected Kubeclient is built for context " \
-    	"#{context_name} with success.")
+      "#{context_name} with success.")
   end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Quick win: resolve https://github.com/Shopify/kubernetes-deploy/issues/271
Basically, expand the prune whitelist to include ServiceAccount, PodTemplate, and ReplicaSet.

**How is this accomplished?**

I just added them to the whitelist. Seems consistent.

**What could go wrong?**

Could prune stuff it shouldn't or miss things it should prune, I suppose. Does this cover enough?