### PR TITLE
Add --server-dry-run feature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Officially support Kubernetes 1.15 ([#546](https://github.com/Shopify/kubernetes-deploy/pull/546))
 - Make sure that we only declare a Service of type LoadBalancer as deployed after its IP address is published. [#547](https://github.com/Shopify/kubernetes-deploy/pull/547)
 - Add more validations to `RunnerTask`. [#554](https://github.com/Shopify/kubernetes-deploy/pull/554)
+- Validate secrets with `--server-dry-run` on supported clusters. [#553](https://github.com/Shopify/kubernetes-deploy/pull/553) 
 
 
 *Bug Fixes*

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -469,13 +469,17 @@ module KubernetesDeploy
       _, err, st = validate_with_dry_run_option(kubectl, "--dry-run")
       if st.success? && sensitive_template_content?
         _, err, st = validate_with_dry_run_option(kubectl, "--server-dry-run")
-        unless st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
-          @validation_errors << "Validation for #{id} failed. Detailed information is unavailable as the raw error may contain sensitive data."
+        if st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
+          return true
         end
       end
 
       return true if st.success?
-      @validation_errors << err
+      @validation_errors << if sensitive_template_content?
+        "Validation for #{id} failed. Detailed information is unavailable as the raw error may contain sensitive data."
+      else
+        err
+      end
     end
 
     def validate_with_dry_run_option(kubectl, dry_run_option)

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -37,6 +37,7 @@ module KubernetesDeploy
     TIMEOUT_OVERRIDE_ANNOTATION = "krane.shopify.io/#{TIMEOUT_OVERRIDE_ANNOTATION_SUFFIX}"
     LAST_APPLIED_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"
     SENSITIVE_TEMPLATE_CONTENT = false
+    SERVER_DRY_RUNNABLE = false
 
     class << self
       def build(namespace:, context:, definition:, logger:, statsd_tags:, crd: nil)
@@ -345,6 +346,10 @@ module KubernetesDeploy
       self.class::SENSITIVE_TEMPLATE_CONTENT
     end
 
+    def server_dry_runnable?
+      self.class::SERVER_DRY_RUNNABLE
+    end
+
     class Event
       EVENT_SEPARATOR = "ENDEVENT--BEGINEVENT"
       FIELD_SEPARATOR = "ENDFIELD--BEGINFIELD"
@@ -467,7 +472,7 @@ module KubernetesDeploy
 
     def validate_spec_with_kubectl(kubectl)
       _, err, st = validate_with_dry_run_option(kubectl, "--dry-run")
-      if st.success? && sensitive_template_content?
+      if st.success? && server_dry_runnable?
         _, err, st = validate_with_dry_run_option(kubectl, "--server-dry-run")
         if st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
           return true

--- a/lib/kubernetes-deploy/kubernetes_resource/secret.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/secret.rb
@@ -3,6 +3,7 @@ module KubernetesDeploy
   class Secret < KubernetesResource
     TIMEOUT = 30.seconds
     SENSITIVE_TEMPLATE_CONTENT = true
+    SERVER_DRY_RUNNABLE = true
 
     def status
       exists? ? "Available" : "Not Found"

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -504,10 +504,19 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_failure(result)
     refute_logs_match(%r{Kubectl err:.*something/invalid})
-    assert_logs_match_all([
-      "Command failed: apply -f",
-      /Invalid template: Deployment-web.*\.yml/,
-    ])
+
+    if server_dry_run_available?
+      assert_logs_match_all([
+        "Template validation failed",
+        /Invalid template: Deployment-web.*\.yml/,
+      ])
+    else
+      assert_logs_match_all([
+        "Command failed: apply -f",
+        /Invalid template: Deployment-web.*\.yml/,
+      ])
+    end
+
     refute_logs_match("kind: Deployment") # content of the sensitive template
   end
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -504,19 +504,10 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_failure(result)
     refute_logs_match(%r{Kubectl err:.*something/invalid})
-    expect_log = if server_dry_run_available?
-      [
-        "Template validation failed",
-        /Invalid template: Deployment-web.*\.yml/,
-        /Detailed information is unavailable as the raw error may contain sensitive data/,
-      ]
-    else
-      [
-        "Command failed: apply -f",
-        /Invalid template: Deployment-web.*\.yml/,
-      ]
-    end
-    assert_logs_match_all(expect_log)
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      /Invalid template: Deployment-web.*\.yml/,
+    ])
     refute_logs_match("kind: Deployment") # content of the sensitive template
   end
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -504,10 +504,19 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     end
     assert_deploy_failure(result)
     refute_logs_match(%r{Kubectl err:.*something/invalid})
-    assert_logs_match_all([
-      "Command failed: apply -f",
-      /Invalid template: Deployment-web.*\.yml/,
-    ])
+    expect_log = if server_dry_run_available?
+      [
+        "Template validation failed",
+        /Invalid template: Deployment-web.*\.yml/,
+        /Detailed information is unavailable as the raw error may contain sensitive data/,
+      ]
+    else
+      [
+        "Command failed: apply -f",
+        /Invalid template: Deployment-web.*\.yml/,
+      ]
+    end
+    assert_logs_match_all(expect_log)
     refute_logs_match("kind: Deployment") # content of the sensitive template
   end
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -505,17 +505,10 @@ class SerialDeployTest < KubernetesDeploy::IntegrationTest
     assert_deploy_failure(result)
     refute_logs_match(%r{Kubectl err:.*something/invalid})
 
-    if server_dry_run_available?
-      assert_logs_match_all([
-        "Template validation failed",
-        /Invalid template: Deployment-web.*\.yml/,
-      ])
-    else
-      assert_logs_match_all([
-        "Command failed: apply -f",
-        /Invalid template: Deployment-web.*\.yml/,
-      ])
-    end
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      /Invalid template: Deployment-web.*\.yml/,
+    ])
 
     refute_logs_match("kind: Deployment") # content of the sensitive template
   end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -36,7 +36,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     assert_logs_match(%r{ConfigMap/hello-cloud-configmap-data\s+Available}, 1)
   end
 
-  def test_unautomounted_service_account_predeployed_without_server_dry_run
+  def test_service_account_predeployed_before_unmanaged_pod
     # Add a valid service account in unmanaged pod
     service_account_name = "build-robot"
     result = deploy_fixtures("hello-cloud",
@@ -45,39 +45,16 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
       pod["spec"]["serviceAccountName"] = service_account_name
       pod["spec"]["automountServiceAccountToken"] = false
     end
-
-    unless server_dry_run_available?
-      # Expect the service account is deployed before the unmanaged pod
-      assert_deploy_success(result)
-      hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
-      hello_cloud.assert_configmap_data_present
-      hello_cloud.assert_all_service_accounts_up
-      hello_cloud.assert_unmanaged_pod_statuses("Succeeded", 1)
-      assert_logs_match_all([
-        %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
-        %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-.*},
-      ], in_order: true)
-    end
-  end
-
-  def test_unautomounted_service_account_deploy_fail_with_server_dry_run
-    service_account_name = "build-robot"
-    result = deploy_fixtures("hello-cloud",
-      subset: ["configmap-data.yml", "unmanaged-pod-1.yml.erb", "service-account.yml"]) do |fixtures|
-      pod = fixtures["unmanaged-pod-1.yml.erb"]["Pod"].first
-      pod["spec"]["serviceAccountName"] = service_account_name
-      pod["spec"]["automountServiceAccountToken"] = false
-    end
-
-    if server_dry_run_available?
-      assert_deploy_failure(result)
-      assert_logs_match_all([
-        "Template validation failed",
-        /Invalid template: Pod-unmanaged-pod-1/,
-        "> Error message:",
-        /pods "unmanaged-pod-1-.*" is forbidden: error looking up .*serviceaccount "build-robot" not found/,
-      ], in_order: true)
-    end
+    # Expect the service account is deployed before the unmanaged pod
+    assert_deploy_success(result)
+    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+    hello_cloud.assert_configmap_data_present
+    hello_cloud.assert_all_service_accounts_up
+    hello_cloud.assert_unmanaged_pod_statuses("Succeeded", 1)
+    assert_logs_match_all([
+      %r{Successfully deployed in \d.\ds: ServiceAccount/build-robot},
+      %r{Successfully deployed in \d+.\ds: Pod/unmanaged-pod-.*},
+    ], in_order: true)
   end
 
   def test_role_and_role_binding_predeployed_before_unmanaged_pod
@@ -352,35 +329,21 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     end
 
     assert_deploy_failure(result)
-    expect_log = if server_dry_run_available?
-      [
-        "Template validation failed",
-        /Invalid template: Deployment-web.*\.yml/,
-        "> Error message:",
-        '    The Deployment "web" is invalid:',
-        'spec.template.spec.containers[0].ports[0].name: Invalid value: "http_test_is_really_long_and_invalid_chars"',
-        /Invalid template: Service-web.*\.yml/,
-        "> Error message:",
-        '    The Service "web" is invalid:',
-        'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"',
-      ]
-    else
-      [
-        "Command failed: apply -f",
-        "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
-        /Invalid template: Deployment-web.*\.yml/,
-        "> Error message:",
-        /Error from server \(Invalid\): error when creating.*Deployment\.?\w* "web" is invalid/,
-        "> Template content:",
-        "              name: http_test_is_really_long_and_invalid_chars",
-        /Invalid template: Service-web.*\.yml/,
-        "> Error message:",
-        /Error from server \(Invalid\): error when creating.*Service "web" is invalid/,
-        "> Template content:",
-        "        targetPort: http_test_is_really_long_and_invalid_chars",
-      ]
-    end
-    assert_logs_match_all(expect_log, in_order: true)
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      /Invalid template: Deployment-web.*\.yml/,
+      "> Error message:",
+      /Error from server \(Invalid\): error when creating.*Deployment\.?\w* "web" is invalid/,
+      "> Template content:",
+      "              name: http_test_is_really_long_and_invalid_chars",
+
+      /Invalid template: Service-web.*\.yml/,
+      "> Error message:",
+      /Error from server \(Invalid\): error when creating.*Service "web" is invalid/,
+      "> Template content:",
+      "        targetPort: http_test_is_really_long_and_invalid_chars",
+    ], in_order: true)
   end
 
   def test_invalid_k8s_spec_that_is_valid_yaml_but_has_no_template_path_in_error_prints_helpful_message
