### PR TITLE
Update google auth to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## next
 
+## 0.26.7
+
+*Other*
+- Bump `googleauth` dependency. ([#512](https://github.com/Shopify/kubernetes-deploy/pull/512))
+
 ## 0.26.6
 
 *Bug Fixes*

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
-  spec.add_dependency("googleauth", "~> 0.6.6") # https://github.com/google/google-auth-library-ruby/issues/153
+  spec.add_dependency("googleauth", "~> 0.8.0")
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", '~> 2.3', '>= 2.3.2')

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  VERSION = "0.26.6"
+  VERSION = "0.26.7"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
- Update `googleauth` gem to `0.8`
- Update is due to dependency conflicts with another one of our tools

**What could go wrong?**
- Ran the tests locally and they are seem to work as expected

cc/ @peiranliushop @stefanmb 