### PR TITLE
render implicit yml multi doc file correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Make sure that we only declare a Service of type LoadBalancer as deployed after its IP address is published. [#547](https://github.com/Shopify/kubernetes-deploy/pull/547)
 
 
+*Bug Fixes*
+- Fix a bug in rendering where we failed to add a yaml doc separator (`---`) to
+  an implicit document if there are multiple documents in the file.
+  ([#551](https://github.com/Shopify/kubernetes-deploy/pull/551))
+
 *Other*
 - Kubernetes 1.10 is no longer officially supported as of this version ([#546](https://github.com/Shopify/kubernetes-deploy/pull/546))
 - We've added a new Krane cli. This code is in alpha. We are providing

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -69,10 +69,10 @@ module KubernetesDeploy
       @logger.info("Rendering #{file_basename}...")
       file_content = File.read(File.join(@template_dir, filename))
       rendered_content = @renderer.render_template(filename, file_content)
-      implicit = true
-      YAML.parse_stream(rendered_content, "<rendered> #{filename}") { |d| implicit = d.implicit }
+      implicit = []
+      YAML.parse_stream(rendered_content, "<rendered> #{filename}") { |d| implicit << d.implicit }
       if rendered_content.present?
-        stream.puts "---\n" if implicit
+        stream.puts "---\n" if implicit.first
         stream.puts rendered_content
         @logger.info("Rendered #{file_basename}")
       else

--- a/test/fixtures/partials/no-doc-separator.yml.erb
+++ b/test/fixtures/partials/no-doc-separator.yml.erb
@@ -1,0 +1,4 @@
+# The first doc has no yaml separator
+key1: foo
+---
+key2: bar

--- a/test/fixtures/partials/no-doc-seperator.yml.erb
+++ b/test/fixtures/partials/no-doc-seperator.yml.erb
@@ -1,2 +1,4 @@
 # This doc has no yaml seperator
 key1: foo
+---
+key2: bar

--- a/test/fixtures/partials/no-doc-seperator.yml.erb
+++ b/test/fixtures/partials/no-doc-seperator.yml.erb
@@ -1,4 +1,0 @@
-# This doc has no yaml seperator
-key1: foo
----
-key2: bar

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -269,8 +269,8 @@ class RenderTaskTest < KubernetesDeploy::TestCase
 
   def test_render_only_adds_initial_doc_seperator_when_missing
     render = build_render_task(fixture_path('partials'))
-    fixture = 'no-doc-seperator.yml.erb'
-    expected = "---\n# This doc has no yaml seperator\nkey1: foo\n---\nkey2: bar\n"
+    fixture = 'no-doc-separator.yml.erb'
+    expected = "---\n# The first doc has no yaml separator\nkey1: foo\n---\nkey2: bar\n"
 
     assert_render_success(render.run(mock_output_stream, [fixture, fixture]))
     stdout_assertion do |output|

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -270,11 +270,11 @@ class RenderTaskTest < KubernetesDeploy::TestCase
   def test_render_only_adds_initial_doc_seperator_when_missing
     render = build_render_task(fixture_path('partials'))
     fixture = 'no-doc-seperator.yml.erb'
-    expected = "---\n# This doc has no yaml seperator\nkey1: foo\n"
+    expected = "---\n# This doc has no yaml seperator\nkey1: foo\n---\nkey2: bar\n"
 
-    assert_render_success(render.run(mock_output_stream, [fixture]))
+    assert_render_success(render.run(mock_output_stream, [fixture, fixture]))
     stdout_assertion do |output|
-      assert_equal expected, output
+      assert_equal "#{expected}#{expected}", output
     end
 
     mock_output_stream.rewind


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix a bug where we fail to add `---` to an implicit document if there are multiple documents in the file. 

Fixes: https://github.com/Shopify/kubernetes-deploy/issues/513 

**How is this accomplished?**
Only test the implicitness of the first yaml doc in a file.

**What could go wrong?**
We start adding doc separators when we shouldn't and create empty docs. 
