### PR TITLE
Krane Deploy CLI

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -11,16 +11,16 @@ module Krane
       )
       OPTIONS = {
         "bindings" => { type: :array, banner: "foo=bar abc=def",
-                        desc: "Expose additional variables to ERB templates (format: k1=v1,k2=v2, JSON string or file "\
+                        desc: "Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file "\
                           "(JSON or YAML) path prefixed by '@')" },
         "filenames" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
-                         desc: "Path to a file that contains the configuration to apply" },
+                         desc: "Path to file or directory that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
                               desc: "Max duration to monitor workloads correctly deployed" },
-        "protected-namespaces" => { type: :string, banner: "list,of,namespaces",
+        "protected-namespaces" => { type: :array, banner: "namespace1 namespace2 namespaceN",
                                     desc: "Enable deploys to a list of selected namespaces; set to an empty string "\
                                       "to disable",
-                                    default: PROTECTED_NAMESPACES.join(',') },
+                                    default: PROTECTED_NAMESPACES },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that do not appear in the template dir",
                      default: true },
         "render-erb" => { type: :boolean, desc: "Enable ERB rendering", default: false },
@@ -46,10 +46,9 @@ module Krane
         logger = KubernetesDeploy::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])
 
-        protected_namespaces = if %w('' "").include?(options['protected-namespaces'])
-          []
-        else
-          options['protected-namespaces'].split(',')
+        protected_namespaces = options['protected-namespaces']
+        if options['protected-namespaces'].size == 1 && %w('' "").include?(options['protected-namespaces'][0])
+          protected_namespaces = []
         end
 
         KubernetesDeploy::OptionsHelper.with_processed_template_paths([options[:filenames]],

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -23,6 +23,7 @@ module Krane
                                     default: PROTECTED_NAMESPACES.join(',') },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that do not appear in the template dir",
                      default: true },
+        "render-erb" => { type: :boolean, desc: "Enable ERB rendering", default: false },
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class DeployCommand
+      DEFAULT_DEPLOY_TIMEOUT = '300s'
+      PROTECTED_NAMESPACES = %w(
+        default
+        kube-system
+        kube-public
+      )
+      OPTIONS = {
+        "bindings" => { type: :array, banner: "foo=bar,abc=def",
+                        desc: "Expose additional variables to ERB templates (format: k1=v1,k2=v2, JSON string or file "\
+                          "(JSON or YAML) path prefixed by '@')" },
+        "filename" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f,
+                        desc: "Path to a file that contains the configuration to apply" },
+        "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
+                              desc: "Max duration to monitor workloads correctly restarted" },
+        "protected-namespaces" => { type: :string, banner: "list,of,namespaces",
+                                    desc: "Enable deploys to a list of selected namespaces; set to an empty string "\
+                                      "to disable",
+                                    default: PROTECTED_NAMESPACES.join(',') },
+        "prune" => { type: :boolean, desc: "Enable deletion of resources that do not appear in the template dir",
+                     default: true },
+        "selector" => { type: :string, banner: "'label=value'",
+                        desc: "Select workloads by selector(s)" },
+        "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
+                                  default: true },
+        "verify-result" => { type: :boolean, default: true,
+                             desc: "Verify workloads correctly restarted" },
+      }
+
+      def self.from_options(namespace, context, options)
+        require 'kubernetes-deploy/deploy_task'
+        require 'kubernetes-deploy/options_helper'
+        require 'kubernetes-deploy/bindings_parser'
+        require 'kubernetes-deploy/label_selector'
+
+        bindings_parser = KubernetesDeploy::BindingsParser.new
+        options[:bindings]&.each { |binding_pair| bindings_parser.add(binding_pair) }
+
+        selector = KubernetesDeploy::LabelSelector.parse(options[:selector]) if options[:selector]
+
+        logger = KubernetesDeploy::FormattedLogger.build(namespace, context,
+          verbose_prefix: options['verbose-log-prefix'])
+
+        protected_namespaces = if %w('' "").include?(options['protected-namespaces'])
+          []
+        else
+          options['protected-namespaces'].split(',')
+        end
+
+        template_paths = []
+        template_paths << options[:filename] if options[:filename]
+
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths(template_paths, krane_cli: true) do |paths|
+          deploy = KubernetesDeploy::DeployTask.new(
+            namespace: namespace,
+            context: context,
+            current_sha: ENV["REVISION"],
+            template_paths: paths,
+            bindings: bindings_parser.parse,
+            logger: logger,
+            max_watch_seconds: KubernetesDeploy::DurationParser.new(options["global-timeout"]).parse!.to_i,
+            selector: selector,
+            protected_namespaces: protected_namespaces,
+          )
+
+          deploy.run!(
+            verify_result: options["verify-result"],
+            allow_protected_ns: !protected_namespaces.empty?,
+            prune: options[:prune]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -10,13 +10,13 @@ module Krane
         kube-public
       )
       OPTIONS = {
-        "bindings" => { type: :array, banner: "foo=bar,abc=def",
+        "bindings" => { type: :array, banner: "foo=bar abc=def",
                         desc: "Expose additional variables to ERB templates (format: k1=v1,k2=v2, JSON string or file "\
                           "(JSON or YAML) path prefixed by '@')" },
-        "filename" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f,
-                        desc: "Path to a file that contains the configuration to apply" },
+        "filenames" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
+                         desc: "Path to a file that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
-                              desc: "Max duration to monitor workloads correctly restarted" },
+                              desc: "Max duration to monitor workloads correctly deployed" },
         "protected-namespaces" => { type: :string, banner: "list,of,namespaces",
                                     desc: "Enable deploys to a list of selected namespaces; set to an empty string "\
                                       "to disable",
@@ -28,7 +28,7 @@ module Krane
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: true },
         "verify-result" => { type: :boolean, default: true,
-                             desc: "Verify workloads correctly restarted" },
+                             desc: "Verify workloads correctly deployed" },
       }
 
       def self.from_options(namespace, context, options)
