### PR TITLE
Krane global deploy

### DIFF
--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -34,6 +34,7 @@ module Krane
 
           deploy.run!(
             verify_result: options["verify-result"],
+            prune: false,
           )
         end
       end

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class GlobalDeployCommand
+      DEFAULT_DEPLOY_TIMEOUT = '300s'
+      OPTIONS = {
+        "filenames" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
+                         desc: "Path to file or directory that contains the configuration to apply" },
+        "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
+                              desc: "Max duration to monitor workloads correctly deployed" },
+        "verify-result" => { type: :boolean, default: true,
+                             desc: "Verify workloads correctly deployed" },
+        "selector" => { type: :string, banner: "'label=value'", required: true,
+                        desc: "Select workloads by selector(s)" },
+      }
+
+      def self.from_options(context, options)
+        require 'krane/global_deploy_task'
+        require 'kubernetes-deploy/options_helper'
+        require 'kubernetes-deploy/label_selector'
+
+        selector = KubernetesDeploy::LabelSelector.parse(options[:selector])
+
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths([options[:filenames]],
+          require_explicit_path: true) do |paths|
+          deploy = ::Krane::GlobalDeployTask.new(
+            context: context,
+            current_sha: ENV["REVISION"],
+            template_paths: paths,
+            max_watch_seconds: KubernetesDeploy::DurationParser.new(options["global-timeout"]).parse!.to_i,
+            selector: selector,
+          )
+
+          deploy.run!(
+            verify_result: options["verify-result"],
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -7,6 +7,7 @@ require 'krane/cli/restart_command'
 require 'krane/cli/run_command'
 require 'krane/cli/render_command'
 require 'krane/cli/deploy_command'
+require 'krane/cli/global_deploy_command'
 
 module Krane
   module CLI
@@ -55,6 +56,14 @@ module Krane
       def deploy(namespace, context)
         rescue_and_exit do
           DeployCommand.from_options(namespace, context, options)
+        end
+      end
+
+      desc("global-deploy CONTEXT", "Ship global resources to a cluster")
+      expand_options(GlobalDeployCommand::OPTIONS)
+      def global_deploy(context)
+        rescue_and_exit do
+          GlobalDeployCommand.from_options(context, options)
         end
       end
 

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'kubernetes-deploy/deploy_task'
+require 'kubernetes-deploy/global_deploy_task_config_validator'
 
 module Krane
   class GlobalDeployTask < KubernetesDeploy::DeployTask
@@ -7,11 +8,11 @@ module Krane
       super(args.merge(allow_globals: true))
     end
 
-    private
-
-    def namespace_definition
-      nil
+    def run!(**args)
+      super(args.merge(task_config_validator: GlobalDeployTaskConfigValidator))
     end
+
+    private
 
     def validate_globals(resources)
       return unless (namespaced = resources.reject(&:global?).presence)

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -9,20 +9,7 @@ module Krane
     end
 
     def run!(**args)
-      super(args.merge(task_config_validator: GlobalDeployTaskConfigValidator))
-    end
-
-    private
-
-    def validate_globals(resources)
-      return unless (namespaced = resources.reject(&:global?).presence)
-      namespaced_names = namespaced.map do |resource|
-        "#{resource.name} (#{resource.type}) in #{File.basename(resource.file_path)}"
-      end
-      namespaced_names = KubernetesDeploy::FormattedLogger.indent_four(namespaced_names.join("\n"))
-
-      @logger.summary.add_paragraph(ColorizedString.new("Namespaced resources:\n#{namespaced_names}").yellow)
-      raise KubernetesDeploy::FatalDeploymentError, "Deploying namespaced resource is not allowed from this command."
+      super(args.merge(task_config_validator: KubernetesDeploy::GlobalDeployTaskConfigValidator))
     end
   end
 end

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -4,10 +4,14 @@ require 'kubernetes-deploy/deploy_task'
 module Krane
   class GlobalDeployTask < KubernetesDeploy::DeployTask
     def initialize(**args)
-      super(args.merge(allow_globals: true, namespace: 'default', protected_namespaces: ''))
+      super(args.merge(allow_globals: true))
     end
 
     private
+
+    def namespace_definition
+      nil
+    end
 
     def validate_globals(resources)
       return unless (namespaced = resources.reject(&:global?).presence)

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'kubernetes-deploy/deploy_task'
+
+module Krane
+  class GlobalDeployTask < KubernetesDeploy::DeployTask
+    def initialize(**args)
+      super(args.merge(allow_globals: true, namespace: 'default', protected_namespaces: ''))
+    end
+
+    private
+
+    def validate_globals(resources)
+      return unless (namespaced = resources.reject(&:global?).presence)
+      namespaced_names = namespaced.map do |resource|
+        "#{resource.name} (#{resource.type}) in #{File.basename(resource.file_path)}"
+      end
+      namespaced_names = KubernetesDeploy::FormattedLogger.indent_four(namespaced_names.join("\n"))
+
+      @logger.summary.add_paragraph(ColorizedString.new("Namespaced resources:\n#{namespaced_names}").yellow)
+      raise KubernetesDeploy::FatalDeploymentError, "Deploying namespaced resource is not allowed from this command."
+    end
+  end
+end

--- a/lib/kubernetes-deploy/cluster_resource_discovery.rb
+++ b/lib/kubernetes-deploy/cluster_resource_discovery.rb
@@ -23,7 +23,8 @@ module KubernetesDeploy
     private
 
     def fetch_globals
-      raw, _, st = kubectl.run("api-resources", "--namespaced=false", output: "wide", attempts: 5)
+      raw, _, st = kubectl.run("api-resources", "--namespaced=false", output: "wide",
+        attempts: 5, use_namespace: false)
       if st.success?
         rows = raw.split("\n")
         header = rows[0]
@@ -42,7 +43,8 @@ module KubernetesDeploy
     end
 
     def fetch_crds
-      raw_json, _, st = kubectl.run("get", "CustomResourceDefinition", output: "json", attempts: 5)
+      raw_json, _, st = kubectl.run("get", "CustomResourceDefinition", output: "json",
+        attempts: 5, use_namespace: false)
       if st.success?
         JSON.parse(raw_json)["items"]
       else

--- a/lib/kubernetes-deploy/deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/deploy_task_config_validator.rb
@@ -9,6 +9,24 @@ module KubernetesDeploy
       @validations += %i(validate_protected_namespaces)
     end
 
+    def validate_resources(resources, allow_globals)
+      return unless (global = resources.select(&:global?).presence)
+      global_names = global.map do |resource|
+        "#{resource.name} (#{resource.type}) in #{File.basename(resource.file_path)}"
+      end
+      global_names = FormattedLogger.indent_four(global_names.join("\n"))
+
+      if allow_globals
+        msg = "The ability for this task to deploy global resources will be removed in the next version,"\
+              " which will affect the following resources:"
+        msg += "\n#{global_names}"
+        logger.summary.add_paragraph(ColorizedString.new(msg).yellow)
+      else
+        logger.summary.add_paragraph(ColorizedString.new("Global resources:\n#{global_names}").yellow)
+        raise FatalDeploymentError, "This command is namespaced and cannot be used to deploy global resources."
+      end
+    end
+
     private
 
     def validate_protected_namespaces

--- a/lib/kubernetes-deploy/deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/deploy_task_config_validator.rb
@@ -2,7 +2,9 @@
 module KubernetesDeploy
   class DeployTaskConfigValidator < TaskConfigValidator
     def initialize(protected_namespaces, allow_protected_ns, prune, *arguments)
-      super(*arguments)
+      task_config = arguments.first
+      skip = task_config.allow_globals ? [:validate_namespace_exists] : []
+      super(*arguments, skip: skip)
       @protected_namespaces = protected_namespaces
       @allow_protected_ns = allow_protected_ns
       @prune = prune

--- a/lib/kubernetes-deploy/deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/deploy_task_config_validator.rb
@@ -2,9 +2,7 @@
 module KubernetesDeploy
   class DeployTaskConfigValidator < TaskConfigValidator
     def initialize(protected_namespaces, allow_protected_ns, prune, *arguments)
-      task_config = arguments.first
-      skip = task_config.allow_globals ? [:validate_namespace_exists] : []
-      super(*arguments, skip: skip)
+      super(*arguments)
       @protected_namespaces = protected_namespaces
       @allow_protected_ns = allow_protected_ns
       @prune = prune

--- a/lib/kubernetes-deploy/global_deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/global_deploy_task_config_validator.rb
@@ -7,5 +7,16 @@ module KubernetesDeploy
       @allow_protected_ns = allow_protected_ns
       @prune = prune
     end
+
+    def validate_resources(resources, _)
+      return unless (namespaced = resources.reject(&:global?).presence)
+      namespaced_names = namespaced.map do |resource|
+        "#{resource.name} (#{resource.type}) in #{File.basename(resource.file_path)}"
+      end
+      namespaced_names = KubernetesDeploy::FormattedLogger.indent_four(namespaced_names.join("\n"))
+
+      logger.summary.add_paragraph(ColorizedString.new("Namespaced resources:\n#{namespaced_names}").yellow)
+      raise KubernetesDeploy::FatalDeploymentError, "Deploying namespaced resource is not allowed from this command."
+    end
   end
 end

--- a/lib/kubernetes-deploy/global_deploy_task_config_validator.rb
+++ b/lib/kubernetes-deploy/global_deploy_task_config_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module KubernetesDeploy
+  class GlobalDeployTaskConfigValidator < TaskConfigValidator
+    def initialize(protected_namespaces, allow_protected_ns, prune, *arguments)
+      super(*arguments, skip: [:validate_namespace_exists])
+      @protected_namespaces = protected_namespaces
+      @allow_protected_ns = allow_protected_ns
+      @prune = prune
+    end
+  end
+end

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -317,7 +317,7 @@ module KubernetesDeploy
     def fetch_events(kubectl)
       return {} unless exists?
       out, _err, st = kubectl.run("get", "events", "--output=go-template=#{Event.go_template_for(type, name)}",
-        log_failure: false)
+        log_failure: false, use_namespace: !global?)
       return {} unless st.success?
 
       event_collector = Hash.new { |hash, key| hash[key] = [] }
