### PR TITLE
Krane Render & make render task work with template_paths

### DIFF
--- a/lib/enumerable/with_delayed_exceptions.rb
+++ b/lib/enumerable/with_delayed_exceptions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Enumerable
+  def with_delayed_exceptions(*catch, &block)
+    exceptions = []
+    each do |i|
+      begin
+        block.call(i)
+      rescue *catch => e
+        exceptions << e
+      end
+    end.tap { raise exceptions.first if exceptions.first }
+  end
+end

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -22,7 +22,9 @@ module Krane
       desc("render", "Render templates")
       expand_options(RenderCommand::OPTIONS)
       def render
-        RenderCommand.from_options(options)
+        rescue_and_exit do
+          RenderCommand.from_options(options)
+        end
       end
 
       desc("version", "Prints the version")

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -5,6 +5,7 @@ require 'thor'
 require 'krane/cli/version_command'
 require 'krane/cli/restart_command'
 require 'krane/cli/run_command'
+require 'krane/cli/render_command'
 
 module Krane
   module CLI
@@ -16,6 +17,12 @@ module Krane
 
       def self.expand_options(task_options)
         task_options.each { |option_name, config| method_option(option_name, config) }
+      end
+
+      desc("render", "Render templates")
+      expand_options(RenderCommand::OPTIONS)
+      def render
+        RenderCommand.from_options(options)
       end
 
       desc("version", "Prints the version")

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class RenderCommand
+      OPTIONS = {
+        bindings: { type: :array, desc: 'Bindings for erb' },
+        f: { type: :array, required: true, desc: 'Directories and files to render' },
+      }
+
+      def self.from_options(options)
+        require 'kubernetes-deploy/render_task'
+        require 'kubernetes-deploy/template_sets'
+        require 'kubernetes-deploy/bindings_parser'
+        require 'kubernetes-deploy/options_helper'
+
+        bindings_parser = KubernetesDeploy::BindingsParser.new
+        options[:bindings]&.each { |b| bindings_parser.add(b) }
+
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths(options[:f]) do |paths|
+          runner = KubernetesDeploy::RenderTask.new(
+            current_sha: ENV["REVISION"],
+            template_paths: paths,
+            bindings: bindings_parser.parse,
+          )
+          runner.run(STDOUT)
+        end
+      end
+    end
+  end
+end

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -23,7 +23,7 @@ module Krane
             template_paths: paths,
             bindings: bindings_parser.parse,
           )
-          runner.run(STDOUT)
+          runner.run!(STDOUT)
         end
       end
     end

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -5,19 +5,18 @@ module Krane
     class RenderCommand
       OPTIONS = {
         bindings: { type: :array, desc: 'Bindings for erb' },
-        f: { type: :array, required: true, desc: 'Directories and files to render' },
+        filenames: { type: :array, required: true, aliases: 'f', desc: 'Directories and files to render' },
       }
 
       def self.from_options(options)
         require 'kubernetes-deploy/render_task'
-        require 'kubernetes-deploy/template_sets'
         require 'kubernetes-deploy/bindings_parser'
         require 'kubernetes-deploy/options_helper'
 
         bindings_parser = KubernetesDeploy::BindingsParser.new
         options[:bindings]&.each { |b| bindings_parser.add(b) }
 
