### PR TITLE
Verify status.loadBalancer when deploying a service of type LoadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Enhancements*
+- Make sure that we only declare a Service of type LoadBalancer as deployed after its IP address is published. [#547](https://github.com/Shopify/kubernetes-deploy/pull/547)
+
 *Other*
 
 - We've added a new Krane cli. This code is in alpha. We are providing

--- a/test/fixtures/for_unit_tests/service_test.yml
+++ b/test/fixtures/for_unit_tests/service_test.yml
@@ -200,3 +200,12 @@ spec:
       containers:
       - name: app
         image: busybox
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standard-lb
+spec:
+  type: LoadBalancer
+  selector:
+    type: standard


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fixes part of https://github.com/Shopify/kubernetes-deploy/issues/543.

Make sure that we only declare a service of type `LoadBalancer` as deployed after its IP address is published (which is an asynchronous process in the case of most cloud providers).

According to the documentation:

> The actual creation of the load balancer happens asynchronously, and information about the provisioned balancer is published in the Service’s .status.loadBalancer field

After being fully provisioned, this will show as something like this:

```yaml
status:
  loadBalancer:
    ingress:
      - ip: 146.148.47.155
```

**How is this accomplished?**

I added an extra condition that will only run if the type of the Service is `LoadBalancer`; if that's the case, it will check for the presence of `status.loadBalancer.ingress.ip` to determine if the Service has been fully provisioned.

**What could go wrong?**

It seems that testing this particular condition is [not possible with `minikube`](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#finding-your-ip-address), as (specifically in that environment) the IP address is never published to the resource data and you need a special command to retrieve it.

**Live test**

```
$ kubernetes-deploy dirceu-test tierstaging-us-east1-2 --template-dir ~/Desktop
[INFO][2019-09-09 08:28:54 -0400]
[INFO][2019-09-09 08:28:54 -0400]	------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-09 08:28:55 -0400]	Context tierstaging-us-east1-2 found
[INFO][2019-09-09 08:28:55 -0400]	Namespace dirceu-test found
[INFO][2019-09-09 08:28:55 -0400]	All required parameters and files are present
[INFO][2019-09-09 08:28:55 -0400]	Discovering resources:
[INFO][2019-09-09 08:28:56 -0400]	  - Service/test-lb
[INFO][2019-09-09 08:28:56 -0400]
[INFO][2019-09-09 08:28:56 -0400]	----------------------------Phase 2: Checking initial resource statuses-----------------------------
[INFO][2019-09-09 08:28:56 -0400]	Service/test-lb                                   Not found
[INFO][2019-09-09 08:28:56 -0400]
[INFO][2019-09-09 08:28:56 -0400]	----------------------------------Phase 3: Deploying all resources----------------------------------
[INFO][2019-09-09 08:28:56 -0400]	Deploying Service/test-lb (timeout: 420s)
[INFO][2019-09-09 08:29:30 -0400]	Still waiting for: Service/test-lb
[INFO][2019-09-09 08:30:00 -0400]	Still waiting for: Service/test-lb
[INFO][2019-09-09 08:30:30 -0400]	Still waiting for: Service/test-lb
[INFO][2019-09-09 08:30:54 -0400]	Successfully deployed in 118.0s: Service/test-lb
[INFO][2019-09-09 08:30:54 -0400]
[INFO][2019-09-09 08:30:54 -0400]	------------------------------------------Result: SUCCESS-------------------------------------------
[INFO][2019-09-09 08:30:54 -0400]	Pruned 1 resource and successfully deployed 1 resource
[INFO][2019-09-09 08:30:54 -0400]
[INFO][2019-09-09 08:30:54 -0400]	Successful resources
[INFO][2019-09-09 08:30:54 -0400]	Service/test-lb                                   Doesn't require any endpoints

$ kubectl --context tierstaging-us-east1-2 -n dirceu-test get service test-lb -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app":"test-lb","name":"test-lb"},"name":"test-lb","namespace":"dirceu-test"},"spec":{"ports":[{"name":"http","port":80,"targetPort":"http"}],"type":"LoadBalancer"}}
  creationTimestamp: "2019-09-09T12:28:57Z"
  labels:
    app: test-lb
    name: test-lb
  name: test-lb
  namespace: dirceu-test
  resourceVersion: "39073112"
  selfLink: /api/v1/namespaces/dirceu-test/services/test-lb
  uid: 64fe58ff-d2fd-11e9-8940-58010a8e017b
spec:
  clusterIP: <REDACTED>
  externalTrafficPolicy: Cluster
  ports:
  - name: http
    nodePort: 32731
    port: 80
    protocol: TCP
    targetPort: http
  sessionAffinity: None
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: <REDACTED>
```