@@ -51,10 +51,8 @@ module Krane
           options['protected-namespaces'].split(',')
         end
 
-        template_paths = []
-        template_paths << options[:filename] if options[:filename]
-
-        KubernetesDeploy::OptionsHelper.with_processed_template_paths(template_paths, krane_cli: true) do |paths|
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths([options[:filenames]],
+          require_explicit_path: true) do |paths|
           deploy = KubernetesDeploy::DeployTask.new(
             namespace: namespace,
             context: context,

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -6,6 +6,7 @@ require 'krane/cli/version_command'
 require 'krane/cli/restart_command'
 require 'krane/cli/run_command'
 require 'krane/cli/render_command'
+require 'krane/cli/deploy_command'
 
 module Krane
   module CLI
@@ -46,6 +47,14 @@ module Krane
       def run_command(namespace, context)
         rescue_and_exit do
           RunCommand.from_options(namespace, context, options)
+        end
+      end
+
+      desc("deploy NAMESPACE CONTEXT", "Apply a configuration to a resource or set of resources")
+      expand_options(DeployCommand::OPTIONS)
+      def deploy(namespace, context)
+        rescue_and_exit do
+          DeployCommand.from_options(namespace, context, options)
         end
       end
 

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -50,7 +50,7 @@ module Krane
         end
       end
 
-      desc("deploy NAMESPACE CONTEXT", "Apply a configuration to a resource or set of resources")
+      desc("deploy NAMESPACE CONTEXT", "Ship resources to a namespace")
       expand_options(DeployCommand::OPTIONS)
       def deploy(namespace, context)
         rescue_and_exit do

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -105,7 +105,8 @@ module KubernetesDeploy
     end
 
     def initialize(namespace:, context:, current_sha:, logger: nil, kubectl_instance: nil, bindings: {},
-      max_watch_seconds: nil, selector: nil, template_paths: [], template_dir: nil, protected_namespaces: nil)
+      max_watch_seconds: nil, selector: nil, template_paths: [], template_dir: nil, protected_namespaces: nil,
+      render_erb: true)
       template_dir = File.expand_path(template_dir) if template_dir
       template_paths = (template_paths.map { |path| File.expand_path(path) } << template_dir).compact
 
@@ -121,6 +122,7 @@ module KubernetesDeploy
       @max_watch_seconds = max_watch_seconds
       @selector = selector
       @protected_namespaces = protected_namespaces || PROTECTED_NAMESPACES
+      @render_erb = render_erb
     end
 
     def run(*args)
@@ -284,7 +286,7 @@ module KubernetesDeploy
       @logger.info("Discovering resources:")
       resources = []
       crds_by_kind = cluster_resource_discoverer.crds.group_by(&:kind)