@@ -389,23 +352,13 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       svc["spec"]["ports"].first["targetPort"] = "http_test_is_really_long_and_invalid_chars"
     end
     assert_deploy_failure(result)
-    expected_log = if server_dry_run_available?
-      [
-        "Template validation failed",
-        /Invalid template: Service-web/,
-        "> Error message:",
-      ]
-    else
-      [
-        "Command failed: apply -f",
-        "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
-        "Unidentified error(s):",
-      ]
-    end
-    expected_log += ['    The Service "web" is invalid:',
-                     'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"']
-
-    assert_logs_match_all(expected_log, in_order: true)
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      "Unidentified error(s):",
+      '    The Service "web" is invalid:',
+      'spec.ports[0].targetPort: Invalid value: "http_test_is_really_long_and_invalid_chars"',
+    ], in_order: true)
   end
 
   def test_output_of_failed_unmanaged_pod
@@ -714,26 +667,24 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     refute_logs_match("sidecar must exit 0") # this container is ready
 
     # Debug info for missing volume timeout
-    expect_log = [
+    assert_logs_match_all([
       %r{Deployment/missing-volumes: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
       /Latest ReplicaSet: missing-volumes-\w+/,
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
-    ]
-    expect_log << /FailedMount.*secrets? "catphotoscom" not found/ unless server_dry_run_available?
-    assert_logs_match_all(expect_log, in_order: true)
+      /FailedMount.*secrets? "catphotoscom" not found/, # event
+    ], in_order: true)
 
     # Debug info for failure
-    expect_log = [
+    assert_logs_match_all([
       "Deployment/init-crash: FAILED",
       /Latest ReplicaSet: init-crash-\w+/,
       "The following containers are in a state that is unlikely to be recoverable:",
       "init-crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
+      "Scaled up replica set init-crash-", # event
       "this is a log from the crashing init container",
-    ]
-    expect_log.insert(-2, "Scaled up replica set init-crash-") unless server_dry_run_available?
-    assert_logs_match_all(expect_log, in_order: true)
+    ], in_order: true)
 
     # Excludes noisy events
     refute_logs_match(/Started container with id/)
@@ -791,22 +742,12 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     end
     assert_deploy_failure(result)
 
-    expect_log = if server_dry_run_available?
-      [
-        "Template validation failed",
-        /Invalid template: Deployment-web.*\.yml/,
-        "> Error message:",
-        /The Deployment "web" is invalid.*`selector` does not match template `labels`/,
-      ]
-    else
-      [
-        "Command failed: apply -f",
-        "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
-        "Unidentified error(s):",
-        /The Deployment "web" is invalid.*`selector` does not match template `labels`/,
-      ]
-    end
-    assert_logs_match_all(expect_log, in_order: true)
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      "WARNING: Any resources not mentioned in the error(s) below were likely created/updated.",
+      "Unidentified error(s):",
+      /The Deployment "web" is invalid.*`selector` does not match template `labels`/,
+    ], in_order: true)
   end
 
   def test_scale_existing_deployment_down_to_zero