-        KubernetesDeploy::OptionsHelper.with_processed_template_paths(options[:f]) do |paths|
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths(options[:filenames]) do |paths|
           runner = KubernetesDeploy::RenderTask.new(
             current_sha: ENV["REVISION"],
             template_paths: paths,

--- a/lib/kubernetes-deploy/delayed_exceptions.rb
+++ b/lib/kubernetes-deploy/delayed_exceptions.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module Enumerable
-  def with_delayed_exceptions(*catch, &block)
+module DelayedExceptions
+  def with_delayed_exceptions(enumerable, *catch, &block)
     exceptions = []
-    each do |i|
+    enumerable.each do |i|
       begin
         block.call(i)
       rescue *catch => e

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -55,24 +55,18 @@ module KubernetesDeploy
     end
 
     def render_templates(stream, template_sets)
-      exceptions = []
       @logger.phase_heading("Rendering template(s)")
       count = 0
-      begin
-        template_sets.with_resource_definitions_and_filename(render_erb: true,
-            current_sha: @current_sha, bindings: @bindings, raw: true) do |rendered_content, filename|
-          render_filename(rendered_content, filename, stream)
-          count += 1
-        end
-      rescue KubernetesDeploy::InvalidTemplateError => exception
-        exceptions << exception
-        log_invalid_template(exception)
+      template_sets.with_resource_definitions_and_filename(render_erb: true,
+          current_sha: @current_sha, bindings: @bindings, raw: true) do |rendered_content, filename|
+        render_filename(rendered_content, filename, stream)
+        count += 1
       end
 
-      unless exceptions.empty?
-        raise exceptions[0]
-      end
       count
+    rescue KubernetesDeploy::InvalidTemplateError => exception
+      log_invalid_template(exception)
+      raise
     end
 
     def render_filename(rendered_content, filename, stream)

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -59,7 +59,7 @@ module KubernetesDeploy
       count = 0
       template_sets.with_resource_definitions_and_filename(render_erb: true,
           current_sha: @current_sha, bindings: @bindings, raw: true) do |rendered_content, filename|
-        render_filename(rendered_content, filename, stream)
+        write_to_stream(rendered_content, filename, stream)
         count += 1
       end
 
@@ -69,7 +69,7 @@ module KubernetesDeploy
       raise
     end
 
-    def render_filename(rendered_content, filename, stream)
+    def write_to_stream(rendered_content, filename, stream)
       file_basename = File.basename(filename)
       @logger.info("Rendering #{file_basename}...")
       implicit = []

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -90,6 +90,8 @@ module KubernetesDeploy
       errors = []
       if @template_dir.present? && @template_paths.present?
         errors << "template_dir and template_paths can not be combined"
+      elsif @template_dir.blank? && @template_paths.blank?
+        errors << "template_dir or template_paths must be set"
       end
 
       if filenames.present?

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -5,32 +5,35 @@ require 'krane/cli/krane'
 class RendertTest < KubernetesDeploy::TestCase
   include EnvTestHelper
   def test_render_with_default_options
-    install_krane_render_expecations
+    install_krane_render_expectations
     krane_render!
   end
 
   def test_render_parses_paths
     paths = "/dev/null /dev/yes /dev/no"
-    install_krane_render_expecations(template_paths: paths.split)
+    install_krane_render_expectations(template_paths: paths.split)
     krane_render!("-f #{paths}")
+
+    install_krane_render_expectations(template_paths: paths.split)
+    krane_render!("--filenames #{paths}")
   end
 
   def test_render_parses_bindings
-    install_krane_render_expecations(bindings: { "foo" => "1", "bar" => "2" })
+    install_krane_render_expectations(bindings: { "foo" => "1", "bar" => "2" })
     krane_render!("-f /dev/null --bindings foo=1,bar=2")
   end
 
   def test_render_uses_current_sha
     test_sha = "TEST"
     with_env("REVISION", test_sha) do
-      install_krane_render_expecations
+      install_krane_render_expectations
       krane_render!
     end
   end
 
   private
 
-  def install_krane_render_expecations(new_args = {})
+  def install_krane_render_expectations(new_args = {})
     options = default_options(new_args)
     response = mock('RenderTask')
     response.expects(:run!).with(STDOUT).returns(true)

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+
+class RendertTest < KubernetesDeploy::TestCase
+  include EnvTestHelper
+  def test_render_with_default_options
+    install_krane_render_expecations
+    krane_render!
+  end
+
+  def test_render_parses_paths
+    paths = "/dev/null /dev/yes /dev/no"
+    install_krane_render_expecations(template_paths: paths.split)
+    krane_render!("-f #{paths}")
+  end
+
+  def test_render_parses_bindings
+    install_krane_render_expecations(bindings: { "foo" => "1", "bar" => "2" })
+    krane_render!("-f /dev/null --bindings foo=1,bar=2")
+  end
+
+  def test_render_uses_current_sha
+    test_sha = "TEST"
+    with_env("REVISION", test_sha) do
+      install_krane_render_expecations
+      krane_render!
+    end
+  end
+
+  private
+
+  def install_krane_render_expecations(new_args = {})
+    options = default_options(new_args)
+    response = mock('RenderTask')
+    response.expects(:run!).with(STDOUT).returns(true)
+    KubernetesDeploy::RenderTask.expects(:new).with(options).returns(response)
+  end
+
+  def krane_render!(flags = '-f /dev/null')
+    krane = Krane::CLI::Krane.new(
+      [],
+      flags.split
+    )
+    krane.invoke("render")
+  end
+
+  def default_options(new_args = {})
+    {
+      current_sha: ENV["REVISION"],
+      template_paths: ["/dev/null"],
+      bindings: {},
+    }.merge(new_args)
+  end
+end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -28,6 +28,34 @@ class KraneTest < KubernetesDeploy::IntegrationTest
     assert_equal(1, task_runner_pods.count)
   end
 
+  def test_render_black_box
+    # Ordered so that template requiring bindings comes first
+    paths = ["test/fixtures/test-partials/partials/independent-configmap.yml.erb",
+             "test/fixtures/hello-cloud/web.yml.erb"]
+    data_value = rand(10_000).to_s
+    bindings = "data=#{data_value}"
+    test_sha = rand(10_000).to_s
+
+    out, err, status = nil
+    with_env("REVISION", test_sha) do
+      out, err, status = krane_black_box("render", "-f #{paths.join(' ')} --bindings #{bindings}")
+    end
+
+    assert_predicate(status, :success?)
+    assert_match("Success", err)
+    assert_match(test_sha, out)
+    assert_match(data_value, out)
+
+    with_env("REVISION", test_sha) do
+      out, err, status = krane_black_box("render", "-f #{paths.join(' ')}")
+    end
+
+    refute_predicate(status, :success?)
+    assert_match("FAILURE", err)
+    refute_match(data_value, out)
+    assert_match(test_sha, out)
+  end
+
   private
 
   def task_runner_pods

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -2,6 +2,8 @@
 require 'integration_test_helper'
 
 class KraneTest < KubernetesDeploy::IntegrationTest
+  include EnvTestHelper
+
   def test_restart_black_box
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
     refute(fetch_restarted_at("web"), "RESTARTED_AT env on fresh deployment")

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -318,6 +318,65 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     assert_logs_match("Rendered effectively_empty.yml.erb successfully, but the result was blank")
   end
 
+  def test_render_task_template_paths_xor_templae_dir
+    render = KubernetesDeploy::RenderTask.new(
+      logger: logger,
+      current_sha: "k#{SecureRandom.hex(6)}",
+      bindings: {},
+      template_dir: fixture_path('collection-with-erb'),
+      template_paths: [fixture_path('collection-with-erb')]
+    )
+
+    assert_render_failure(render.run(mock_output_stream))
+    assert_logs_match_all([
+      "template_dir and template_paths can not be combined",
+    ], in_order: true)
+
+    render = KubernetesDeploy::RenderTask.new(
+      logger: logger,
+      current_sha: "k#{SecureRandom.hex(6)}",
+      bindings: {},
+    )
+
+    assert_render_failure(render.run(mock_output_stream))
+    assert_logs_match_all([
+      "template_dir or template_paths must be set",
+    ], in_order: true)
+  end
+
+  def test_render_task_invalid_filenames_with_template_paths
+    render = build_render_task_with_template_paths(fixture_path('collection-with-erb'))
+
+    assert_render_failure(render.run(mock_output_stream, ['blah']))
+    assert_logs_match_all([
+      "template_dir must be set to use filenames",
+    ], in_order: true)
+  end
+
+  def test_render_task_with_template_paths
+    render = build_render_task_with_template_paths(
+      File.join(fixture_path('hello-cloud'), 'configmap-data.yml')
+    )
+
+    assert_render_success(render.run(mock_output_stream))
+
+    stdout_assertion do |output|
+      assert_equal output, <<~RENDERED
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: hello-cloud-configmap-data
+          labels:
+            name: hello-cloud-configmap-data
+            app: hello-cloud
+        data:
+          datapoint1: value1
+          datapoint2: value2
+      RENDERED
+    end
+  end
+
   private
 
   def build_render_task(template_dir, bindings = {})
@@ -326,6 +385,15 @@ class RenderTaskTest < KubernetesDeploy::TestCase
       current_sha: "k#{SecureRandom.hex(6)}",
       bindings: bindings,
       template_dir: template_dir
+    )
+  end
+
+  def build_render_task_with_template_paths(template_paths, bindings = {})
+    KubernetesDeploy::RenderTask.new(
+      logger: logger,
+      current_sha: "k#{SecureRandom.hex(6)}",
+      bindings: bindings,
+      template_paths: Array(template_paths)
     )
   end
 

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -318,7 +318,7 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     assert_logs_match("Rendered effectively_empty.yml.erb successfully, but the result was blank")
   end
 
