### PR TITLE
Add DeployTaskConfigValidator to deploy task

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -332,8 +332,8 @@ module KubernetesDeploy
     end
 
     def validate_configuration(allow_protected_ns:, prune:)
-      task_config_validator =
-        DeployTaskConfigValidator.new(@namespace, allow_protected_ns, prune, @task_config, kubectl, kubeclient_builder)
+      task_config_validator = DeployTaskConfigValidator.new(@protected_namespaces, allow_protected_ns, prune,
+        @task_config, kubectl, kubeclient_builder)
       errors = []
       errors += task_config_validator.errors
       errors += @template_sets.validate

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -40,6 +40,7 @@ require 'kubernetes-deploy/ejson_secret_provisioner'
 require 'kubernetes-deploy/renderer'
 require 'kubernetes-deploy/cluster_resource_discovery'
 require 'kubernetes-deploy/template_sets'
+require 'kubernetes-deploy/deploy_task_config_validator'
 
 module KubernetesDeploy
   class DeployTask
@@ -331,36 +332,17 @@ module KubernetesDeploy
     end
 
     def validate_configuration(allow_protected_ns:, prune:)
+      task_config_validator =
+        DeployTaskConfigValidator.new(@namespace, allow_protected_ns, prune, @task_config, kubectl, kubeclient_builder)
       errors = []
-      errors += kubeclient_builder.validate_config_files
+      errors += task_config_validator.errors
       errors += @template_sets.validate
-
-      if @namespace.blank?
-        errors << "Namespace must be specified"
-      elsif @protected_namespaces.include?(@namespace)
-        if allow_protected_ns && prune
-          errors << "Refusing to deploy to protected namespace '#{@namespace}' with pruning enabled"
-        elsif allow_protected_ns
-          @logger.warn("You're deploying to protected namespace #{@namespace}, which cannot be pruned.")
-          @logger.warn("Existing resources can only be removed manually with kubectl. " \
-            "Removing templates from the set deployed will have no effect.")
-          @logger.warn("***Please do not deploy to #{@namespace} unless you really know what you are doing.***")
-        else
-          errors << "Refusing to deploy to protected namespace '#{@namespace}'"
-        end
-      end
-
-      if @context.blank?
-        errors << "Context must be specified"
-      end
-
       unless errors.empty?
+        @logger.summary.add_action("Configuration invalid")
         @logger.summary.add_paragraph(errors.map { |err| "- #{err}" }.join("\n"))
-        raise FatalDeploymentError, "Configuration invalid"
+        raise KubernetesDeploy::TaskConfigurationError
       end
 
-      confirm_context_exists
-      confirm_namespace_exists
       confirm_ejson_keys_not_prunable if prune
       @logger.info("Using resource selector #{@selector}") if @selector
       @namespace_tags |= tags_from_namespace_labels
@@ -526,37 +508,6 @@ module KubernetesDeploy
           bad_files << { filename: File.basename(path), err: line, content: content }
         end
       end
-    end
-
-    def confirm_context_exists
-      out, err, st = kubectl.run("config", "get-contexts", "-o", "name",
-        use_namespace: false, use_context: false, log_failure: false)
-      available_contexts = out.split("\n")
-      if !st.success?
-        raise FatalDeploymentError, err
-      elsif !available_contexts.include?(@context)
-        raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
-      end
-      confirm_cluster_reachable
-      @logger.info("Context #{@context} found")
-    end
-
-    def confirm_cluster_reachable
-      success = false
-      with_retries(2) do
-        begin
-          success = kubectl.version_info
-        rescue KubectlError
-          success = false
-        end
-      end
-      raise FatalDeploymentError, "Failed to reach server for #{@context}" unless success
-      TaskConfigValidator.new(@task_config, kubectl, kubeclient_builder, only: [:validate_server_version]).valid?
-    end
-
-    def confirm_namespace_exists
-      raise FatalDeploymentError, "Namespace #{@namespace} not found" unless namespace_definition.present?
-      @logger.info("Namespace #{@namespace} found")
     end
 
     def namespace_definition

--- a/lib/kubernetes-deploy/deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/deploy_task_config_validator.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class DeployTaskConfigValidator < TaskConfigValidator
-    PROTECTED_NAMESPACES = %w(
-      default
-      kube-system
-      kube-public
-    )
-
-    def initialize(allow_protected_ns, prune, *arguments)
+    def initialize(protected_namespaces, allow_protected_ns, prune, *arguments)
       super(*arguments)
+      @protected_namespaces = protected_namespaces
       @allow_protected_ns = allow_protected_ns
       @prune = prune
       @validations += %i(validate_protected_namespaces)
