### PR TITLE
Cluster resources

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -69,6 +69,8 @@ module KubernetesDeploy
         ConfigMap
         PersistentVolumeClaim
         ServiceAccount
+        ClusterRole
+        ClusterRoleBinding
         Role
         RoleBinding
         Secret

--- a/test/fixtures/hello-cloud/clusterrole-binding.yml
+++ b/test/fixtures/hello-cloud/clusterrole-binding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterrole
+subjects:
+- kind: ServiceAccount
+  name: build-robot
+  namespace: default

--- a/test/fixtures/hello-cloud/clusterrole.yml
+++ b/test/fixtures/hello-cloud/clusterrole.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterrole
+rules: []

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -143,6 +143,18 @@ module FixtureSetAssertions
       assert(desired.present?, "Service account #{name} does not exist")
     end
 
+    def assert_clusterrole_present(name)
+      cluster_roles = rbac_v1_kubeclient.get_cluster_roles
+      desired = cluster_roles.find { |sa| sa.metadata.name == name }
+      assert(desired.present?, "ClusterRole #{name} does not exist")
+    end
+
+    def assert_clusterrole_binding_present(name)
+      cluster_role_bindings = rbac_v1_kubeclient.get_cluster_role_bindings
+      desired = cluster_role_bindings.find { |sa| sa.metadata.name == name }
+      assert(desired.present?, "ClusterRole binding #{name} does not exist")
+    end
+
     def assert_role_present(name)
       roles = rbac_v1_kubeclient.get_roles(namespace: namespace)
       desired = roles.find { |sa| sa.metadata.name == name }

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -15,6 +15,8 @@ module FixtureSetAssertions
       assert_poddisruptionbudget
       assert_bare_replicaset_up
       assert_all_service_accounts_up
+      assert_all_clusterroles_up
+      assert_all_clusterroles_bindings_up
       assert_all_roles_up
       assert_all_role_bindings_up
       assert_daemon_set_up
@@ -89,6 +91,14 @@ module FixtureSetAssertions
 
     def assert_all_service_accounts_up
       assert_service_account_present("build-robot")
+    end
+
+    def assert_all_clusterroles_up
+      assert_clusterrole_present("clusterrole")
+    end
+
+    def assert_all_clusterroles_bindings_up
+      assert_clusterrole_binding_present("cluster-role-binding")
     end
 
     def assert_all_roles_up

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -15,7 +15,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       %r{- Pod/unmanaged-pod-2-[-\w]+ \(timeout: 60s\)}, # annotation timeout override
       "Hello from the command runner!", # unmanaged pod logs
       "Result: SUCCESS",
-      "Successfully deployed 24 resources",
+      "Successfully deployed 26 resources",
     ], in_order: true)
     refute_logs_match(/Using resource selector/)
 
@@ -45,6 +45,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       pod["spec"]["serviceAccountName"] = service_account_name
       pod["spec"]["automountServiceAccountToken"] = false
     end
+
     # Expect the service account is deployed before the unmanaged pod
     assert_deploy_success(result)
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
@@ -54,6 +55,39 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match_all([
       %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
       %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-.*},
+    ], in_order: true)
+  end
+
+  def test_clusterrole_and_clusterrole_binding_predeployed_before_role_and_unmanaged_pod
+    result = deploy_fixtures(
+      "hello-cloud",
+      subset: [
+        "configmap-data.yml",
+        "unmanaged-pod-1.yml.erb",
+        "role-binding.yml",
+        "role.yml",
+        "clusterrole.yml",
+        "clusterrole-binding.yml",
+        "service-account.yml",
+      ]
+    )
+
+    # Expect that cluster role and cluster role binding is deployed before the unmanaged pod
+    assert_deploy_success(result)
+    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+    hello_cloud.assert_configmap_data_present
+    hello_cloud.assert_all_service_accounts_up
+    hello_cloud.assert_all_clusterroles_up
+    hello_cloud.assert_all_clusterroles_bindings_up
+    hello_cloud.assert_all_roles_up
+    hello_cloud.assert_all_role_bindings_up
+    hello_cloud.assert_unmanaged_pod_statuses("Succeeded", 1)
+    assert_logs_match_all([
+      %r{Successfully deployed in \d.\ds: ClusterRole/clusterrole},
+      %r{Successfully deployed in \d.\ds: ClusterRoleBinding/cluster-role-binding},
+      %r{Successfully deployed in \d.\ds: Role/role},
+      %r{Successfully deployed in \d.\ds: RoleBinding/role-binding},
+      %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-1-.*},
     ], in_order: true)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Deploy ClusterRole and ClusterRoleBinding before SA and unmanaged pod, because our unmanaged pod uses them to access cluster resources.

**How is this accomplished?**
ClusterRole and ClusterRoleBinding to `predeploy_sequence` after ServiceAccount, but before Role and RoleBinding, because they can use ClusterRole in some cases

**What could go wrong?**
...