-  def test_render_task_template_paths_xor_templae_dir
+  def test_render_task_template_paths_xor_template_dir
     render = KubernetesDeploy::RenderTask.new(
       logger: logger,
       current_sha: "k#{SecureRandom.hex(6)}",

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -223,7 +223,7 @@ class RenderTaskTest < KubernetesDeploy::TestCase
 
     assert_render_failure(render.run(mock_output_stream, ["../"]))
     assert_logs_match_all([
-      %r{test/fixtures" is not a file},
+      "is outside the template directory, which was resolved as",
     ])
   end
 
@@ -237,11 +237,12 @@ class RenderTaskTest < KubernetesDeploy::TestCase
   end
 
   def test_render_empty_template_dir
-    render = build_render_task(Dir.mktmpdir)
+    tmp_dir = Dir.mktmpdir
+    render = build_render_task(tmp_dir)
 
     assert_render_failure(render.run(mock_output_stream))
     assert_logs_match_all([
-      /no templates found in template dir/,
+      "Template directory #{tmp_dir} does not contain any valid templates",
     ])
   end
 

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -341,7 +341,7 @@ class RenderTaskTest < KubernetesDeploy::TestCase
     assert_render_failure(render.run(mock_output_stream))
     assert_logs_match_all([
       "template_dir or template_paths must be set",
-    ], in_order: true)
+    ])
   end
 
   def test_render_task_invalid_filenames_with_template_paths


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
As part of the Krane 1.0 work render task will render from for multiple dirs. This requires the render task to make use of TemplateSets.

**How is this accomplished?**
I've attempted to make this backwards compatible so the first step was hooking up the render_task to TemplateSets.

This also required some slight modification of TemplateSet (and passing of args down to it). The biggest one is that when a rendering error occurs its not raised until all other templates have been processed. 

**What could go wrong?**
I need to add tests to show the new behavior.
