### PR TITLE
Ruby 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Naming/FileName:
   Enabled: true

--- a/.shopify-build/kubernetes-deploy.yml
+++ b/.shopify-build/kubernetes-deploy.yml
@@ -1,6 +1,6 @@
 containers:
   default:
-    docker: circleci/ruby:2.5.1-node-browsers
+    docker: circleci/ruby:2.4.6-node-browsers
 
 steps:
   - label: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 *Important!*
 - The next release will be 1.0.0, which means that master will contain breaking changes.
 
+*Other*
+- We now require Ruby 2.4.x since Ruby 2.3 is past EoL.
+
 ## 0.28.0
 
 *Enhancements*
 - Officially support Kubernetes 1.15 ([#546](https://github.com/Shopify/kubernetes-deploy/pull/546))
 - Make sure that we only declare a Service of type LoadBalancer as deployed after its IP address is published. [#547](https://github.com/Shopify/kubernetes-deploy/pull/547)
 - Add more validations to `RunnerTask`. [#554](https://github.com/Shopify/kubernetes-deploy/pull/554)
-- Validate secrets with `--server-dry-run` on supported clusters. [#553](https://github.com/Shopify/kubernetes-deploy/pull/553) 
+- Validate secrets with `--server-dry-run` on supported clusters. [#553](https://github.com/Shopify/kubernetes-deploy/pull/553)
 *Bug Fixes*
 - Fix a bug in rendering where we failed to add a yaml doc separator (`---`) to
   an implicit document if there are multiple documents in the file.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 
 ## Prerequisites
 
-* Ruby 2.3+
+* Ruby 2.4+
 * Your cluster must be running Kubernetes v1.11.0 or higher<sup>1</sup>
 * Each app must have a deploy directory containing its Kubernetes templates (see [Templates](#using-templates-and-variables))
 

--- a/bin/ci
+++ b/bin/ci
@@ -17,5 +17,5 @@ docker run --rm \
     -e VERBOSE=1 \
     -e PARALLELISM=$PARALLELISM \
     -w /usr/src/app \
-    ruby:2.3 \
+    ruby:2.4 \
     bin/test

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 ---
 name: kubernetes-deploy
 up:
-  - ruby: 2.3.3 # Matches gemspec
+  - ruby: 2.4.6 # Matches gemspec
   - bundler
   - homebrew:
     - Caskroom/cask/minikube

--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
   spec.add_dependency("googleauth", "~> 0.8.0")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
End our support of Ruby 2.3 since Ruby 2.3 is no longer supported.

**How is this accomplished?**
Bump some things.

**What could go wrong?**
There isn't anything that requires 2.4, though there appears to be some [gem version fun](https://github.com/Shopify/kubernetes-deploy/pull/535). We could since the burden to support 2.3 is trivial today we could keep supporting. However, I'm of the belief that we shouldn't tie ourselves to unsupported versions. 