### PR TITLE
Add krane run command

### DIFF
--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -4,6 +4,7 @@ require 'krane'
 require 'thor'
 require 'krane/cli/version_command'
 require 'krane/cli/restart_command'
+require 'krane/cli/run_command'
 
 module Krane
   module CLI
@@ -28,6 +29,14 @@ module Krane
       def restart(namespace, context)
         rescue_and_exit do
           RestartCommand.from_options(namespace, context, options)
+        end
+      end
+
+      desc("run NAMESPACE CONTEXT", "Run a pod that exits upon completing a task")
+      expand_options(RunCommand::OPTIONS)
+      def run_command(namespace, context)
+        rescue_and_exit do
+          RunCommand.from_options(namespace, context, options)
         end
       end
 

--- a/lib/krane/cli/run_command.rb
+++ b/lib/krane/cli/run_command.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class RunCommand
+      DEFAULT_RUN_TIMEOUT = '300s'
+
+      OPTIONS = {
+        "global-timeout" => {
+          type: :string,
+          banner: "duration",
+          desc: "Timeout error is raised if the pod runs for longer than the specified number of seconds",
+          default: DEFAULT_RUN_TIMEOUT,
+        },
+        "arguments" => {
+          type: :string,
+          banner: '"ARG1 ARG2 ARG3"',
+          desc: "Override the default arguments for the command with a space-separated list of arguments",
+        },
+        "verify-result" => { type: :boolean, desc: "Wait for completion and verify pod success", default: true },
+        "command" => { type: :array, desc: "Override the default command in the container image" },
+        "template" => {
+          type: :string,
+          desc: "The template file you'll be rendering",
+          default: 'task-runner-template',
+        },
+        "env-vars" => {
+          type: :string,
+          banner: "VAR=val,FOO=bar",
+          desc: "A Comma-separated list of env vars",
+          default: '',
+        },
+      }
+
+      def self.from_options(namespace, context, options)
+        require "kubernetes-deploy/runner_task"
+        runner = KubernetesDeploy::RunnerTask.new(
+          namespace: namespace,
+          context: context,
+          max_watch_seconds: KubernetesDeploy::DurationParser.new(options["global-timeout"]).parse!.to_i,
+        )
+
+        runner.run!(
+          verify_result: options['verify-result'],
+          task_template: options['template'],
+          entrypoint: options['command'],
+          args: options['arguments']&.split(" "),
+          env_vars: options['env-vars'].split(','),
+        )
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -154,8 +154,8 @@ module KubernetesDeploy
         raise TaskConfigurationError, message
       end
 
-      container.command = entrypoint
-      container.args = args
+      container.command = entrypoint if entrypoint
+      container.args = args if args
 
       env_args = env_vars.map do |env|
         key, value = env.split('=', 2)

--- a/lib/kubernetes-deploy/runner_task_config_validator.rb
+++ b/lib/kubernetes-deploy/runner_task_config_validator.rb
@@ -5,16 +5,10 @@ module KubernetesDeploy
       super(*arguments)
       @template = template
       @args = args
-      @validations += %i(validate_template validate_args)
+      @validations += %i(validate_template)
     end
 
     private
-
-    def validate_args
-      if @args.blank?
-        @errors << "Args can't be nil"
-      end
-    end
 
     def validate_template
       if @template.blank?

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -4,21 +4,21 @@ require 'krane/cli/krane'
 
 class RestartTest < KubernetesDeploy::TestCase
   def test_restart_with_default_options
-    set_krane_restart_expecations
+    set_krane_restart_expectations
     krane_restart!
   end
 
   def test_restart_parses_global_timeout
-    set_krane_restart_expecations(new_args: { max_watch_seconds: 10 })
+    set_krane_restart_expectations(new_args: { max_watch_seconds: 10 })
     krane_restart!(flags: '--global-timeout 10s')
