### PR TITLE
Support StatefulSets with 0 replicas

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -40,7 +40,8 @@ module KubernetesDeploy
     end
 
     def timeout_message
-      "This service does not seem to select any pods. This means its spec.selector is probably incorrect."
+      "This service does not seem to select any pods and this is likely invalid. "\
+      "Please confirm the spec.selector is correct and the targeted workload is healthy."
     end
 
     private

--- a/test/fixtures/for_unit_tests/service_test.yml
+++ b/test/fixtures/for_unit_tests/service_test.yml
@@ -139,3 +139,36 @@ spec:
       containers:
       - name: app
         image: busybox
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zero-replica-statefulset
+spec:
+  selector:
+    type: zero-replica-statefulset
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    type: zero-replica-statefulset
+  name: stateful-busybox
+spec:
+  serviceName: "zero-replica-statefulset"
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: hello-cloud
+        name: stateful-busybox
+        type: zero-replica-statefulset
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        ports:
+        - containerPort: 80

--- a/test/fixtures/hello-cloud/stateful_set.yml
+++ b/test/fixtures/hello-cloud/stateful_set.yml
@@ -1,3 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stateful-busybox
+  labels:
+    name: stateful-busybox
+    app: hello-cloud
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: http
+  selector:
+    name: stateful-busybox
+    app: hello-cloud
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:

--- a/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/service_test.rb
@@ -58,6 +58,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: deployment_fixtures)
     stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: [])
     svc.sync(build_resource_cache)
 
     assert(svc.exists?)
@@ -67,6 +68,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: deployment_fixtures)
     stub_kind_get("Pod", items: pod_fixtures)
+    stub_kind_get("StatefulSet", items: [])
     svc.sync(build_resource_cache)
 
     assert(svc.exists?)
@@ -81,6 +83,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: [])
     stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: [])
     svc.sync(build_resource_cache)
 
     assert(svc.exists?)
@@ -95,6 +98,7 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: deployment_fixtures)
     stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: [])
     svc.sync(build_resource_cache)
 
     assert(svc.exists?)
@@ -109,6 +113,22 @@ class ServiceTest < KubernetesDeploy::TestCase
     stub_kind_get("Service", items: [svc_def])
     stub_kind_get("Deployment", items: deployment_fixtures)
     stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: [])
+    svc.sync(build_resource_cache)
+
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status)
+  end
+
+  def test_services_for_zero_replica_statefulset_do_not_require_endpoints
+    svc_def = service_fixture('zero-replica-statefulset')
+    svc = build_service(svc_def)
+
+    stub_kind_get("Service", items: [svc_def])
+    stub_kind_get("Deployment", items: [])
+    stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: stateful_set_fixtures)
     svc.sync(build_resource_cache)
 
     assert(svc.exists?)
@@ -128,6 +148,10 @@ class ServiceTest < KubernetesDeploy::TestCase
 
   def deployment_fixtures
     fixtures.select { |f| f["kind"] == "Deployment" }
+  end
+
+  def stateful_set_fixtures
+    fixtures.select { |f| f["kind"] == "StatefulSet" }
   end
 
   def pod_fixtures


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Currently when one deploys a StatefulSet + Service pair where the SS's replicas is set to zero, the service will eventually time out. This behavior is wrong, its valid for a service to point at a SS that's intentionally been scaled down. We should treat this case the same as a deployment. 

fixes: https://github.com/Shopify/kubernetes-deploy/issues/265

**How is this accomplished?**
Have the service check to see if it's actually pointing at a deployment or statefulset that has been scaled down. 

**What could go wrong?**

- We're intentionally not handling the case of a service in front of other pod generating controllers: CronJob/Job.  The assumption here is its unusual to point a service at  collection of pods that normally isn't running. Further since they normally aren't running, I'd have expected a bug report about it by now.

- This keeps the same bad assumption that the pod selector will also select the deployment / SS that was raised in https://github.com/Shopify/kubernetes-deploy/issues/483. I've got a second PR to solve it https://github.com/Shopify/kubernetes-deploy/pull/541 so feel ok doing this in two steps.