### PR TITLE
Force dependency on activesupport 5.x

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.required_ruby_version = '>= 2.4.0'
-  spec.add_dependency("activesupport", ">= 5.0")
+  spec.add_dependency("activesupport", "< 6.0")
   spec.add_dependency("kubeclient", "~> 4.3")
   spec.add_dependency("googleauth", "~> 0.8.0")
   spec.add_dependency("ejson", "~> 1.0")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix build errors. ActiveSupport 6.0.0 no longer supports Ruby 2.4, which is still supported by this gem:

```
Gem::RuntimeRequirementNotMetError: activesupport requires Ruby version >=
  | 2.5.0. The current ruby version is 2.4.6.354.
```

**How is this accomplished?**
Changing `activesupport` dependency in `kubernetes-deploy.gemspec` to `< 6.0`.

**What could go wrong?**
Nothing.