-    set_krane_restart_expecations(new_args: { max_watch_seconds: 60**2 })
+    set_krane_restart_expectations(new_args: { max_watch_seconds: 60**2 })
     krane_restart!(flags: '--global-timeout 1h')
   end
 
   def test_restart_passes_deployments_transparently
-    set_krane_restart_expecations(deployments: ['web'])
+    set_krane_restart_expectations(deployments: ['web'])
     krane_restart!(flags: '--deployments web')
-    set_krane_restart_expecations(deployments: ['web', 'jobs'])
+    set_krane_restart_expectations(deployments: ['web', 'jobs'])
     krane_restart!(flags: '--deployments web jobs')
   end
 
@@ -33,9 +33,9 @@ class RestartTest < KubernetesDeploy::TestCase
   end
 
   def test_restart_passes_verify_result
-    set_krane_restart_expecations(run_args: { verify_result: true })
+    set_krane_restart_expectations(run_args: { verify_result: true })
     krane_restart!(flags: '--verify-result true')
-    set_krane_restart_expecations(run_args: { verify_result: false })
+    set_krane_restart_expectations(run_args: { verify_result: false })
     krane_restart!(flags: '--verify-result false')
   end
 
@@ -48,7 +48,7 @@ class RestartTest < KubernetesDeploy::TestCase
 
   private
 
-  def set_krane_restart_expecations(new_args: {}, deployments: nil, run_args: {})
+  def set_krane_restart_expectations(new_args: {}, deployments: nil, run_args: {})
     options = default_options(new_args, deployments, run_args)
     response = mock('RestartTask')
     response.expects(:run!).with(options[:deployments], options[:run_args]).returns(true)

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+
+class RunTest < KubernetesDeploy::TestCase
+  def test_run_with_default_options
+    set_krane_run_expectations
+    krane_run!
+  end
+
+  def test_run_parses_global_timeout
+    set_krane_run_expectations(new_args: { max_watch_seconds: 10 })
+    krane_run!(flags: '--global-timeout 10s')
+    set_krane_run_expectations(new_args: { max_watch_seconds: 60**2 })
+    krane_run!(flags: '--global-timeout 1h')
+  end
+
+  def test_run_parses_verify_result
+    set_krane_run_expectations(run_args: { verify_result: true })
+    krane_run!(flags: '--verify-result true')
+    set_krane_run_expectations(run_args: { verify_result: false })
+    krane_run!(flags: '--no-verify-result')
+  end
+
+  def test_run_parses_command
+    set_krane_run_expectations(run_args: { entrypoint: %w(/bin/sh) })
+    krane_run!(flags: '--command /bin/sh')
+  end
+
+  def test_run_parses_arguments
+    set_krane_run_expectations(run_args: { args: %w(hello) })
+    krane_run!(flags: '--arguments hello')
+  end
+
+  def test_run_parses_template
+    set_krane_run_expectations(run_args: { task_template: 'some-name' })
+    krane_run!(flags: '--template some-name')
+  end
+
+  def test_run_parses_env_vars
+    set_krane_run_expectations(run_args: { env_vars: %w(SOMETHING=8000 FOO=bar) })
+    krane_run!(flags: '--env-vars SOMETHING=8000,FOO=bar')
+  end
+
+  def test_run_failure_with_not_enough_arguments_as_black_box
+    out, err, status = krane_black_box('run', 'not_enough_arguments')
+    assert_equal(1, status.exitstatus)
+    assert_empty(out)
+    assert_match("ERROR", err)
+  end
+
+  def test_run_failure_with_too_many_args
+    out, err, status = krane_black_box('run', 'ns ctx some_extra_arg')
+    assert_equal(1, status.exitstatus)
+    assert_empty(out)
+    assert_match("ERROR", err)
+  end
+
+  private
+
+  def set_krane_run_expectations(new_args: {}, run_args: {})
+    options = default_options(new_args, run_args)
+    response = mock('RestartTask')
+    response.expects(:run!).with(options[:run_args]).returns(true)
+    KubernetesDeploy::RunnerTask.expects(:new).with(options[:new_args]).returns(response)
+  end
+
+  def krane_run!(flags: '')
+    krane = Krane::CLI::Krane.new(
+      [run_task_config.namespace, run_task_config.context],
+      flags.split
+    )
+    krane.invoke("run_command")
+  end
+
+  def run_task_config
+    @run_config ||= task_config(namespace: 'hello-cloud')
+  end
+
+  def default_options(new_args = {}, run_args = {})
+    {
+      new_args: {
+        namespace: run_task_config.namespace,
+        context: run_task_config.context,
+        max_watch_seconds: 300,
+      }.merge(new_args),
+      run_args: {
+        verify_result: true,
+        task_template: 'task-runner-template',
+        entrypoint: nil,
+        args: nil,
+        env_vars: [],
+      }.merge(run_args),
+    }
+  end
+end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -16,7 +16,23 @@ class KraneTest < KubernetesDeploy::IntegrationTest
     refute(fetch_restarted_at("redis"), "RESTARTED_AT env is present")
   end
 