@@ -17,7 +12,7 @@ module KubernetesDeploy
     private
 
     def validate_protected_namespaces
-      if PROTECTED_NAMESPACES.include?(namespace)
+      if @protected_namespaces.include?(namespace)
         if @allow_protected_ns && @prune
           @errors << "Refusing to deploy to protected namespace '#{namespace}' with pruning enabled"
         elsif @allow_protected_ns

--- a/lib/kubernetes-deploy/deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/deploy_task_config_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class DeployTaskConfigValidator < TaskConfigValidator
+    PROTECTED_NAMESPACES = %w(
+      default
+      kube-system
+      kube-public
+    )
+
+    def initialize(allow_protected_ns, prune, *arguments)
+      super(*arguments)
+      @allow_protected_ns = allow_protected_ns
+      @prune = prune
+      @validations += %i(validate_protected_namespaces)
+    end
+
+    private
+
+    def validate_protected_namespaces
+      if PROTECTED_NAMESPACES.include?(namespace)
+        if @allow_protected_ns && @prune
+          @errors << "Refusing to deploy to protected namespace '#{namespace}' with pruning enabled"
+        elsif @allow_protected_ns
+          logger.warn("You're deploying to protected namespace #{namespace}, which cannot be pruned.")
+          logger.warn("Existing resources can only be removed manually with kubectl. " \
+            "Removing templates from the set deployed will have no effect.")
+          logger.warn("***Please do not deploy to #{namespace} unless you really know what you are doing.***")
+        else
+          @errors << "Refusing to deploy to protected namespace '#{namespace}'"
+        end
+      end
+    end
+  end
+end

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -215,7 +215,7 @@ class KubernetesDeployTest < KubernetesDeploy::IntegrationTest
   def test_refuses_deploy_to_protected_namespace_without_override
     generated_ns = @namespace
     @namespace = 'default'
-    assert_deploy_failure(deploy_fixtures("hello-cloud", prune: false))
+    assert_deploy_failure(deploy_fixtures("hello-cloud"))
     assert_logs_match_all([
       "Configuration invalid",
       "- Refusing to deploy to protected namespace",
@@ -1646,7 +1646,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     assert_deploy_failure(result)
     assert_logs_match_all([
       'Name: "unmanaged-pod-1-<%= deployment_id %>"',
-      ], in_order: true)
+    ], in_order: true)
   end
 
   def test_deploy_fails_if_context_is_invalid

--- a/test/unit/kubernetes-deploy/deploy_task_test.rb
+++ b/test/unit/kubernetes-deploy/deploy_task_test.rb
@@ -8,17 +8,43 @@ class DeployTaskTest < KubernetesDeploy::TestCase
     refute_nil(::KubernetesDeploy::VERSION)
   end
 
-  def test_initializer
+  def test_initializer_without_namespace
+    assert_raises_message(ArgumentError, "namespace is required") do
+      KubernetesDeploy::DeployTask.new(
+        namespace: "",
+        context: KubeclientHelper::TEST_CONTEXT,
+        logger: logger,
+        current_sha: "",
+        template_paths: ["unknown"],
+      ).run
+    end
+  end
+
+  def test_initializer_without_context
+    assert_raises_message(ArgumentError, "context is required") do
+      KubernetesDeploy::DeployTask.new(
+        namespace: "something",
+        context: "",
+        logger: logger,
+        current_sha: "",
+        template_paths: ["unknown"],
+      ).run
+    end
+  end
+
+  def test_initializer_without_valid_file
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).at_least_once.returns(["", "", SystemExit.new(0)])
+    KubernetesDeploy::Kubectl.any_instance.expects(:server_version).at_least_once.returns(
+      Gem::Version.new(KubernetesDeploy::MIN_KUBE_VERSION)
+    )
     KubernetesDeploy::DeployTask.new(
-      namespace: "",
-      context: "",
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
       logger: logger,
       current_sha: "",
       template_paths: ["unknown"],
     ).run
     assert_logs_match("Configuration invalid")
-    assert_logs_match("Namespace must be specified")
-    assert_logs_match("Context must be specified")
     assert_logs_match(/File (\S+) does not exist/)
   end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Part of #344 to be consistent about preflight validations.

**How is this accomplished?**

Added `DeployTaskConfigValidator` which takes care of namespace and context checks via `TaskConfigValidator` plus the deploy-specific check on protected namespaces. This allowed us to remove the duplicate validations from `deploy_task.rb`.

We've decided to leave `template_sets` and `ejson` validations in `deploy_task.rb` because doing so in this PR would make it really big. It's open to refactoring in a later PR if deemed necessary.

**What could go wrong?**

We didn't refactor correctly and validations aren't carried out properly?
