### PR TITLE
Update `DeployTask` test setup to use `render_erb: false` by default

### DIFF
--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -40,7 +40,7 @@ module FixtureDeployHelper
     success
   end
 
-  def deploy_raw_fixtures(set, wait: true, bindings: {}, subset: nil)
+  def deploy_raw_fixtures(set, wait: true, bindings: {}, subset: nil, render_erb: false)
     success = false
     if subset
       Dir.mktmpdir("fixture_dir") do |target_dir|
@@ -52,17 +52,17 @@ module FixtureDeployHelper
         subset.each do |file|
           FileUtils.copy_entry(File.join(fixture_path(set), file), File.join(target_dir, file))
         end
-        success = deploy_dirs(target_dir, wait: wait, bindings: bindings)
+        success = deploy_dirs(target_dir, wait: wait, bindings: bindings, render_erb: render_erb)
       end
     else
-      success = deploy_dirs(fixture_path(set), wait: wait, bindings: bindings)
+      success = deploy_dirs(fixture_path(set), wait: wait, bindings: bindings, render_erb: render_erb)
     end
     success
   end
 
   def deploy_dirs_without_profiling(dirs, wait: true, allow_protected_ns: false, prune: true, bindings: {},
     sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
-    protected_namespaces: nil, render_erb: true)
+    protected_namespaces: nil, render_erb: false)
     kubectl_instance ||= build_kubectl
 
     deploy = KubernetesDeploy::DeployTask.new(

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -4,7 +4,8 @@ require 'kubernetes-deploy/restart_task'
 
 class RestartTaskTest < KubernetesDeploy::IntegrationTest
   def test_restart_by_annotation
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"],
+      render_erb: true))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
@@ -30,10 +31,12 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   def test_restart_by_selector
     assert_deploy_success(deploy_fixtures("branched",
       bindings: { "branch" => "master" },
-      selector: KubernetesDeploy::LabelSelector.parse("branch=master")))
+      selector: KubernetesDeploy::LabelSelector.parse("branch=master"),
+      render_erb: true))
     assert_deploy_success(deploy_fixtures("branched",
       bindings: { "branch" => "staging" },
-      selector: KubernetesDeploy::LabelSelector.parse("branch=staging")))
+      selector: KubernetesDeploy::LabelSelector.parse("branch=staging"),
+      render_erb: true))
 
     refute(fetch_restarted_at("master-web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("staging-web"), "no RESTARTED_AT env on fresh deployment")
@@ -69,7 +72,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_named_deployments_twice
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
+      render_erb: true))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
@@ -100,7 +104,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_with_same_resource_twice
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
+      render_erb: true))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
@@ -131,7 +136,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_one_not_existing_deployment
-    assert(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
+    assert(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"], render_erb: true))
 
     restart = build_restart_task
     assert_restart_failure(restart.perform(%w(walrus web)))
@@ -194,7 +199,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_failure
-    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
+      render_erb: true) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30
       container = deployment["spec"]["template"]["spec"]["containers"].first
@@ -231,7 +237,7 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_restart_successful_with_partial_availability
-    result = deploy_fixtures("slow-cloud") do |fixtures|
+    result = deploy_fixtures("slow-cloud", render_erb: true) do |fixtures|
       web = fixtures["web.yml.erb"]["Deployment"].first
       web["spec"]["strategy"]['rollingUpdate']['maxUnavailable'] = '50%'
       container = web["spec"]["template"]["spec"]["containers"].first
@@ -261,7 +267,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_verify_result_false_succeeds
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"],
+      render_erb: true))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
@@ -293,7 +300,8 @@ class RestartTaskTest < KubernetesDeploy::IntegrationTest
   end
 
   def test_verify_result_false_succeeds_quickly_when_verification_would_timeout
-    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
+      render_erb: true) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30
       container = deployment["spec"]["template"]["spec"]["containers"].first


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

As a follow-up to https://github.com/Shopify/kubernetes-deploy/pull/557, I want to be explicit whenever we use ERB rendering in the tests as this is becoming `false` by default in 1.0

**How is this accomplished?**

I changed the default value for `render_erb` to `false` in the test setup, and passed the value as `true` only in the places where we actually needed it.

**What could go wrong?**

🤷‍♂ 