@@ -500,7 +500,7 @@ module KubernetesDeploy
     def validate_with_dry_run_option(kubectl, dry_run_option)
       command = ["apply", "-f", file_path, dry_run_option, "--output=name"]
       kubectl.run(*command, log_failure: false, output_is_sensitive: sensitive_template_content?,
-                               retry_whitelist: [:client_timeout], attempts: 3)
+                               retry_whitelist: [:client_timeout], attempts: 3, use_namespace: !global?)
     end
 
     def labels

--- a/lib/kubernetes-deploy/resource_cache.rb
+++ b/lib/kubernetes-deploy/resource_cache.rb
@@ -4,7 +4,7 @@ require 'concurrent/hash'
 
 module KubernetesDeploy
   class ResourceCache
-    delegate :namespace, :context, :logger, :allow_globals, to: :@task_config
+    delegate :namespace, :context, :logger, :global_mode, to: :@task_config
 
     def initialize(task_config)
       @task_config = task_config
@@ -53,7 +53,7 @@ module KubernetesDeploy
       resource_class = KubernetesResource.class_for_kind(kind)
       output_is_sensitive = resource_class.nil? ? false : resource_class::SENSITIVE_TEMPLATE_CONTENT
       raw_json, _, st = @kubectl.run("get", kind, "--chunk-size=0", attempts: 5, output: "json",
-         output_is_sensitive: output_is_sensitive, use_namespace: !allow_globals)
+         output_is_sensitive: output_is_sensitive, use_namespace: !global_mode)
       raise KubectlError unless st.success?
 
       instances = {}

