### PR TITLE
Display full deploy error log after server dry run

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -483,10 +483,15 @@ module KubernetesDeploy
         bad_files = find_bad_files_from_kubectl_output(line)
         if bad_files.present?
           bad_files.each do |f|
-            if filenames_with_sensitive_content.include?(f[:filename]) && !server_dry_run_validated_resource.include?(f[:filename])
+            if filenames_with_sensitive_content.include?(f[:filename])
               # Hide the error and template contents in case it has sensitive information
-              # we display full error messages from kubernetes as we assume there's no sensitive info leak after server-dry-run
-              record_invalid_template(err: "SUPPRESSED FOR SECURITY", filename: f[:filename], content: nil)
+              # we display full error messages as we assume there's no sensitive info leak after server-dry-run
+              err_msg = if server_dry_run_validated_resource.include?(f[:filename])
+                f[:err]
+              else
+                "SUPPRESSED FOR SECURITY"
+              end
+              record_invalid_template(err: err_msg, filename: f[:filename], content: nil)
             else
               record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
             end

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -502,7 +502,7 @@ module KubernetesDeploy
       end
       return unless unidentified_errors.any?
 
-      if filenames_with_sensitive_content.any? { |f| !server_dry_run_validated_resource.include?(f) }
+      if (filenames_with_sensitive_content - server_dry_run_validated_resource).present?
         warn_msg = "WARNING: There was an error applying some or all resources. The raw output may be sensitive and " \
           "so cannot be displayed."
         @logger.summary.add_paragraph(ColorizedString.new(warn_msg).yellow)

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -9,6 +9,7 @@ module KubernetesDeploy
     }
     DEFAULT_TIMEOUT = 15
     MAX_RETRY_DELAY = 16
+    SERVER_DRY_RUN_MIN_VERSION = "1.13"
 
     class ResourceNotFoundError < StandardError; end
 
@@ -82,6 +83,10 @@ module KubernetesDeploy
 
     def server_version
       version_info[:server]
+    end
+
+    def server_dry_run_enabled?
+      server_version >= Gem::Version.new(SERVER_DRY_RUN_MIN_VERSION)
     end
 
     private

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -121,6 +121,7 @@ module KubernetesDeploy
       @validation_errors = []
       @validation_warnings = []
       @instance_data = {}
+      @server_dry_run_validated = false
     end
 
     def to_kubeclient_resource
@@ -350,6 +351,10 @@ module KubernetesDeploy
       self.class::SERVER_DRY_RUNNABLE
     end
 
+    def server_dry_run_validated?
+      @server_dry_run_validated
+    end
+
     class Event
       EVENT_SEPARATOR = "ENDEVENT--BEGINEVENT"
       FIELD_SEPARATOR = "ENDFIELD--BEGINFIELD"
@@ -474,9 +479,8 @@ module KubernetesDeploy
       _, err, st = validate_with_dry_run_option(kubectl, "--dry-run")
       if st.success? && server_dry_runnable?
         _, err, st = validate_with_dry_run_option(kubectl, "--server-dry-run")
-        if st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
-          return true
-        end
+        @server_dry_run_validated = true if st.success?
+        return true if st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
       end
 
       return true if st.success?

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -15,7 +15,6 @@ module KubernetesDeploy
     GLOBAL = false
     TIMEOUT = 5.minutes
     LOG_LINE_COUNT = 250
-    SERVER_DRY_RUN_MIN_VERSION = "1.13"
     SERVER_DRY_RUN_DISABLED_ERROR =
       /(unknown flag: --server-dry-run)|(doesn't support dry-run)|(dryRun alpha feature is disabled)/
 
@@ -478,7 +477,7 @@ module KubernetesDeploy
 
     def validate_spec_with_kubectl(kubectl)
       err = ""
-      if server_dry_run_enabled?(kubectl) && server_dry_runnable_resource?
+      if kubectl.server_dry_run_enabled? && server_dry_runnable_resource?
         _, err, st = validate_with_dry_run_option(kubectl, "--server-dry-run")
         @server_dry_run_validated = st.success?
         return true if st.success?

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -501,10 +501,6 @@ module KubernetesDeploy
                                retry_whitelist: [:client_timeout], attempts: 3)
     end
 
