### PR TITLE
Add better handling for bad duration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *Important!*
 - The next release will be 1.0.0, which means that master will contain breaking changes.
 
+*Bug Fixes*
+- Handle improper duration values more elegantly with better messaging
+
 *Other*
 - We now require Ruby 2.4.x since Ruby 2.3 is past EoL.
 

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -61,6 +61,12 @@ module Krane
         exit(TIMEOUT_EXIT_CODE)
       rescue KubernetesDeploy::FatalDeploymentError
         exit(FAILURE_EXIT_CODE)
+      rescue KubernetesDeploy::DurationParser::ParsingError => e
+        STDERR.puts(<<~ERROR_MESSAGE)
+          Error parsing duration
+          #{e.message}. Duration must be a full ISO8601 duration or time value (e.g. 300s, 10m, 1h)
+        ERROR_MESSAGE
+        exit(FAILURE_EXIT_CODE)
       end
     end
   end

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -49,11 +49,18 @@ class RunTest < KubernetesDeploy::TestCase
     assert_match("ERROR", err)
   end
 
-  def test_run_failure_with_too_many_args
+  def test_run_failure_with_too_many_args_as_black_box
     out, err, status = krane_black_box('run', 'ns ctx some_extra_arg')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
+  end
+
+  def test_run_failure_with_bad_timeout_as_black_box
+    out, err, status = krane_black_box('run', 'ns ctx --global-timeout=mittens')
+    assert_equal(1, status.exitstatus)
+    assert_empty(out)
+    assert_match("Error parsing duration", err)
   end
 
   private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Wanted to get this big fix in, even though we needed to revert the PR that originally added it:
See https://github.com/Shopify/kubernetes-deploy/pull/564 for more context.

**How is this accomplished?**

Extend rescue and exit to rescue parsing errors and handle them a bit better.

**What could go wrong?**

Not much really.