@@ -1107,15 +1048,16 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   def test_bad_container_on_daemon_sets_fails
     assert_deploy_failure(deploy_fixtures("invalid", subset: ["crash_loop_daemon_set.yml"]))
     num_ds = expected_daemonset_pod_count
-    expect_log = [
+    assert_logs_match_all([
       "Failed to deploy 1 resource",
       "DaemonSet/crash-loop: FAILED",
       "crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: #{num_ds} updatedNumberScheduled, #{num_ds} desiredNumberScheduled, 0 numberReady",
+      "Events (common success events excluded):",
+      "BackOff: Back-off restarting failed container",
       "Logs from container 'crash-loop-back-off':",
       "this is a log from the crashing container",
-    ]
-    assert_logs_match_all(expect_log, in_order: true)
+    ], in_order: true)
   end
 
   def test_bad_container_on_stateful_sets_fails_with_rolling_update
@@ -1128,18 +1070,15 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     end
 
     assert_deploy_failure(result)
-    expect_log = [
+    assert_logs_match_all([
       "Successfully deployed 1 resource and failed to deploy 1 resource",
       "StatefulSet/stateful-busybox: FAILED",
       "app: Crashing repeatedly (exit 1). See logs for more information.",
+      "Events (common success events excluded):",
+      %r{\[Pod/stateful-busybox-\d\]\tBackOff: Back-off restarting failed container},
       "Logs from container 'app':",
       "ls: /not-a-dir: No such file or directory",
-    ]
-    unless server_dry_run_available?
-      expect_log.insert(-3, "Events (common success events excluded):",
-        %r{\[Pod/stateful-busybox-\d\]\tBackOff: Back-off restarting failed container})
-    end
-    assert_logs_match_all(expect_log, in_order: true)
+    ], in_order: true)
   end
 
   def test_on_delete_stateful_sets_are_not_monitored
