### PR TITLE
Adjust activesupport dependency to limit upper version to <6.0.0

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.required_ruby_version = '>= 2.3.0'
-  spec.add_dependency("activesupport", ">= 5.0")
+  spec.add_dependency("activesupport", "~> 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
   spec.add_dependency("googleauth", "~> 0.8.0")
   spec.add_dependency("ejson", "~> 1.0")


### PR DESCRIPTION
This pull request tries to solve issue https://github.com/Shopify/kubernetes-deploy/issues/534