### PR TITLE
Drop k8s 1.10 support and add 1.15

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,4 +1,11 @@
 steps:
+  - name: 'Run Test Suite (:kubernetes: 1.15-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: 4
+      KUBERNETES_VERSION: v1.15-latest
   - name: 'Run Test Suite (:kubernetes: 1.14-latest)'
     command: bin/ci
     agents:
@@ -27,10 +34,3 @@ steps:
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.11-latest
-  - name: 'Run Test Suite (:kubernetes: 1.10-latest)'
-    command: bin/ci
-    agents:
-      queue: minikube-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.10-latest

--- a/.shopify-build/kubernetes-deploy.yml
+++ b/.shopify-build/kubernetes-deploy.yml
@@ -9,6 +9,13 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
+  - label: 'Run Test Suite (:kubernetes: 1.15-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.15-latest
   - label: 'Run Test Suite (:kubernetes: 1.14-latest)'
     command: bin/ci
     agents:
@@ -37,10 +44,3 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.11-latest
-  - label: 'Run Test Suite (:kubernetes: 1.10-latest)'
-    command: bin/ci
-    agents:
-      queue: minikube-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.10-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+*Enhancements*
+- Officially support Kubernetes 1.15 ([#XXX](https://github.com/Shopify/kubernetes-deploy/pull/XXX))
+
+*Other*
+- Kubernetes 1.10 is no longer officially supported as of this version
+
 ## 0.27.0
 *Enhancements*
 - (alpha) Introduce a new `-f` flag for `kubernetes-deploy`. Allows passing in of multiple directories and/or filenames. Currently only usable by `kubernetes-deploy`, not `kubernetes-render`. [#514](https://github.com/Shopify/kubernetes-deploy/pull/514)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kubernetes-deploy [![Build status](https://badge.buildkite.com/61937e40a1fc69754d9d198be120543d6de310de2ba8d3cb0e.svg?branch=master)](https://buildkite.com/shopify/kubernetes-deploy) [![codecov](https://codecov.io/gh/Shopify/kubernetes-deploy/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/kubernetes-deploy)
+bin/setup# kubernetes-deploy [![Build status](https://badge.buildkite.com/61937e40a1fc69754d9d198be120543d6de310de2ba8d3cb0e.svg?branch=master)](https://buildkite.com/shopify/kubernetes-deploy) [![codecov](https://codecov.io/gh/Shopify/kubernetes-deploy/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/kubernetes-deploy)
 
 `kubernetes-deploy` is a command line tool that helps you ship changes to a Kubernetes namespace and understand the result. At Shopify, we use it within our much-beloved, open-source [Shipit](https://github.com/Shopify/shipit-engine#kubernetes) deployment app.
 
@@ -68,7 +68,7 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 ## Prerequisites
 
 * Ruby 2.3+
-* Your cluster must be running Kubernetes v1.10.0 or higher<sup>1</sup>
+* Your cluster must be running Kubernetes v1.11.0 or higher<sup>1</sup>
 * Each app must have a deploy directory containing its Kubernetes templates (see [Templates](#using-templates-and-variables))
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our
@@ -81,10 +81,11 @@ official compatibility chart below.
 |        1.7         |        0.20.6         |
 |        1.8         |        0.21.1         |
 |        1.9         |        0.24.0         |
+|        1.10        |        0.27.0         |
 
 ## Installation
 
-1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.10.0 or higher) and make sure it is available in your $PATH
+1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.11.0 or higher) and make sure it is available in your $PATH
 2. Set up your [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/) for access to your cluster(s).
 3. `gem install kubernetes-deploy`
 
@@ -462,7 +463,7 @@ Refer to `kubernetes-restart --help` for the authoritative set of options.
 
 ## Prerequisites
 
-* You've already deployed a [`PodTemplate`](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podtemplate-v1-core) object with field `template` containing a `Pod` specification that does not include the `apiVersion` or `kind` parameters. An example is provided in this repo in `test/fixtures/hello-cloud/template-runner.yml`.
+* You've already deployed a [`PodTemplate`](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podtemplate-v1-core) object with field `template` containing a `Pod` specification that does not include the `apiVersion` or `kind` parameters. An example is provided in this repo in `test/fixtures/hello-cloud/template-runner.yml`.
 * The `Pod` specification in that template has a container named `task-runner`.
 
 Based on this specification `kubernetes-run` will create a new pod with the entrypoint of the `task-runner ` container overridden with the supplied arguments.

--- a/bin/setup
+++ b/bin/setup
@@ -9,8 +9,8 @@ if [ ! -x "$(which minikube)" ]; then
 fi
 
 if [ ! -x "$(which kubectl)" ]; then
-  echo -e "\n\033[0;33mPlease install kubectl version 1.10.0 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
+  echo -e "\n\033[0;33mPlease install kubectl version 1.11.0 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
 else
   KUBECTL_VERSION=$(kubectl version --short --client | grep -oe "v[[:digit:]\.]\+")
-  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.10.0 or greater.\033[0m"
+  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.11.0 or greater.\033[0m"
 fi

--- a/lib/kubernetes-deploy/common.rb
+++ b/lib/kubernetes-deploy/common.rb
@@ -19,6 +19,6 @@ require 'kubernetes-deploy/task_config'
 require 'kubernetes-deploy/task_config_validator'
 
 module KubernetesDeploy
-  MIN_KUBE_VERSION = '1.10.0'
+  MIN_KUBE_VERSION = '1.11.0'
   StatsD.build
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Our (un)official Kubernetes version support policy is everything from the oldest version on gke to most recent officially released version. 1.10 is not supported by GKE so we should drop it.

1.15 is also out so we should support it as well.

closes: https://github.com/Shopify/kubernetes-deploy/issues/544

**How is this accomplished?**
Same as previous PRs: 
https://github.com/Shopify/kubernetes-deploy/pull/409

**What could go wrong?**
We break compatibility with 1.10 and people were relying on it. 