@@ -1170,7 +1109,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   def test_resource_quotas_are_deployed_first
     result = deploy_fixtures("resource-quota")
     assert_deploy_failure(result, :timed_out)
-    expect_log = [
+    assert_logs_match_all([
       "Predeploying priority resources",
       "Deploying ResourceQuota/resource-quotas (timeout: 30s)",
       "Deployment/web rollout timed out",
@@ -1179,9 +1118,8 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "ResourceQuota/resource-quotas",
       %r{Deployment/web: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
-    ]
-    expect_log << "failed quota: resource-quotas" unless server_dry_run_available?
-    assert_logs_match_all(expect_log, in_order: true)
+      "failed quota: resource-quotas", # from an event
+    ], in_order: true)
 
     rqs = kubeclient.get_resource_quotas(namespace: @namespace)
     assert_equal(1, rqs.length)
@@ -1321,16 +1259,13 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     end
 
     assert_deploy_failure(fixtures)
-    expect_log = [
+    assert_logs_match_all([
       "Deploying Job/hello-job (timeout: 600s)",
       "Result: FAILURE",
       "Job/hello-job: FAILED",
       "Final status: Failed",
-    ]
-    unless server_dry_run_available?
-      expect_log << /DeadlineExceeded.*Job was active longer than specified deadline/
-    end
-    assert_logs_match_all(expect_log)
+      %r{\[Job/hello-job\]\tDeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)},
+    ])
   end
 
   def test_resource_watcher_reports_failed_after_timeout

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -36,6 +36,15 @@ module KubernetesDeploy
       _kubectl.server_version
     end
 