-    def server_dry_run_enabled?(kubectl)
-      kubectl.server_version >= Gem::Version.new(SERVER_DRY_RUN_MIN_VERSION)
-    end
-
     def labels
       @definition.dig("metadata", "labels")
     end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -479,7 +479,7 @@ module KubernetesDeploy
       _, err, st = validate_with_dry_run_option(kubectl, "--dry-run")
       if st.success? && server_dry_runnable?
         _, err, st = validate_with_dry_run_option(kubectl, "--server-dry-run")
-        @server_dry_run_validated = true if st.success?
+        @server_dry_run_validated = st.success?
         return true if st.success? || err.match(SERVER_DRY_RUN_DISABLED_ERROR)
       end
 

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -65,3 +65,13 @@ spec:
         image: busybox
         imagePullPolicy: IfNotPresent
         command: ["tail", "-f", "/dev/null"]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: web-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -65,13 +65,3 @@ spec:
         image: busybox
         imagePullPolicy: IfNotPresent
         command: ["tail", "-f", "/dev/null"]
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: web-secret
-type: Opaque
-data:
-  username: YWRtaW4=
-  password: cGFzc3dvcmQ=
-

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -320,7 +320,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   # https://github.com/kubernetes/kubernetes/issues/42057 shows how this manifested for a particular field,
   # and although that particular case has been fixed, other invalid specs still aren't caught until apply.
   def test_multiple_invalid_k8s_specs_fails_on_apply_and_prints_template
-    result = deploy_fixtures("hello-cloud", subset: ["web.yml.erb"]) do |fixtures|
+    result = deploy_fixtures("hello-cloud", subset: ["web.yml.erb", "secret.yml"]) do |fixtures|
       bad_port_name = "http_test_is_really_long_and_invalid_chars"
       svc = fixtures["web.yml.erb"]["Service"].first
       svc["spec"]["ports"].first["targetPort"] = bad_port_name

--- a/test/integration/kubernetes_deploy_test.rb
+++ b/test/integration/kubernetes_deploy_test.rb
@@ -1406,8 +1406,6 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
         /WARNING:.*The raw output may be sensitive and so cannot be displayed/,
       ])
     end
-
-
   end
 
   def test_validation_failure_on_sensitive_resources_does_not_print_template

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -202,6 +202,7 @@ module KubernetesDeploy
       def obj.run(*)
         ["", "", SystemExit.new(0)]
       end
+
       def obj.server_version
         Gem::Version.new('1.13.6')
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -202,6 +202,9 @@ module KubernetesDeploy
       def obj.run(*)
         ["", "", SystemExit.new(0)]
       end
+      def obj.server_version
+        Gem::Version.new('1.13.6')
+      end
       obj
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -203,8 +203,8 @@ module KubernetesDeploy
         ["", "", SystemExit.new(0)]
       end
 
-      def obj.server_version
-        Gem::Version.new('1.13.6')
+      def obj.server_dry_run_enabled?
+        true
       end
       obj
     end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Follow up work: https://github.com/Shopify/kubernetes-deploy/issues/484

As we bring in server-dry-run in https://github.com/Shopify/kubernetes-deploy/pull/553 for resources type with sensitive information. Spec validation error is able to be caught during template validation phrase, we can display a full error message if deploy failure. 

The pre-condition is we trust kubernetes will not leak sensitive info. 

**How is this accomplished?**
- Add instance variable `server_dry_run_validated` to kubernetes_resource, default to be false, if server-dry-run succeeds during template validation, set it to true.
- During deploy, if detect `server_dry_run_validated` is true, display full error message. 

**What could go wrong?**
Pre-condition is not true, Kubernetes may leak sensitive info . 

