### PR TITLE
Krane Restart cli

### DIFF
--- a/exe/kubernetes-restart
+++ b/exe/kubernetes-restart
@@ -25,7 +25,7 @@ context = ARGV[1]
 restart = KubernetesDeploy::RestartTask.new(namespace: namespace, context: context,
    max_watch_seconds: max_watch_seconds)
 begin
-  restart.perform!(raw_deployments, selector: selector)
+  restart.run!(raw_deployments, selector: selector)
 rescue KubernetesDeploy::DeploymentTimeoutError
   exit(70)
 rescue KubernetesDeploy::FatalDeploymentError

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -23,7 +23,7 @@ module Krane
         VersionCommand.from_options(options)
       end
 
-      desc("restart NAMESPACE CONTEXT", "Restarts things")
+      desc("restart NAMESPACE CONTEXT", "Restart the pods in one or more deployments")
       expand_options(RestartCommand::OPTIONS)
       def restart(namespace, context)
         rescue_and_exit do

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -3,10 +3,14 @@
 require 'krane'
 require 'thor'
 require 'krane/cli/version_command'
+require 'krane/cli/restart_command'
 
 module Krane
   module CLI
     class Krane < Thor
+      TIMEOUT_EXIT_CODE = 70
+      FAILURE_EXIT_CODE = 1
+
       package_name "Krane"
 
       def self.expand_options(task_options)
@@ -19,8 +23,26 @@ module Krane
         VersionCommand.from_options(options)
       end
 
+      desc("restart NAMESPACE CONTEXT", "Restarts things")
+      expand_options(RestartCommand::OPTIONS)
+      def restart(namespace, context)
+        rescue_and_exit do
+          RestartCommand.from_options(namespace, context, options)
+        end
+      end
+
       def self.exit_on_failure?
         true
+      end
+
+      private
+
+      def rescue_and_exit
+        yield
+      rescue KubernetesDeploy::DeploymentTimeoutError
+        exit(TIMEOUT_EXIT_CODE)
+      rescue KubernetesDeploy::FatalDeploymentError
+        exit(FAILURE_EXIT_CODE)
       end
     end
   end

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -5,9 +5,9 @@ module Krane
     class RestartCommand
       DEFAULT_GLOBAL_TIMEOUT = '300s'
       OPTIONS = {
-        "global-timeout" => { default: DEFAULT_GLOBAL_TIMEOUT, type: :string },
-        "deployments" => { type: :string },
-        "selector" => { type: :string },
+        "global-timeout" => { default: DEFAULT_GLOBAL_TIMEOUT, type: :string, banner: "duration" },
+        "deployments" => { type: :string, banner: "list,of,deployments" },
+        "selector" => { type: :string, banner: "'label=value'" },
         "verify-result" => { type: :boolean, default: true },
       }
 

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -6,13 +6,13 @@ module Krane
       DEFAULT_RESTART_TIMEOUT = '300s'
       OPTIONS = {
         "deployments" => { type: :string, banner: "list,of,deployments",
-          desc: "List of workload names to restart" },
+                           desc: "List of workload names to restart" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_RESTART_TIMEOUT,
-          desc: "Max duration to monitor workloads correctly restarted" },
+                              desc: "Max duration to monitor workloads correctly restarted" },
         "selector" => { type: :string, banner: "'label=value'",
-          desc: "Select workloads by selector(s)" },
+                        desc: "Select workloads by selector(s)" },
         "verify-result" => { type: :boolean, default: true,
-          desc: "Verify workloads correctly restarted" },
+                             desc: "Verify workloads correctly restarted" },
       }
 
       def self.from_options(namespace, context, options)

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -3,8 +3,9 @@
 module Krane
   module CLI
     class RestartCommand