+  def test_run_success_black_box
+    assert_empty(task_runner_pods)
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["template-runner.yml", "configmap-data.yml"]))
+    template = "hello-cloud-template-runner"
+    out, err, status = krane_black_box("run",
+      "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --template #{template} --command ls --arguments '-a /'")
+    assert_match("Success", err)
+    assert_empty(out)
+    assert_predicate(status, :success?)
+    assert_equal(1, task_runner_pods.count)
+  end
+
   private
+
+  def task_runner_pods
+    kubeclient.get_pods(namespace: @namespace, label_selector: "name=runner,app=hello-cloud")
+  end
 
   def fetch_restarted_at(deployment_name)
     deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -204,23 +204,6 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
   end
 
-  def test_run_fails_if_args_are_missing
-    task_runner = build_task_runner
-    result = task_runner.run(task_template: 'hello-cloud-template-runner',
-      entrypoint: ['/bin/sh', '-c'],
-      args: nil,
-      env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
-    assert_task_run_failure(result)
-
-    assert_logs_match_all([
-      "Initializing task",
-      "Validating configuration",
-      "Result: FAILURE",
-      "Configuration invalid",
-      "Args can't be nil",
-    ], in_order: true)
-  end
-
   def test_run_fails_if_task_template_is_blank
     task_runner = build_task_runner
     result = task_runner.run(task_template: '',
@@ -238,7 +221,7 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     ], in_order: true)
   end
 
-  def test_run_bang_fails_if_task_template_or_args_are_invalid
+  def test_run_bang_fails_if_task_template_is_invalid
     task_runner = build_task_runner
     assert_raises(KubernetesDeploy::TaskConfigurationError) do
       task_runner.run!(task_template: '',


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Add krane run, which is part of https://github.com/Shopify/kubernetes-deploy/issues/531

I think I'd like to refactor a bit more so I won't call that issue complete yet.

**How is this accomplished?**

In an effort to make these PRs small and digestible, I ported over the runner task to `krane` in this PR and added a bunch of tests. I'd like to do refactors in another PR.

**What could go wrong?**

It could not work, I guess.

**Some things to note:**

- I wanted to make entrypoint and args optional. Is what I did here sufficient for that?
- I wanted to use `type: :array` for arguments but that was failing for some cases. Thor has a lot of trouble parsing arrays whose first element is a string that starts with `-`, e.g. `--command=echo --arguments=-n hello` does not work. I fought with this for a while, I'm convinced it's something to do with how Thor parses arrays. I don't think it's worth blocking this on a Thor bug but it's something I might look into shortly.
- env-vars should be `type: :hash` but that's a refactor I'll do in my next PR
- I removed `validate_args` because I want args to be optional cc @dirceu 
- All the edits in `restart test` are a typo fix. You can focus on the second commit.