+    def server_dry_run_available?
+      @server_dry_run ||= begin
+        file_path = "#{fixture_path('hello-cloud')}/service-account.yml"
+        command = ["apply", "-f", file_path, "--server-dry-run", "--output=name"]
+        _, _, st = _kubectl.run(*command, log_failure: false, attempts: 3)
+        st.success?
+      end
+    end
+
     def _kubectl
       @_kubectl ||= KubernetesDeploy::Kubectl.new(namespace: "default", context: TEST_CONTEXT, logger: logger,
         log_failure_by_default: true, default_timeout: '5s')

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -37,12 +37,7 @@ module KubernetesDeploy
     end
 
     def server_dry_run_available?
-      @server_dry_run ||= begin
-        file_path = "#{fixture_path('hello-cloud')}/service-account.yml"
-        command = ["apply", "-f", file_path, "--server-dry-run", "--output=name"]
-        _, _, st = _kubectl.run(*command, log_failure: false, attempts: 3)
-        st.success?
-      end
+      kube_server_version >= Gem::Version.new('1.13')
     end
 
     def _kubectl

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -114,13 +114,13 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def stub_server_dry_run_validation_request
     stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
-     resp: dummy_secret_hash, json: false,
-     kwargs: {
-       log_failure: false,
-       output_is_sensitive: true,
-       retry_whitelist: [:client_timeout],
-       attempts: 3,
-     })
+      resp: dummy_secret_hash, json: false,
+      kwargs: {
+        log_failure: false,
+        output_is_sensitive: true,
+        retry_whitelist: [:client_timeout],
+        attempts: 3,
+      })
   end
 
   def correct_ejson_key_secret_data

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   def test_resources_based_on_ejson_file_existence
     stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
+    stub_server_dry_run_validation_request.times(3)
     assert_empty(build_provisioner(fixture_path('hello-cloud')).resources)
     refute_empty(build_provisioner(fixture_path('ejson-cloud')).resources)
   end
@@ -18,6 +19,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def test_resource_is_built_correctly
     stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
+    stub_server_dry_run_validation_request.times(3)
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
     refute_empty(resources)
 
@@ -78,6 +80,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def test_proactively_validates_resulting_resources_and_raises_without_logging
     stub_dry_run_validation_request
+    stub_server_dry_run_validation_request
     KubernetesDeploy::Secret.any_instance.expects(:validation_failed?).returns(true)
     msg = "Generation of Kubernetes secrets from ejson failed: Resulting resource Secret/catphotoscom failed validation"
     assert_raises_message(KubernetesDeploy::EjsonSecretError, msg) do
@@ -88,6 +91,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
 
   def test_run_with_selector_does_not_raise_exception
     stub_dry_run_validation_request.times(3) # there are three secrets in the ejson
+    stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
     provisioner = build_provisioner(
       fixture_path('ejson-cloud'),
       selector: KubernetesDeploy::LabelSelector.new("app" => "yay")
@@ -98,7 +102,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   private
 
   def stub_dry_run_validation_request
-    stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
+    stub_kubectl_response("apply", "-f", anything, "--dry-run", "--output=name",
       resp: dummy_secret_hash, json: false,
       kwargs: {
         log_failure: false,
@@ -106,6 +110,17 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
         retry_whitelist: [:client_timeout],
         attempts: 3,
       })
+  end
+
+  def stub_server_dry_run_validation_request
+    stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
+     resp: dummy_secret_hash, json: false,
+     kwargs: {
+       log_failure: false,
+       output_is_sensitive: true,
+       retry_whitelist: [:client_timeout],
+       attempts: 3,
+     })
   end
 
   def correct_ejson_key_secret_data

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -98,7 +98,8 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
   private
 
   def stub_dry_run_validation_request
