### PR TITLE
Revert "Remove `kubernetes-run` and slightly refactor `krane run`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 *Important!*
 - The next release will be 1.0.0, which means that master will contain breaking changes.
 
-*Other*
-- **[Breaking change]** Simplify how the user passes environment variables to the `krane run` `--env-vars` argument, "`--env-vars KEY:value FOO:bar`" ([#563](https://github.com/Shopify/kubernetes-deploy/pull/563))
-- **[Breaking change]** Remove `kuberenetes-run`. Use `krane run` instead ([#563](https://github.com/Shopify/kubernetes-deploy/pull/563))
-
 ## 0.28.0
 
 *Enhancements*

--- a/exe/kubernetes-run
+++ b/exe/kubernetes-run
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kubernetes-deploy/runner_task'
+require 'kubernetes-deploy/options_helper'
+require 'optparse'
+
+template = "task-runner-template"
+entrypoint = nil
+env_vars = []
+verify_result = true
+max_watch_seconds = nil
+
+ARGV.options do |opts|
+  opts.on("--skip-wait", "Skip verification of pod success") { verify_result = false }
+  opts.on("--max-watch-seconds=seconds",
+    "Timeout error is raised if the pod runs for longer than the specified number of seconds") do |t|
+    max_watch_seconds = t.to_i
+  end
+  opts.on("--template=TEMPLATE") { |n| template = n }
+  opts.on("--env-vars=ENV_VARS") { |vars| env_vars = vars.split(",") }
+  opts.on("--entrypoint=ENTRYPOINT") { |c| entrypoint = [c] }
+  opts.parse!
+end
+
+namespace = ARGV[0]
+context = ARGV[1]
+
+runner = KubernetesDeploy::RunnerTask.new(
+  namespace: namespace,
+  context: context,
+  max_watch_seconds: max_watch_seconds
+)
+
+success = runner.run(
+  verify_result: verify_result,
+  task_template: template,
+  entrypoint: entrypoint,
+  args: ARGV[2..-1],
+  env_vars: env_vars
+)
+exit(1) unless success

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -61,12 +61,6 @@ module Krane
         exit(TIMEOUT_EXIT_CODE)
       rescue KubernetesDeploy::FatalDeploymentError
         exit(FAILURE_EXIT_CODE)
-      rescue KubernetesDeploy::DurationParser::ParsingError => e
-        STDERR.puts(<<~ERROR_MESSAGE)
-          Error parsing duration
-          #{e.message}. Duration must be a full ISO8601 duration or time value (e.g. 300s, 10m, 1h)
-        ERROR_MESSAGE
-        exit(FAILURE_EXIT_CODE)
       end
     end
   end

--- a/lib/krane/cli/run_command.rb
+++ b/lib/krane/cli/run_command.rb
@@ -25,10 +25,10 @@ module Krane
           default: 'task-runner-template',
         },
         "env-vars" => {
-          type: :hash,
-          banner: "VAR:val FOO:bar",
-          desc: "A space-separated list of environment variables written as e.g. PORT:8000",
-          default: {},
+          type: :string,
+          banner: "VAR=val,FOO=bar",
+          desc: "A Comma-separated list of env vars",
+          default: '',
         },
       }
 
@@ -43,9 +43,9 @@ module Krane
         runner.run!(
           verify_result: options['verify-result'],
           task_template: options['template'],
-          command: options['command'],
+          entrypoint: options['command'],
           args: options['arguments']&.split(" "),
-          env_vars: options['env-vars'],
+          env_vars: options['env-vars'].split(','),
         )
       end
     end

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -23,7 +23,7 @@ class RunTest < KubernetesDeploy::TestCase
   end
 
   def test_run_parses_command
-    set_krane_run_expectations(run_args: { command: %w(/bin/sh) })
+    set_krane_run_expectations(run_args: { entrypoint: %w(/bin/sh) })
     krane_run!(flags: '--command /bin/sh')
   end
 
@@ -38,8 +38,8 @@ class RunTest < KubernetesDeploy::TestCase
   end
 
   def test_run_parses_env_vars
-    set_krane_run_expectations(run_args: { env_vars: { 'SOMETHING' => '8000', 'FOO' => 'bar' } })
-    krane_run!(flags: '--env-vars SOMETHING:8000 FOO:bar')
+    set_krane_run_expectations(run_args: { env_vars: %w(SOMETHING=8000 FOO=bar) })
+    krane_run!(flags: '--env-vars SOMETHING=8000,FOO=bar')
   end
 
   def test_run_failure_with_not_enough_arguments_as_black_box
@@ -49,18 +49,11 @@ class RunTest < KubernetesDeploy::TestCase
     assert_match("ERROR", err)
   end
 
-  def test_run_failure_with_too_many_args_as_black_box
+  def test_run_failure_with_too_many_args
     out, err, status = krane_black_box('run', 'ns ctx some_extra_arg')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
-  end
-
-  def test_run_failure_with_bad_timeout_as_black_box
-    out, err, status = krane_black_box('run', 'ns ctx --global-timeout=mittens')
-    assert_equal(1, status.exitstatus)
-    assert_empty(out)
-    assert_match("Error parsing duration", err)
   end
 
   private
@@ -94,9 +87,9 @@ class RunTest < KubernetesDeploy::TestCase
       run_args: {
         verify_result: true,
         task_template: 'task-runner-template',
-        command: nil,
+        entrypoint: nil,
         args: nil,
-        env_vars: {},
+        env_vars: [],
       }.merge(run_args),
     }
   end

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -22,7 +22,7 @@ module TaskRunnerTestHelper
   def run_params(log_lines: 5, log_interval: 0.1, verify_result: true)
     {
       task_template: 'hello-cloud-template-runner',
-      command: ['/bin/sh', '-c'],
+      entrypoint: ['/bin/sh', '-c'],
       args: [
         "i=1; " \
         "while [ $i -le #{log_lines} ]; do " \

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -207,9 +207,9 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
   def test_run_fails_if_task_template_is_blank
     task_runner = build_task_runner
     result = task_runner.run(task_template: '',
-      command: ['/bin/sh', '-c'],
+      entrypoint: ['/bin/sh', '-c'],
       args: nil,
-      env_vars: { MY_CUSTOM_VARIABLE: "MITTENS" })
+      env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
     assert_task_run_failure(result)
 
     assert_logs_match_all([
@@ -225,9 +225,9 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = build_task_runner
     assert_raises(KubernetesDeploy::TaskConfigurationError) do
       task_runner.run!(task_template: '',
-        command: ['/bin/sh', '-c'],
+        entrypoint: ['/bin/sh', '-c'],
         args: nil,
-        env_vars: { MY_CUSTOM_VARIABLE: "MITTENS" })
+        env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
     end
   end
 
@@ -272,9 +272,9 @@ class RunnerTaskTest < KubernetesDeploy::IntegrationTest
     task_runner = build_task_runner
     result = task_runner.run(
       task_template: 'hello-cloud-template-runner',
-      command: ['/bin/sh', '-c'],
+      entrypoint: ['/bin/sh', '-c'],
       args: ['echo "The value is: $MY_CUSTOM_VARIABLE"'],
-      env_vars: { MY_CUSTOM_VARIABLE: "MITTENS", SOME_VARIABLE: "GLOVES" }
+      env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"]
     )
     assert_task_run_success(result)
 


### PR DESCRIPTION
Reverts Shopify/kubernetes-deploy#563

Upon thinking about it more, we want all of the kubernetes-* and krane commands to have overlap in at least one release.

I'll flick up a PR for the duration bug fix but the refactor to improve the UX of krane run will have to wait.

cc @dturn @dirceu 