--- a/lib/kubernetes-deploy/resource_cache.rb
+++ b/lib/kubernetes-deploy/resource_cache.rb
@@ -4,7 +4,7 @@ require 'concurrent/hash'
 
 module KubernetesDeploy
   class ResourceCache
-    delegate :namespace, :context, :logger, to: :@task_config
+    delegate :namespace, :context, :logger, :allow_globals, to: :@task_config
 
     def initialize(task_config)
       @task_config = task_config
@@ -53,7 +53,7 @@ module KubernetesDeploy
       resource_class = KubernetesResource.class_for_kind(kind)
       output_is_sensitive = resource_class.nil? ? false : resource_class::SENSITIVE_TEMPLATE_CONTENT
       raw_json, _, st = @kubectl.run("get", kind, "--chunk-size=0", attempts: 5, output: "json",
-         output_is_sensitive: output_is_sensitive)
+         output_is_sensitive: output_is_sensitive, use_namespace: !allow_globals)
       raise KubectlError unless st.success?
 
       instances = {}

--- a/lib/kubernetes-deploy/task_config.rb
+++ b/lib/kubernetes-deploy/task_config.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class TaskConfig
-    attr_reader :context, :namespace
+    attr_reader :context, :namespace, :global_mode
+    attr_accessor :namespace_definition
 
