### PR TITLE
Allow for yaml aliases to be loaded using YAML.safe_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug Fixes*
+- Re-enable support for YAML aliases when using YAML.safe_load [#510](https://github.com/Shopify/kubernetes-deploy/pull/510)
+
 ## 0.26.5
 
 *Bug Fixes*

--- a/lib/kubernetes-deploy/bindings_parser.rb
+++ b/lib/kubernetes-deploy/bindings_parser.rb
@@ -41,7 +41,7 @@ module KubernetesDeploy
         when '.json'
           bindings = parse_json(File.read(file_path))
         when '.yaml', '.yml'
-          bindings = YAML.safe_load(File.read(file_path))
+          bindings = YAML.safe_load(File.read(file_path), [], [], true, file_path)
         else
           raise ArgumentError, "Supplied file does not appear to be JSON or YAML"
         end

--- a/test/fixtures/for_unit_tests/bindings-with-aliases.yaml
+++ b/test/fixtures/for_unit_tests/bindings-with-aliases.yaml
@@ -1,0 +1,6 @@
+---
+alias: &alias
+  baz: bang
+foo: a,b,c
+bar:
+  <<: *alias

--- a/test/unit/kubernetes-deploy/bindings_parser_test.rb
+++ b/test/unit/kubernetes-deploy/bindings_parser_test.rb
@@ -81,6 +81,13 @@ class BindingsParserTest < ::Minitest::Test
     assert_equal(expected, bindings.parse)
   end
 
+  def test_parses_yaml_file_with_aliases
+    expected = { "foo" => "a,b,c", "bar" => { "baz" => "bang" }, "alias" => { "baz" => "bang" } }
+    bindings = KubernetesDeploy::BindingsParser.new
+    bindings.add('@test/fixtures/for_unit_tests/bindings-with-aliases.yaml')
+    assert_equal(expected, bindings.parse)
+  end
+
   private
 
   def parse(string)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
As of https://github.com/Shopify/kubernetes-deploy/pull/504 and [`0.26.5` ](https://github.com/Shopify/kubernetes-deploy/blob/master/CHANGELOG.md#0265), YAML aliases no longer load and instead throw a `Psych::BadAlias`.

This PR reenabled YAML aliases based on the Psych docs:
https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load

**How is this accomplished?**
Changes `YAML.safe_load`

**What could go wrong?**
Matches the YAML alias behaviour pre-`0.26.5`, so I'm hoping this is pretty safe. It looks like the dropping of YAML alias support wasn't intentional.