-      @template_sets.with_resource_definitions(render_erb: true,
+      @template_sets.with_resource_definitions(render_erb: @render_erb,
           current_sha: @current_sha, bindings: @bindings) do |r_def|
         crd = crds_by_kind[r_def["kind"]]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -105,7 +105,7 @@ module KubernetesDeploy
     end
 
     def initialize(namespace:, context:, current_sha:, logger: nil, kubectl_instance: nil, bindings: {},
-      max_watch_seconds: nil, selector: nil, template_paths: [], template_dir: nil)
+      max_watch_seconds: nil, selector: nil, template_paths: [], template_dir: nil, protected_namespaces: nil)
       template_dir = File.expand_path(template_dir) if template_dir
       template_paths = (template_paths.map { |path| File.expand_path(path) } << template_dir).compact
 
@@ -120,6 +120,7 @@ module KubernetesDeploy
       @kubectl = kubectl_instance
       @max_watch_seconds = max_watch_seconds
       @selector = selector
+      @protected_namespaces = protected_namespaces || PROTECTED_NAMESPACES
     end
 
     def run(*args)
@@ -147,7 +148,7 @@ module KubernetesDeploy
       end
 
       @logger.phase_heading("Deploying all resources")
-      if PROTECTED_NAMESPACES.include?(@namespace) && prune
+      if @protected_namespaces.include?(@namespace) && prune
         raise FatalDeploymentError, "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
       end
 
@@ -334,7 +335,7 @@ module KubernetesDeploy
 
       if @namespace.blank?
         errors << "Namespace must be specified"
-      elsif PROTECTED_NAMESPACES.include?(@namespace)
+      elsif @protected_namespaces.include?(@namespace)
         if allow_protected_ns && prune
           errors << "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
         elsif allow_protected_ns

--- a/lib/kubernetes-deploy/options_helper.rb
+++ b/lib/kubernetes-deploy/options_helper.rb
@@ -6,9 +6,9 @@ module KubernetesDeploy
 
     STDIN_TEMP_FILE = "from_stdin.yml.erb"
     class << self
-      def with_processed_template_paths(template_paths, krane_cli: false)
+      def with_processed_template_paths(template_paths, require_explicit_path: false)
         validated_paths = []
-        if template_paths.empty? && !krane_cli
+        if template_paths.empty? && !require_explicit_path
           validated_paths << default_template_dir
         else
           template_paths.uniq!

--- a/lib/kubernetes-deploy/options_helper.rb
+++ b/lib/kubernetes-deploy/options_helper.rb
@@ -6,9 +6,9 @@ module KubernetesDeploy
 
     STDIN_TEMP_FILE = "from_stdin.yml.erb"
     class << self
-      def with_processed_template_paths(template_paths)
+      def with_processed_template_paths(template_paths, krane_cli: false)
         validated_paths = []
-        if template_paths.empty?
+        if template_paths.empty? && !krane_cli
           validated_paths << default_template_dir
         else
           template_paths.uniq!

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -74,6 +74,16 @@ class DeployTest < KubernetesDeploy::TestCase
     krane_deploy!(flags: '--filenames /my/other/file/path')
   end
 