-    stub_kubectl_response("create", "-f", anything, "--dry-run", "--output=name", resp: dummy_secret_hash, json: false,
+    stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
+      resp: dummy_secret_hash, json: false,
       kwargs: {
         log_failure: false,
         output_is_sensitive: true,

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -187,7 +187,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'bad', use_deprecated: true),
       replica_sets: []
     )
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -201,7 +201,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_fails_with_invalid_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: 'bad'), replica_sets: [])
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -215,7 +215,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_with_percent_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: '10%'), replica_sets: [])
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
     assert(deploy.validate_definition(kubectl))
@@ -227,7 +227,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: '10', use_deprecated: true),
       replica_sets: []
     )
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
 
@@ -241,7 +241,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_with_number_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: '10'), replica_sets: [])
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
 
@@ -258,7 +258,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: 'Recreate', use_deprecated: true),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -275,7 +275,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: 'Recreate'),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -292,7 +292,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: nil),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('create', '-f', anything, '--dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
     assert(deploy.validate_definition(kubectl))

--- a/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/deployment_test.rb
@@ -187,7 +187,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'bad', use_deprecated: true),
       replica_sets: []
     )
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -201,7 +201,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_fails_with_invalid_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: 'bad'), replica_sets: [])
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -215,7 +215,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_with_percent_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: '10%'), replica_sets: [])
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
     assert(deploy.validate_definition(kubectl))
@@ -227,7 +227,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: '10', use_deprecated: true),
       replica_sets: []
     )
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
 
@@ -241,7 +241,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
 
   def test_validation_with_number_rollout_annotation
     deploy = build_synced_deployment(template: build_deployment_template(rollout: '10'), replica_sets: [])
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
 
@@ -258,7 +258,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: 'Recreate', use_deprecated: true),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -275,7 +275,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: 'Recreate'),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "super failed", SystemExit.new(1)]
     )
     refute(deploy.validate_definition(kubectl))
@@ -292,7 +292,7 @@ class DeploymentTest < KubernetesDeploy::TestCase
       template: build_deployment_template(rollout: 'maxUnavailable', strategy: nil),
       replica_sets: [build_rs_template]
     )
-    kubectl.expects(:run).with('apply', '-f', anything, '--server-dry-run', '--output=name', anything).returns(
+    kubectl.expects(:run).with('apply', '-f', anything, '--dry-run', '--output=name', anything).returns(
       ["", "", SystemExit.new(0)]
     )
     assert(deploy.validate_definition(kubectl))

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -40,6 +40,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
   class DummySensitiveResource < DummyResource
     SENSITIVE_TEMPLATE_CONTENT = true
+    SERVER_DRY_RUNNABLE = true
   end
 
   def test_unusual_timeout_output


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Work on: https://github.com/Shopify/kubernetes-deploy/issues/484
Make Krane use `--server-dry-run` during template validation phrase. 

The `--dry-run` we use before, the validation is only processed on client side, some failure during actual `apply` step cannot be captured, since `apply` happens in kubernetes server side.
The `--server-dry-run` will hit the server and tell us about the result of apply,  while not actually persisting it. 

Details about [--server-dry-run](https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run).

`--server-dry-run` was released in version [v1.12](https://github.com/kubernetes/kubernetes/blob/33541bdd34c32ad1dbef20a1282d7917b300d952/CHANGELOG-1.12.md#new-features).
while enabled as beta feature in version [v1.13](https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run).

In current stage, we attempt to apply server dry on to resources with sensitive content. This is because when some failure happen at deploy stage, logs info will be omitted if any of the template content is sensitive. Those validation failure should be caught during template validation, so try to run `--server-dry-run` if possible.  
 
**How is this accomplished?**
Add an overridable property `SERVER_DRY_RUNNABLE` to kubernetes-resource, default to be false. Make it true, if we would like to try `--server-dry-run` on that type of resource.

Breaks a number of tests.
- For unit tests, make it test against version above v1.13
- For integration tests, they are compatible with all supported versions

**What could go wrong?**
try to 🎩 as much as possible, may still miss some.