-    def initialize(context, namespace, logger = nil)
+    def initialize(context, namespace, logger = nil, global_mode = false)
       @context = context
       @namespace = namespace
       @logger = logger
+      @global_mode = global_mode
     end
 
     def logger

--- a/lib/kubernetes-deploy/task_config_validator.rb
+++ b/lib/kubernetes-deploy/task_config_validator.rb
@@ -70,10 +70,12 @@ module KubernetesDeploy
         return @errors << "Namespace can not be blank"
       end
 
-      _, err, st = @kubectl.run("get", "namespace", "-o", "name", namespace,
-        use_namespace: false, log_failure: false)
+      definition, err, st = @kubectl.run("get", "namespace", namespace,
+        use_namespace: false, log_failure: false, attempts: 3, output: 'json')
 
-      unless st.success?
+      if st.success?
+        @task_config.namespace_definition = JSON.parse(definition, symbolize_names: true)
+      else
         @errors << if err.match("Error from server [(]NotFound[)]: namespace")
           "Could not find Namespace: #{namespace} in Context: #{context}"
         else

--- a/lib/kubernetes-deploy/task_config_validator.rb
+++ b/lib/kubernetes-deploy/task_config_validator.rb
@@ -11,12 +11,12 @@ module KubernetesDeploy
 
     delegate :context, :namespace, :logger, to: :@task_config
 
-    def initialize(task_config, kubectl, kubeclient_builder, only: nil)
+    def initialize(task_config, kubectl, kubeclient_builder, only: nil, skip: [])
       @task_config = task_config
       @kubectl = kubectl
       @kubeclient_builder = kubeclient_builder
       @errors = nil
-      @validations = only || DEFAULT_VALIDATIONS
+      @validations = (only || DEFAULT_VALIDATIONS) - skip
     end
 
     def valid?

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/cli/krane'
+require 'krane/global_deploy_task'
+
+class GlobalDeployTest < KubernetesDeploy::TestCase
+  def test_global_deploy_with_default_options
+    set_krane_global_deploy_expectations!
+    krane_global_deploy!
+  end
+
+  def test_deploy_parses_global_timeout
+    set_krane_global_deploy_expectations!(new_args: { max_watch_seconds: 10 })
+    krane_global_deploy!(flags: '--global-timeout 10s')
+    set_krane_global_deploy_expectations!(new_args: { max_watch_seconds: 60**2 })
+    krane_global_deploy!(flags: '--global-timeout 1h')
+  end
+
+  def test_deploy_passes_verify_result
+    set_krane_global_deploy_expectations!(run_args: { verify_result: true })
+    krane_global_deploy!(flags: '--verify-result true')
+    set_krane_global_deploy_expectations!(run_args: { verify_result: false })
+    krane_global_deploy!(flags: '--verify-result false')
+  end
+
+  def test_deploy_passes_filename
+    set_krane_global_deploy_expectations!(new_args: { template_paths: ['/my/file/path'] })
+    krane_global_deploy!(flags: '-f /my/file/path')
+    set_krane_global_deploy_expectations!(new_args: { template_paths: ['/my/other/file/path'] })
+    krane_global_deploy!(flags: '--filenames /my/other/file/path')
+  end
+
+  def test_deploy_parses_selector
+    selector = 'name:web'
+    set_krane_global_deploy_expectations!(new_args: { selector: selector })
+    krane_global_deploy!(flags: "--selector #{selector}")
+  end
+
+  private
+
+  def set_krane_global_deploy_expectations!(new_args: {}, run_args: {})
+    options = default_options(new_args, run_args)
+    selector_args = options[:new_args][:selector]
+    selector = mock('LabelSelector')
+    KubernetesDeploy::LabelSelector.expects(:parse).with(selector_args).returns(selector)
+    response = mock('GlobalDeployTask')
+    response.expects(:run!).with(options[:run_args]).returns(true)
+    Krane::GlobalDeployTask.expects(:new).with(options[:new_args].merge(selector: selector)).returns(response)
+  end
+
+  def krane_global_deploy!(flags: '')
+    flags += ' -f /tmp' unless flags.include?('-f')
+    flags += ' --selector name:web' unless flags.include?('--selector')
+    krane = Krane::CLI::Krane.new(
+      [task_config.context],
+      flags.split
+    )
+    krane.invoke("global_deploy")
+  end
+
+  def default_options(new_args = {}, run_args = {})
+    {
+      new_args: {
+        context: task_config.context,
+        template_paths: ['/tmp'],
+        max_watch_seconds: 300,
+        current_sha: nil,
+        selector: 'name:web',
+      }.merge(new_args),
+      run_args: {
+        verify_result: true,
+      }.merge(run_args),
+    }
+  end
+end

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -69,6 +69,7 @@ class GlobalDeployTest < KubernetesDeploy::TestCase
       }.merge(new_args),
       run_args: {
         verify_result: true,
+        prune: false,
       }.merge(run_args),
     }
   end