+  def test_deploy_fails_without_filename
+    krane = Krane::CLI::Krane.new(
+      [deploy_task_config.namespace, deploy_task_config.context],
+      []
+    )
+    assert_raises_message(Thor::RequiredArgumentMissingError, "No value provided for required options '--filenames'") do
+      krane.invoke("deploy")
+    end
+  end
+
   private
 
   def set_krane_deploy_expectations(new_args: {}, run_args: {})

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+
+class DeployTest < KubernetesDeploy::TestCase
+  def test_deploy_with_default_options
+    set_krane_deploy_expectations
+    krane_deploy!
+  end
+
+  def test_deploy_parses_global_timeout
+    set_krane_deploy_expectations(new_args: { max_watch_seconds: 10 })
+    krane_deploy!(flags: '--global-timeout 10s')
+    set_krane_deploy_expectations(new_args: { max_watch_seconds: 60**2 })
+    krane_deploy!(flags: '--global-timeout 1h')
+  end
+
+  def test_deploy_parses_selector
+    selector = KubernetesDeploy::LabelSelector.new('name' => 'web')
+    KubernetesDeploy::LabelSelector.expects(:parse).returns(selector)
+    set_krane_deploy_expectations(new_args: { selector: selector })
+    krane_deploy!(flags: '--selector name:web')
+  end
+
+  def test_deploy_parses_bindings
+    # FIXME: this require is only needed intermittently
+    require 'kubernetes-deploy/bindings_parser'
+    bindings_parser = KubernetesDeploy::BindingsParser.new
+    bindings_parser.expects(:add).with('foo=bar')
+    bindings_parser.expects(:add).with('abc=def')
+    bindings_parser.expects(:parse).returns(true)
+    KubernetesDeploy::BindingsParser.expects(:new).returns(bindings_parser)
+    set_krane_deploy_expectations(new_args: { bindings: true })
+    krane_deploy!(flags: '--bindings foo=bar abc=def')
+  end
+
+  def test_deploy_passes_verify_result
+    set_krane_deploy_expectations(run_args: { verify_result: true })
+    krane_deploy!(flags: '--verify-result true')
+    set_krane_deploy_expectations(run_args: { verify_result: false })
+    krane_deploy!(flags: '--verify-result false')
+  end
+
+  def test_deploy_passes_prune
+    set_krane_deploy_expectations(run_args: { prune: true })
+    krane_deploy!
+    set_krane_deploy_expectations(run_args: { prune: false })
+    krane_deploy!(flags: '--no-prune')
+  end
+
+  def test_deploy_passes_protected_namespaces
+    default_namespaces = %w(default kube-system kube-public)
+    set_krane_deploy_expectations(new_args: { protected_namespaces: default_namespaces },
+      run_args: { allow_protected_ns: true })
+    krane_deploy!
+
+    set_krane_deploy_expectations(new_args: { protected_namespaces: ['foo', 'bar'] },
+      run_args: { allow_protected_ns: true })
+    krane_deploy!(flags: '--protected-namespaces foo,bar')
+
+    set_krane_deploy_expectations(new_args: { protected_namespaces: [] },
+      run_args: { allow_protected_ns: false })
+    krane_deploy!(flags: "--protected-namespaces=")
+
+    set_krane_deploy_expectations(new_args: { protected_namespaces: [] },
+      run_args: { allow_protected_ns: false })
+    krane_deploy!(flags: "--protected-namespaces=''")
+  end
+
+  def test_deploy_passes_filename
+    set_krane_deploy_expectations(new_args: { template_paths: ['/my/file/path'] })
+    krane_deploy!(flags: '-f /my/file/path')
+    set_krane_deploy_expectations(new_args: { template_paths: ['/my/other/file/path'] })
+    krane_deploy!(flags: '--filename /my/other/file/path')
+  end
+
+  private
+
+  def set_krane_deploy_expectations(new_args: {}, run_args: {})
+    options = default_options(new_args, run_args)
+    KubernetesDeploy::FormattedLogger.expects(:build).returns(logger)
+    response = mock('DeployTask')
+    response.expects(:run!).with(options[:run_args]).returns(true)
+    KubernetesDeploy::DeployTask.expects(:new).with(options[:new_args]).returns(response)
+  end
+
+  def krane_deploy!(flags: '')
+    flags += ' -f /tmp' unless flags.include?('-f')
+    krane = Krane::CLI::Krane.new(
+      [deploy_task_config.namespace, deploy_task_config.context],
+      flags.split
+    )
+    krane.invoke("deploy")
+  end
+
+  def deploy_task_config
+    @deploy_config ||= task_config(namespace: 'test-namespace')
+  end
+
+  def default_options(new_args = {}, run_args = {})
+    {
+      new_args: {
+        namespace: deploy_task_config.namespace,
+        context: deploy_task_config.context,
+        current_sha: nil,
+        template_paths: ['/tmp'],
+        bindings: {},
+        logger: logger,
+        max_watch_seconds: 300,
+        selector: nil,
+        protected_namespaces: ["default", "kube-system", "kube-public"],
+      }.merge(new_args),
+      run_args: {
+        verify_result: true,
+        allow_protected_ns: true,
+        prune: true,
+      }.merge(run_args),
+    }
+  end
+end

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -71,7 +71,7 @@ class DeployTest < KubernetesDeploy::TestCase
     set_krane_deploy_expectations(new_args: { template_paths: ['/my/file/path'] })
     krane_deploy!(flags: '-f /my/file/path')
     set_krane_deploy_expectations(new_args: { template_paths: ['/my/other/file/path'] })
-    krane_deploy!(flags: '--filename /my/other/file/path')
+    krane_deploy!(flags: '--filenames /my/other/file/path')
   end
 
   private

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 require 'krane/cli/krane'
+require 'kubernetes-deploy/bindings_parser'
 
 class DeployTest < KubernetesDeploy::TestCase
   def test_deploy_with_default_options
