### PR TITLE
change logic for services backed by multiple deployments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Naming/FileName:
 
 Sorbet/ConstantsFromStrings:
   Enabled: false
+
+Layout/Tab:
+  Exclude:
+    - test/integration/kubernetes_deploy_test.rb

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -49,7 +49,7 @@ module KubernetesDeploy
     end
 
     def requires_endpoints?
-      # service of type External don't have endpoints
+      # services of type External don't have endpoints
       return false if external_name_svc?
 
       # problem counting replicas - by default, assume endpoints are required
@@ -69,8 +69,8 @@ module KubernetesDeploy
 
     def related_replica_count
       return 0 unless selector.present?
-      return unless @related_deployments.length == 1
-      @related_deployments.first["spec"]["replicas"].to_i
+      return if @related_deployments.blank?
+      @related_deployments.inject(0) { |sum, d| sum + d["spec"]["replicas"].to_i }
     end
 
     def external_name_svc?

--- a/test/fixtures/for_unit_tests/service_test.yml
+++ b/test/fixtures/for_unit_tests/service_test.yml
@@ -25,7 +25,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  type: standard
+  name: standard
   labels:
     type: standard
 spec:
@@ -75,7 +75,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  type: zero-replica
+  name: zero-replica
   labels:
     type: zero-replica
 spec:
@@ -87,6 +87,54 @@ spec:
     metadata:
       labels:
         type: zero-replica
+    spec:
+      containers:
+      - name: app
+        image: busybox
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zero-replica-multiple
+spec:
+  selector:
+    type: zero-replica-multiple
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: zero-replica-multiple-1
+  labels:
+    type: zero-replica-multiple
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      type: zero-replica-multiple
+  template:
+    metadata:
+      labels:
+        type: zero-replica-multiple
+    spec:
+      containers:
+      - name: app
+        image: busybox
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: zero-replica-multiple-2
+  labels:
+    type: zero-replica-multiple
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      type: zero-replica-multiple
+  template:
+    metadata:
+      labels:
+        type: zero-replica-multiple
     spec:
       containers:
       - name: app

--- a/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
+++ b/test/unit/kubernetes-deploy/kubeclient_builder_test.rb
@@ -62,6 +62,6 @@ class KubeClientBuilderTest < KubernetesDeploy::TestCase
     context_name = "docker-for-desktop"
     client = kubeclient_builder.build_v1_kubeclient(context_name)
     assert(!client.nil?, "Expected Kubeclient is built for context " \
-    	"#{context_name} with success.")
+      "#{context_name} with success.")
   end
 end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -102,6 +102,20 @@ class ServiceTest < KubernetesDeploy::TestCase
     assert_equal("Doesn't require any endpoints", svc.status)
   end
 
+  def test_services_for_multiple_zero_replica_deployments_do_not_require_endpoints
+    svc_def = service_fixture('zero-replica-multiple')
+    svc = build_service(svc_def)
+
+    stub_kind_get("Service", items: [svc_def])
+    stub_kind_get("Deployment", items: deployment_fixtures)
+    stub_kind_get("Pod", items: [])
+    svc.sync(build_resource_cache)
+
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status)
+  end
+
   private
 
   def build_service(definition)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Attempt to fix https://github.com/Shopify/kubernetes-deploy/issues/483

**How is this accomplished?**
Change the logic for related deployments to sum the replicas instead of bailing if there are more than one.

**What could go wrong?**
...