--- a/test/fixtures/globals/storage_classes.yml
+++ b/test/fixtures/globals/storage_classes.yml
@@ -2,4 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: testing-storage-class
+  labels:
+    app: krane
 provisioner: kubernetes.io/no-provisioner

--- a/test/helpers/resource_cache_test_helper.rb
+++ b/test/helpers/resource_cache_test_helper.rb
@@ -6,7 +6,7 @@ module ResourceCacheTestHelper
       kind,
       "--chunk-size=0",
       resp: { items: items },
-      kwargs: { attempts: 5, output_is_sensitive: false },
+      kwargs: { attempts: 5, output_is_sensitive: false, use_namespace: true },
       times: times,
     )
   end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -89,7 +89,7 @@ class KraneTest < KubernetesDeploy::IntegrationTest
 
   def test_global_deploy_black_box_success
     setup_template_dir("globals") do |target_dir|
-      flags = "-f #{target_dir}"
+      flags = "-f #{target_dir} --selector app=krane"
       out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
       assert_empty(out)
       assert_match("Success", err)
@@ -101,7 +101,7 @@ class KraneTest < KubernetesDeploy::IntegrationTest
 
   def test_global_deploy_black_box_failure
     setup_template_dir("resource-quota") do |target_dir|
-      flags = "-f #{target_dir}"
+      flags = "-f #{target_dir} --selector app=krane"
       out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
       assert_empty(out)
       assert_match("FAILURE", err)

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -87,6 +87,29 @@ class KraneTest < KubernetesDeploy::IntegrationTest
     end
   end
 
+  def test_global_deploy_black_box_success
+    setup_template_dir("globals") do |target_dir|
+      flags = "-f #{target_dir}"
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      assert_match("Success", err)
+      assert_predicate(status, :success?)
+    end
+  ensure
+    storage_v1_kubeclient.delete_storage_class("testing-storage-class")
+  end
+
+  def test_global_deploy_black_box_failure
+    setup_template_dir("resource-quota") do |target_dir|
+      flags = "-f #{target_dir}"
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      assert_match("FAILURE", err)
+      refute_predicate(status, :success?)
+      assert_equal(status.exitstatus, 1)
+    end
+  end
+
   private
 
   def task_runner_pods

--- a/test/unit/kubernetes-deploy/deploy_task_test.rb
+++ b/test/unit/kubernetes-deploy/deploy_task_test.rb
@@ -9,7 +9,7 @@ class DeployTaskTest < KubernetesDeploy::TestCase
   end
 
   def test_initializer_without_valid_file
-    KubernetesDeploy::Kubectl.any_instance.expects(:run).at_least_once.returns(["", "", SystemExit.new(0)])
+    KubernetesDeploy::Kubectl.any_instance.expects(:run).at_least_once.returns(["{}", "", SystemExit.new(0)])
     KubernetesDeploy::Kubectl.any_instance.expects(:server_version).at_least_once.returns(
       Gem::Version.new(KubernetesDeploy::MIN_KUBE_VERSION)
     )

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -109,7 +109,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
         output_is_sensitive: true,
         retry_whitelist: [:client_timeout],
         attempts: 3,
-        use_namespace: true
+        use_namespace: true,
       })
   end
 