+      DEFAULT_GLOBAL_TIMEOUT = '300s'
       OPTIONS = {
-        "global-timeout" => { default: '300s', type: :string },
+        "global-timeout" => { default: DEFAULT_GLOBAL_TIMEOUT, type: :string },
         "deployments" => { type: :string },
         "selector" => { type: :string },
         "verify-result" => { type: :boolean, default: true },
@@ -21,7 +22,7 @@ module Krane
         restart.run!(
           options[:deployments]&.split(","),
           selector: selector,
-          verify: options["verify-result"]
+          verify_result: options["verify-result"]
         )
       end
     end

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -5,7 +5,7 @@ module Krane
     class RestartCommand
       DEFAULT_RESTART_TIMEOUT = '300s'
       OPTIONS = {
-        "deployments" => { type: :string, banner: "list,of,deployments",
+        "deployments" => { type: :array, banner: "list of deployments",
                            desc: "List of workload names to restart" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_RESTART_TIMEOUT,
                               desc: "Max duration to monitor workloads correctly restarted" },
@@ -24,7 +24,7 @@ module Krane
           max_watch_seconds: KubernetesDeploy::DurationParser.new(options["global-timeout"]).parse!.to_i,
         )
         restart.run!(
-          options[:deployments]&.split(","),
+          options[:deployments],
           selector: selector,
           verify_result: options["verify-result"]
         )

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -3,9 +3,9 @@
 module Krane
   module CLI
     class RestartCommand
-      DEFAULT_GLOBAL_TIMEOUT = '300s'
+      DEFAULT_RESTART_TIMEOUT = '300s'
       OPTIONS = {
-        "global-timeout" => { default: DEFAULT_GLOBAL_TIMEOUT, type: :string, banner: "duration" },
+        "global-timeout" => { default: DEFAULT_RESTART_TIMEOUT, type: :string, banner: "duration" },
         "deployments" => { type: :string, banner: "list,of,deployments" },
         "selector" => { type: :string, banner: "'label=value'" },
         "verify-result" => { type: :boolean, default: true },

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class RestartCommand
+      OPTIONS = {
+        "global-timeout" => { default: '300s', type: :string },
+        "deployments" => { type: :string },
+        "selector" => { type: :string },
+        "verify-result" => { type: :boolean, default: true },
+      }
+
+      def self.from_options(namespace, context, options)
+        require 'kubernetes-deploy/restart_task'
+        selector = KubernetesDeploy::LabelSelector.parse(options[:selector]) if options[:selector]
+        restart = KubernetesDeploy::RestartTask.new(
+          namespace: namespace,
+          context: context,
+          max_watch_seconds: KubernetesDeploy::DurationParser.new(options["global-timeout"]).parse!.to_i,
+        )
+        restart.run!(
+          options[:deployments]&.split(","),
+          selector: selector,
+          verify: options["verify-result"]
+        )
+      end
+    end
+  end
+end

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -5,10 +5,14 @@ module Krane
     class RestartCommand
       DEFAULT_RESTART_TIMEOUT = '300s'
       OPTIONS = {
-        "global-timeout" => { default: DEFAULT_RESTART_TIMEOUT, type: :string, banner: "duration" },
-        "deployments" => { type: :string, banner: "list,of,deployments" },
-        "selector" => { type: :string, banner: "'label=value'" },
-        "verify-result" => { type: :boolean, default: true },
+        "deployments" => { type: :string, banner: "list,of,deployments",
+          desc: "List of workload names to restart" },
+        "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_RESTART_TIMEOUT,
+          desc: "Max duration to monitor workloads correctly restarted" },
+        "selector" => { type: :string, banner: "'label=value'",
+          desc: "Select workloads by selector(s)" },
+        "verify-result" => { type: :boolean, default: true,
+          desc: "Verify workloads correctly restarted" },
       }
 
       def self.from_options(namespace, context, options)

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -37,7 +37,7 @@ module KubernetesDeploy
     end
     alias_method :perform, :run
 
-    def run!(deployments_names = nil, selector: nil, verify: true)
+    def run!(deployments_names = nil, selector: nil, verify_result: true)
       start = Time.now.utc
       @logger.reset
 
@@ -48,12 +48,12 @@ module KubernetesDeploy
       @logger.phase_heading("Triggering restart by touching ENV[RESTARTED_AT]")
       patch_kubeclient_deployments(deployments)
 
-      @logger.phase_heading("Waiting for rollout")
-      if verify
+      if verify_result
+        @logger.phase_heading("Waiting for rollout")
         resources = build_watchables(deployments, start)
         verify_restart(resources)
       else
-        warning = "Result verification is disabled for this restart"
+        warning = "Result verification is disabled for this task"
         @logger.summary.add_paragraph(ColorizedString.new(warning).yellow)
       end
       StatsD.distribution('restart.duration', StatsD.duration(start), tags: tags('success', deployments))

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -29,14 +29,15 @@ module KubernetesDeploy
       @max_watch_seconds = max_watch_seconds
     end
 
-    def perform(*args)
+    def run(*args)
       perform!(*args)
       true
     rescue FatalDeploymentError
       false
     end
+    alias_method :perform, :run
 
-    def perform!(deployments_names = nil, selector: nil)
+    def run!(deployments_names = nil, selector: nil, verify: true)
       start = Time.now.utc
       @logger.reset
 
@@ -48,15 +49,13 @@ module KubernetesDeploy
       patch_kubeclient_deployments(deployments)
 
       @logger.phase_heading("Waiting for rollout")
-      resources = build_watchables(deployments, start)
-      ResourceWatcher.new(resources: resources, logger: @logger, operation_name: "restart",
-        timeout: @max_watch_seconds, namespace: @namespace, context: @context).run
-      failed_resources = resources.reject(&:deploy_succeeded?)
-      success = failed_resources.empty?
-      if !success && failed_resources.all?(&:deploy_timed_out?)
-        raise DeploymentTimeoutError
+      if verify
+        resources = build_watchables(deployments, start)
+        verify_restart(resources)
+      else
+        warning = "Result verification is disabled for this restart"
+        @logger.summary.add_paragraph(ColorizedString.new(warning).yellow)
       end
-      raise FatalDeploymentError unless success
       StatsD.distribution('restart.duration', StatsD.duration(start), tags: tags('success', deployments))
       @logger.print_summary(:success)
     rescue DeploymentTimeoutError
@@ -69,6 +68,7 @@ module KubernetesDeploy
       @logger.print_summary(:failure)
       raise
     end
+    alias_method :perform!, :run!
 
     private
 
@@ -166,6 +166,17 @@ module KubernetesDeploy
           },
         },
       }