@@ -23,8 +24,6 @@ class DeployTest < KubernetesDeploy::TestCase
   end
 
   def test_deploy_parses_bindings
-    # FIXME: this require is only needed intermittently
-    require 'kubernetes-deploy/bindings_parser'
     bindings_parser = KubernetesDeploy::BindingsParser.new
     bindings_parser.expects(:add).with('foo=bar')
     bindings_parser.expects(:add).with('abc=def')

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -55,11 +55,7 @@ class DeployTest < KubernetesDeploy::TestCase
 
     set_krane_deploy_expectations(new_args: { protected_namespaces: ['foo', 'bar'] },
       run_args: { allow_protected_ns: true })
-    krane_deploy!(flags: '--protected-namespaces foo,bar')
-
-    set_krane_deploy_expectations(new_args: { protected_namespaces: [] },
-      run_args: { allow_protected_ns: false })
-    krane_deploy!(flags: "--protected-namespaces=")
+    krane_deploy!(flags: '--protected-namespaces foo bar')
 
     set_krane_deploy_expectations(new_args: { protected_namespaces: [] },
       run_args: { allow_protected_ns: false })

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -61,7 +61,8 @@ module FixtureDeployHelper
   end
 
   def deploy_dirs_without_profiling(dirs, wait: true, allow_protected_ns: false, prune: true, bindings: {},
-    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil)
+    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
+    protected_namespaces: nil)
     kubectl_instance ||= build_kubectl
 
     deploy = KubernetesDeploy::DeployTask.new(
@@ -74,6 +75,7 @@ module FixtureDeployHelper
       bindings: bindings,
       max_watch_seconds: max_watch_seconds,
       selector: selector,
+      protected_namespaces: protected_namespaces,
     )
     deploy.run(
       verify_result: wait,
@@ -95,6 +97,14 @@ module FixtureDeployHelper
       deploy_result
     else
       deploy_dirs_without_profiling(dirs, args)
+    end
+  end
+
+  def setup_template_dir(set, subset: nil)
+    fixtures = load_fixtures(set, subset)
+    Dir.mktmpdir("fixture_dir") do |target_dir|
+      write_fixtures_to_dir(fixtures, target_dir)
+      yield target_dir if block_given?
     end
   end
 

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -62,7 +62,7 @@ module FixtureDeployHelper
 
   def deploy_dirs_without_profiling(dirs, wait: true, allow_protected_ns: false, prune: true, bindings: {},
     sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
-    protected_namespaces: nil)
+    protected_namespaces: nil, render_erb: true)
     kubectl_instance ||= build_kubectl
 
     deploy = KubernetesDeploy::DeployTask.new(
@@ -76,6 +76,7 @@ module FixtureDeployHelper
       max_watch_seconds: max_watch_seconds,
       selector: selector,
       protected_namespaces: protected_namespaces,
+      render_erb: render_erb,
     )
     deploy.run(
       verify_result: wait,

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -59,8 +59,9 @@ class KraneTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_deploy_black_box
-    setup_template_dir("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]) do |target_dir|
-      out, err, status = krane_black_box("deploy", "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} -f #{target_dir}")
+    setup_template_dir("hello-cloud") do |target_dir|
+      flags = "-f #{target_dir} --render-erb --bindings deployment_id=1 current_sha=123"
+      out, err, status = krane_black_box("deploy", "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} #{flags}")
       assert_empty(out)
       assert_match("Success", err)
       assert_predicate(status, :success?)

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -58,6 +58,15 @@ class KraneTest < KubernetesDeploy::IntegrationTest
     assert_match(test_sha, out)
   end
 
+  def test_deploy_black_box
+    setup_template_dir("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]) do |target_dir|
+      out, err, status = krane_black_box("deploy", "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} -f #{target_dir}")
+      assert_empty(out)
+      assert_match("Success", err)
+      assert_predicate(status, :success?)
+    end
+  end
+
   private
 
   def task_runner_pods

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -194,6 +194,15 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
     @namespace = generated_ns
   end
 
+  def test_deploy_succeeds_with_specific_protected_namespaces
+    generated_ns = @namespace
+    @namespace = 'default' # this should fail if we use the default options for protected namespaces
+    protected_namespaces = %w(kube-system kube-public)
+    assert_deploy_success(deploy_fixtures("hello-cloud", prune: true, protected_namespaces: protected_namespaces))
+  ensure
+    @namespace = generated_ns
+  end
+
   def test_refuses_deploy_to_protected_namespace_without_override
     generated_ns = @namespace
     @namespace = 'default'

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1584,6 +1584,15 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     ], in_order: true)
   end
 
+  def test_fail_erb_templates_if_rendering_is_disabled
+    result = deploy_fixtures("hello-cloud", subset: ["unmanaged-pod-1.yml.erb"], render_erb: false)
+    # Expect that deploy will fail due to the ERB tags in this template
+    assert_deploy_failure(result)
+    assert_logs_match_all([
+      'Name: "unmanaged-pod-1-<%= deployment_id %>"',
+    ], in_order: true)
+  end
+
   private
 
   def expected_daemonset_pod_count


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Add `krane deploy` command using the design [proposed here](https://docs.google.com/document/d/1oInUsKplYGNWTymPY48xtDCx3x4Cwc-phcEKUkt2v4U/view#).

Related to https://github.com/Shopify/kubernetes-deploy/issues/532.

**How is this accomplished?**

- Add new command to Krane.
- Add the ability to specify a list of protected namespaces.

**What could go wrong?**

- Not enough test coverage for all combinations of command line options?
- Not sure if the help messages are clear enough.

**:tophat:ing examples**

Help message:

```bash
$ bundle exec krane help deploy
Usage:
  krane deploy NAMESPACE CONTEXT f, --filenames=/tmp/my-resource.yml

Options:
      [--bindings=foo=bar abc=def]                               # Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')
  f, --filenames=/tmp/my-resource.yml                            # Path to file or directory that contains the configuration to apply
      [--global-timeout=duration]                                # Max duration to monitor workloads correctly deployed
                                                                 # Default: 300s
      [--protected-namespaces=namespace1 namespace2 namespaceN]  # Enable deploys to a list of selected namespaces; set to an empty string to disable
                                                                 # Default: ["default", "kube-system", "kube-public"]
      [--prune], [--no-prune]                                    # Enable deletion of resources that do not appear in the template dir
                                                                 # Default: true
      [--render-erb], [--no-render-erb]                          # Enable ERB rendering
      [--selector='label=value']                                 # Select workloads by selector(s)
      [--verbose-log-prefix], [--no-verbose-log-prefix]          # Add [context][namespace] to the log prefix
                                                                 # Default: true
      [--verify-result], [--no-verify-result]                    # Verify workloads correctly deployed
                                                                 # Default: true

Ship resources to a namespace
```

Specifying a directory with `-f`:

```bash
$ bundle exec krane deploy dirceu-test-krane-deploy remote-cluster -f ~/Desktop
[INFO][2019-09-18 12:57:03 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:57:03 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-18 12:57:03 -0400][remote-cluster][dirceu-test-krane-deploy]     Context remote-cluster found
[INFO][2019-09-18 12:57:03 -0400][remote-cluster][dirceu-test-krane-deploy]     Namespace dirceu-test-krane-deploy found
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]     All required parameters and files are present
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]     Discovering resources:
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]       - Service/standard
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]       - Service/non-standard
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]       - Deployment/standard-1
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]       - Service/from-another-file
[INFO][2019-09-18 12:57:04 -0400][remote-cluster][dirceu-test-krane-deploy]       - Deployment/standard-2
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     ----------------------------Phase 2: Checking initial resource statuses-----------------------------
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-1                             Not Found
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-2                             Not Found
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/from-another-file                         Not found
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/non-standard                              Not found
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/standard                                  Not found
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     ----------------------------------Phase 3: Deploying all resources----------------------------------
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     Deploying resources:
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     - Deployment/standard-1 (timeout: 420s)
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     - Deployment/standard-2 (timeout: 420s)
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     - Service/from-another-file (timeout: 420s)
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     - Service/non-standard (timeout: 420s)
[INFO][2019-09-18 12:57:05 -0400][remote-cluster][dirceu-test-krane-deploy]     - Service/standard (timeout: 420s)
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Successfully deployed in 5.6s: Deployment/standard-1, Deployment/standard-2, Service/from-another-file, Service/non-standard, Service/standard
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------------Result: SUCCESS-------------------------------------------
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Successfully deployed 5 resources
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Successful resources
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-1                             0 replicas
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-2                             0 replicas
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/from-another-file                         Doesn't require any endpoints
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/non-standard                              Doesn't require any endpoints
[INFO][2019-09-18 12:57:11 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/standard                                  Doesn't require any endpoints
```

Specifying a single file with `-f`:

```bash
$ bundle exec krane deploy dirceu-test-krane-deploy remote-cluster -f ~/Desktop/another-one.yml 
[INFO][2019-09-18 12:58:46 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:58:46 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-18 12:58:46 -0400][remote-cluster][dirceu-test-krane-deploy]     Context remote-cluster found
[INFO][2019-09-18 12:58:46 -0400][remote-cluster][dirceu-test-krane-deploy]     Namespace dirceu-test-krane-deploy found
[INFO][2019-09-18 12:58:47 -0400][remote-cluster][dirceu-test-krane-deploy]     All required parameters and files are present
[INFO][2019-09-18 12:58:47 -0400][remote-cluster][dirceu-test-krane-deploy]     Discovering resources:
[INFO][2019-09-18 12:58:47 -0400][remote-cluster][dirceu-test-krane-deploy]       - Service/from-another-file
[INFO][2019-09-18 12:58:47 -0400][remote-cluster][dirceu-test-krane-deploy]       - Deployment/standard-2
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     ----------------------------Phase 2: Checking initial resource statuses-----------------------------
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-2                             Not Found
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/from-another-file                         Not found
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     ----------------------------------Phase 3: Deploying all resources----------------------------------
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     Deploying resources:
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     - Deployment/standard-2 (timeout: 420s)
[INFO][2019-09-18 12:58:48 -0400][remote-cluster][dirceu-test-krane-deploy]     - Service/from-another-file (timeout: 420s)
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     Successfully deployed in 4.8s: Deployment/standard-2, Service/from-another-file
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------------Result: SUCCESS-------------------------------------------
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     Successfully deployed 2 resources
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     Successful resources
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     Deployment/standard-2                             0 replicas
[INFO][2019-09-18 12:58:53 -0400][remote-cluster][dirceu-test-krane-deploy]     Service/from-another-file                         Doesn't require any endpoints
```

Using a selector that's not present in all resources:

```bash
$ bundle exec krane deploy dirceu-test-krane-deploy remote-cluster -f ~/Desktop/another-one.yml --selector type=standard-2
[INFO][2019-09-18 13:01:33 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 13:01:33 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-18 13:01:33 -0400][remote-cluster][dirceu-test-krane-deploy]     Context remote-cluster found
[INFO][2019-09-18 13:01:33 -0400][remote-cluster][dirceu-test-krane-deploy]     Namespace dirceu-test-krane-deploy found
[INFO][2019-09-18 13:01:34 -0400][remote-cluster][dirceu-test-krane-deploy]     Using resource selector type=standard-2
[INFO][2019-09-18 13:01:34 -0400][remote-cluster][dirceu-test-krane-deploy]     All required parameters and files are present
[INFO][2019-09-18 13:01:34 -0400][remote-cluster][dirceu-test-krane-deploy]     Discovering resources:
[INFO][2019-09-18 13:01:34 -0400][remote-cluster][dirceu-test-krane-deploy]       - Service/from-another-file
[INFO][2019-09-18 13:01:34 -0400][remote-cluster][dirceu-test-krane-deploy]       - Deployment/standard-2
[INFO][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]
[INFO][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]     ------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]    Template validation failed
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]    Invalid template: Service-from-another-file20190918-50751-f79xq8.yml
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]    > Error message:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        selector type=standard-2 does not match label type=standard
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]    > Template content:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        ---
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        apiVersion: v1
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        kind: Service
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        metadata:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]          name: from-another-file
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]          labels:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]            type: standard
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]        spec:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]          selector:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]            type: standard
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]          ports:
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]          - protocol: TCP
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]            port: 80
[FATAL][2019-09-18 13:01:35 -0400][remote-cluster][dirceu-test-krane-deploy]            targetPort: 9376
```

Protected namespaces:

```bash
$ bundle exec krane deploy default minikube -f ~/Desktop/another-one.yml                                                          
[INFO][2019-09-18 13:18:32 -0400][minikube][default]
[INFO][2019-09-18 13:18:32 -0400][minikube][default]    ------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-18 13:18:32 -0400][minikube][default]
[INFO][2019-09-18 13:18:33 -0400][minikube][default]    ------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2019-09-18 13:18:33 -0400][minikube][default]   Configuration invalid
[FATAL][2019-09-18 13:18:33 -0400][minikube][default]
[FATAL][2019-09-18 13:18:33 -0400][minikube][default]   - Refusing to deploy to protected namespace 'default' with pruning enabled
```

```bash
$ bundle exec krane deploy default minikube -f ~/Desktop/another-one.yml --no-prune                                               
[INFO][2019-09-18 13:18:41 -0400][minikube][default]
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    ------------------------------------Phase 1: Initializing deploy------------------------------------
[WARN][2019-09-18 13:18:41 -0400][minikube][default]    You're deploying to protected namespace default, which cannot be pruned.
[WARN][2019-09-18 13:18:41 -0400][minikube][default]    Existing resources can only be removed manually with kubectl. Removing templates from the set deployed will have no effect.
[WARN][2019-09-18 13:18:41 -0400][minikube][default]    ***Please do not deploy to default unless you really know what you are doing.***
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Context minikube found
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Namespace default found
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    All required parameters and files are present
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Discovering resources:
[INFO][2019-09-18 13:18:41 -0400][minikube][default]      - Service/from-another-file
[INFO][2019-09-18 13:18:41 -0400][minikube][default]      - Deployment/standard-2
[INFO][2019-09-18 13:18:41 -0400][minikube][default]
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    ----------------------------Phase 2: Checking initial resource statuses-----------------------------
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Deployment/standard-2                             Not Found
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Service/from-another-file                         Not found
[INFO][2019-09-18 13:18:41 -0400][minikube][default]
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    ----------------------------------Phase 3: Deploying all resources----------------------------------
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    Deploying resources:
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    - Deployment/standard-2 (timeout: 420s)
[INFO][2019-09-18 13:18:41 -0400][minikube][default]    - Service/from-another-file (timeout: 420s)
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    Successfully deployed in 0.4s: Deployment/standard-2, Service/from-another-file
[INFO][2019-09-18 13:18:42 -0400][minikube][default]
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    ------------------------------------------Result: SUCCESS-------------------------------------------
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    Successfully deployed 2 resources
[INFO][2019-09-18 13:18:42 -0400][minikube][default]
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    Successful resources
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    Deployment/standard-2                             0 replicas
[INFO][2019-09-18 13:18:42 -0400][minikube][default]    Service/from-another-file                         Doesn't require any endpoints
```

```bash
bundle exec krane deploy default minikube -f ~/Desktop/another-one.yml --protected-namespaces=kube-system,kube-public           
[INFO][2019-09-18 13:19:02 -0400][minikube][default]
[INFO][2019-09-18 13:19:02 -0400][minikube][default]    ------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2019-09-18 13:19:02 -0400][minikube][default]    Context minikube found
[INFO][2019-09-18 13:19:02 -0400][minikube][default]    Namespace default found
[INFO][2019-09-18 13:19:02 -0400][minikube][default]    All required parameters and files are present
[INFO][2019-09-18 13:19:02 -0400][minikube][default]    Discovering resources:
[INFO][2019-09-18 13:19:03 -0400][minikube][default]      - Service/from-another-file
[INFO][2019-09-18 13:19:03 -0400][minikube][default]      - Deployment/standard-2
[INFO][2019-09-18 13:19:03 -0400][minikube][default]
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    ----------------------------Phase 2: Checking initial resource statuses-----------------------------
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    Deployment/standard-2                             0 replicas
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    Service/from-another-file                         Doesn't require any endpoints
[INFO][2019-09-18 13:19:03 -0400][minikube][default]
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    ----------------------------------Phase 3: Deploying all resources----------------------------------
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    Deploying resources:
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    - Deployment/standard-2 (progress deadline: 600s)
[INFO][2019-09-18 13:19:03 -0400][minikube][default]    - Service/from-another-file (timeout: 420s)
[INFO][2019-09-18 13:19:05 -0400][minikube][default]    Successfully deployed in 2.2s: Deployment/standard-2, Service/from-another-file
[INFO][2019-09-18 13:19:05 -0400][minikube][default]
[INFO][2019-09-18 13:19:05 -0400][minikube][default]    ------------------------------------------Result: SUCCESS-------------------------------------------
[INFO][2019-09-18 13:19:05 -0400][minikube][default]    Successfully deployed 2 resources
[INFO][2019-09-18 13:19:05 -0400][minikube][default]
[INFO][2019-09-18 13:19:05 -0400][minikube][default]    Successful resources
[INFO][2019-09-18 13:19:05 -0400][minikube][default]    Deployment/standard-2                             0 replicas
```