--- a/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
+++ b/test/unit/kubernetes-deploy/ejson_secret_provisioner_test.rb
@@ -109,6 +109,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
         output_is_sensitive: true,
         retry_whitelist: [:client_timeout],
         attempts: 3,
+        use_namespace: true
       })
   end
 
@@ -120,6 +121,7 @@ class EjsonSecretProvisionerTest < KubernetesDeploy::TestCase
         output_is_sensitive: true,
         retry_whitelist: [:client_timeout],
         attempts: 3,
+        use_namespace: true,
       })
   end
 

--- a/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/horizontal_pod_autoscaler_test.rb
@@ -7,7 +7,7 @@ class HorizontalPodAutoscalerTest < KubernetesDeploy::TestCase
   # We can't get integration coverage for HPA right now because the metrics server just isn't reliable enough on our CI
   def test_hpa_is_whitelisted_for_pruning
     KubernetesDeploy::Kubectl.any_instance.expects("run")
-      .with("get", "CustomResourceDefinition", output: "json", attempts: 5)
+      .with("get", "CustomResourceDefinition", output: "json", attempts: 5, use_namespace: false)
       .returns(['{ "items": [] }', "", SystemExit.new(0)])
     task = KubernetesDeploy::DeployTask.new(namespace: 'test', context: KubeclientHelper::TEST_CONTEXT,
       current_sha: 'foo', template_paths: [''], logger: logger)

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -411,7 +411,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
 
   def test_disappeared_is_false_if_resource_has_been_deployed_and_we_get_a_server_error
     dummy = DummyResource.new
-    cache = KubernetesDeploy::ResourceCache.new(task_config: task_config(namespace: 'test', context: 'minikube'))
+    cache = KubernetesDeploy::ResourceCache.new(task_config(namespace: 'test', context: 'minikube'))
     KubernetesDeploy::Kubectl.any_instance.expects(:run).returns(["", "NotFound", stub(success?: false)]).twice
 
     dummy.sync(cache)

--- a/test/unit/resource_cache_test.rb
+++ b/test/unit/resource_cache_test.rb
@@ -37,7 +37,7 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
   end
 
   def test_if_kubectl_error_then_empty_result_returned_but_not_cached
-    stub_kubectl_response('get', 'FakeConfigMap', '--chunk-size=0', kwargs: { attempts: 5, output_is_sensitive: false },
+    stub_kubectl_response('get', 'FakeConfigMap', '--chunk-size=0', kwargs: { use_namespace: true, attempts: 5, output_is_sensitive: false },
       success: false, resp: { "items" => [] }, err: 'no', times: 4)
 
     # All of these calls should attempt the request again (see the 'times' arg above)

--- a/test/unit/resource_cache_test.rb
+++ b/test/unit/resource_cache_test.rb
@@ -37,7 +37,8 @@ class ResourceCacheTest < KubernetesDeploy::TestCase
   end
 
   def test_if_kubectl_error_then_empty_result_returned_but_not_cached
-    stub_kubectl_response('get', 'FakeConfigMap', '--chunk-size=0', kwargs: { use_namespace: true, attempts: 5, output_is_sensitive: false },
+    stub_kubectl_response('get', 'FakeConfigMap', '--chunk-size=0',
+      kwargs: { use_namespace: true, attempts: 5, output_is_sensitive: false },
       success: false, resp: { "items" => [] }, err: 'no', times: 4)
 
     # All of these calls should attempt the request again (see the 'times' arg above)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Part of the krane 1.0 work is refusing to allow `krane deploy` to deploy global resources. See https://github.com/Shopify/kubernetes-deploy/issues/522 for more of an explanation.

To allow our users to have a better experience than just `kubectl apply` we're adding a new command `krane global-deploy`. This command will not support erb rendering, for that you can pipe the results of `krane render`.  This version does not support pruning or `--label-selector` thought we would accept the feature in future versions.

**How is this accomplished?**
Add a krane global-deploy command and a krane/global_deploy_task. The global_deploy_task is a thin wrapper around `kubernetes_deploy/deploy_task.

**What could go wrong?**

This assumes the approach we want is to share deploy_task with the namespaced version and only override the parts we want. 

We could chop up the deploy task and then make the deploy_task and global_deploy_task be more fully featured. 