+    end
+
+    def verify_restart(resources)
+      ResourceWatcher.new(resources: resources, logger: @logger, operation_name: "restart",
+        timeout: @max_watch_seconds, namespace: @namespace, context: @context).run
+      failed_resources = resources.reject(&:deploy_succeeded?)
+      success = failed_resources.empty?
+      if !success && failed_resources.all?(&:deploy_timed_out?)
+        raise DeploymentTimeoutError
+      end
+      raise FatalDeploymentError unless success
     end
 
     def verify_config!

--- a/test/exe/krane_test.rb
+++ b/test/exe/krane_test.rb
@@ -3,29 +3,19 @@ require 'test_helper'
 require 'krane/cli/krane'
 
 class KraneTest < KubernetesDeploy::TestCase
-  def test_version_prints_current_version
-    assert_output(/krane #{KubernetesDeploy::VERSION}/) { krane.version }
-  end
-
-  def test_version_success_as_black_box
-    out, err, status = krane_black_box("version")
+  def test_help_success_as_black_box
+    _, err, status = krane_black_box("help")
     assert_predicate(status, :success?)
     assert_empty(err)
-    assert_match(KubernetesDeploy::VERSION, out)
   end
 
-  def test_version_failure_as_black_box
-    out, err, status = krane_black_box("version", "-q")
-    assert_equal(status.exitstatus, 1)
-    assert_empty(out)
-    assert_match("ERROR", err)
+  def test_krane_success_as_black_box
+    _, err, status = krane_black_box("")
+    assert_predicate(status, :success?)
+    assert_empty(err)
   end
 
   private
-
-  def krane
-    Krane::CLI::Krane.new
-  end
 
   def krane_black_box(command, args = "")
     path = File.expand_path("../../../exe/krane", __FILE__)

--- a/test/exe/krane_test.rb
+++ b/test/exe/krane_test.rb
@@ -14,11 +14,4 @@ class KraneTest < KubernetesDeploy::TestCase
     assert_predicate(status, :success?)
     assert_empty(err)
   end
-
-  private
-
-  def krane_black_box(command, args = "")
-    path = File.expand_path("../../../exe/krane", __FILE__)
-    Open3.capture3("#{path} #{command} #{args}")
-  end
 end

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+
+class RestartTest < KubernetesDeploy::TestCase
+  def test_restart_prints_current_version
+    assert_output(/krane #{KubernetesDeploy::VERSION}/) { krane.restart }
+  end
+
+  def test_restart_success_as_black_box
+    out, err, status = krane_black_box("restart")
+    assert_predicate(status, :success?)
+    assert_empty(err)
+    assert_match(KubernetesDeploy::VERSION, out)
+  end
+
+  def test_restart_failure_as_black_box
+    out, err, status = krane_black_box("restart", "-q")
+    assert_equal(status.exitstatus, 1)
+    assert_empty(out)
+    assert_match("ERROR", err)
+  end
+
+  private
+
+  def krane
+    Krane::CLI::Krane.new
+  end
+
+  def krane_black_box(command, args = "")
+    path = File.expand_path("../../../exe/krane", __FILE__)
+    Open3.capture3("#{path} #{command} #{args}")
+  end
+end

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -19,7 +19,7 @@ class RestartTest < KubernetesDeploy::TestCase
     set_krane_restart_expecations(deployments: ['web'])
     krane_restart!(flags: '--deployments web')
     set_krane_restart_expecations(deployments: ['web', 'jobs'])
-    krane_restart!(flags: '--deployments web,jobs')
+    krane_restart!(flags: '--deployments web jobs')
   end
 
   def test_restart_parses_selector

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -3,15 +3,40 @@ require 'test_helper'
 require 'krane/cli/krane'
 
 class RestartTest < KubernetesDeploy::TestCase
-  def test_restart_prints_current_version
-    assert_output(/krane #{KubernetesDeploy::VERSION}/) { krane.restart }
+  def test_restart_with_default_options
+    set_krane_restart_expecations
+    krane_restart!
   end
 
-  def test_restart_success_as_black_box
-    out, err, status = krane_black_box("restart")
-    assert_predicate(status, :success?)
-    assert_empty(err)
-    assert_match(KubernetesDeploy::VERSION, out)
+  def test_restart_parses_global_timeout
+    set_krane_restart_expecations(new_args: { max_watch_seconds: 10 })
+    krane_restart!(flags: '--global-timeout 10s')
+    set_krane_restart_expecations(new_args: { max_watch_seconds: 60**2 })
+    krane_restart!(flags: '--global-timeout 1h')
+  end
+
+  def test_restart_passes_deployments_transparently
+    set_krane_restart_expecations(deployments: ['web'])
+    krane_restart!(flags: '--deployments web')
+    set_krane_restart_expecations(deployments: ['web', 'jobs'])
+    krane_restart!(flags: '--deployments web,jobs')
+  end
+
+  def test_restart_parses_selector
+    options = default_options
+    response = mock('RestartTask')
+    response.expects(:run!).returns(true).with(options[:deployments],
+      has_entries(selector: is_a(KubernetesDeploy::LabelSelector), verify_result: true))
+    KubernetesDeploy::RestartTask.expects(:new).with(options[:new_args]).returns(response)
+
+    krane_restart!(flags: '--selector name:web')
+  end
+
+  def test_restart_passes_verify_result
+    set_krane_restart_expecations(run_args: { verify_result: true })
+    krane_restart!(flags: '--verify-result true')
+    set_krane_restart_expecations(run_args: { verify_result: false })
+    krane_restart!(flags: '--verify-result false')
   end
 
   def test_restart_failure_as_black_box
@@ -23,12 +48,37 @@ class RestartTest < KubernetesDeploy::TestCase
 
   private
 
-  def krane
-    Krane::CLI::Krane.new
+  def set_krane_restart_expecations(new_args: {}, deployments: nil, run_args: {})
+    options = default_options(new_args, deployments, run_args)
+    response = mock('RestartTask')
+    response.expects(:run!).with(options[:deployments], options[:run_args]).returns(true)
+    KubernetesDeploy::RestartTask.expects(:new).with(options[:new_args]).returns(response)
   end
 
-  def krane_black_box(command, args = "")
-    path = File.expand_path("../../../exe/krane", __FILE__)
-    Open3.capture3("#{path} #{command} #{args}")
+  def krane_restart!(flags: '')
+    krane = Krane::CLI::Krane.new(
+      [restart_task_config.namespace, restart_task_config.context],
+      flags.split
+    )
+    krane.invoke("restart")
+  end
+
+  def restart_task_config
+    @restart_config ||= task_config(namespace: 'test-namespace')
+  end
+
+  def default_options(new_args = {}, deployments = nil, run_args = {})
+    {
+      new_args: {
+        namespace: restart_task_config.namespace,
+        context: restart_task_config.context,
+        max_watch_seconds: 300,
+      }.merge(new_args),
+      deployments: deployments,
+      run_args: {
+        selector: nil,
+        verify_result: true,
+      }.merge(run_args),
+    }
   end
 end

--- a/test/exe/version_test.rb
+++ b/test/exe/version_test.rb
@@ -26,9 +26,4 @@ class VersionTest < KubernetesDeploy::TestCase
   def krane
     Krane::CLI::Krane.new
   end
-
-  def krane_black_box(command, args = "")
-    path = File.expand_path("../../../exe/krane", __FILE__)
-    Open3.capture3("#{path} #{command} #{args}")
-  end
 end

--- a/test/exe/version_test.rb
+++ b/test/exe/version_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+
+class VersionTest < KubernetesDeploy::TestCase
+  def test_version_prints_current_version
+    assert_output(/krane #{KubernetesDeploy::VERSION}/) { krane.version }
+  end
+
+  def test_version_success_as_black_box
+    out, err, status = krane_black_box("version")
+    assert_predicate(status, :success?)
+    assert_empty(err)
+    assert_match(KubernetesDeploy::VERSION, out)
+  end
+
+  def test_version_failure_as_black_box
+    out, err, status = krane_black_box("version", "-q")
+    assert_equal(status.exitstatus, 1)
+    assert_empty(out)
+    assert_match("ERROR", err)
+  end
+
+  private
+
+  def krane
+    Krane::CLI::Krane.new
+  end
+
+  def krane_black_box(command, args = "")
+    path = File.expand_path("../../../exe/krane", __FILE__)
+    Open3.capture3("#{path} #{command} #{args}")
+  end
+end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'integration_test_helper'
+
+class KraneTest < KubernetesDeploy::IntegrationTest
+  def test_restart_black_box
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
+    refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
+    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
+
+    out, err, status = krane_black_box("restart", "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --deployments web")
+    assert_empty(out)
+    assert_match("Success", err)
+    assert_predicate(status, :success?)
+
+    assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
+    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
+  end
+
+  private
+
+  def fetch_restarted_at(deployment_name)
+    deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
+    containers = deployment.spec.template.spec.containers
+    app_container = containers.find { |c| c["name"] == "app" }
+    app_container&.env&.find { |n| n.name == "RESTARTED_AT" }
+  end
+end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -4,16 +4,16 @@ require 'integration_test_helper'
 class KraneTest < KubernetesDeploy::IntegrationTest
   def test_restart_black_box
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
-    refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
-    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
+    refute(fetch_restarted_at("web"), "RESTARTED_AT env on fresh deployment")
+    refute(fetch_restarted_at("redis"), "RESTARTED_AT env on fresh deployment")
 
     out, err, status = krane_black_box("restart", "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --deployments web")
     assert_empty(out)
     assert_match("Success", err)
     assert_predicate(status, :success?)
 
-    assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
-    refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
+    assert(fetch_restarted_at("web"), "no RESTARTED_AT env is present after the restart")
+    refute(fetch_restarted_at("redis"), "RESTARTED_AT env is present")
   end
 
   private

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -260,7 +260,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
     assert(fetch_restarted_at("web"), "RESTARTED_AT is present after the restart")
   end
 
-  def test_verify_result_false_succeds
+  def test_verify_result_false_succeeds
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
@@ -292,7 +292,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
       in_order: true)
   end
 
-  def test_verify_result_false_succeds_quickly_when_verification_would_timeout
+  def test_verify_result_false_succeeds_quickly_when_verification_would_timeout
     success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -223,6 +223,11 @@ module KubernetesDeploy
       KubernetesDeploy::TaskConfig.new(context, namespace, logger)
     end
 
+    def krane_black_box(command, args = "")
+      path = File.expand_path("../../exe/krane", __FILE__)
+      Open3.capture3("#{path} #{command} #{args}")
+    end
+
     private
 
     def log_to_real_fds?


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Add `krane restart` command

**How is this accomplished?**
- Add a new command to Krane. 
- Add the ability to skip verification phase of restart
- Update the restart command to use run/run!. Though I've kept aliases to the old method names for now.

**What could go wrong?**
We don't have enough testing or the test structure will have to be fixed going forward. 
This command doesn't support the `-f` flag yet, I'm waiting on a PR in Thor to merge. 

Are the banners helpful enough