### PR TITLE
Pin statsd-instrument gem to 2.3.X line as 2.5.0 has incompatible changes

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("googleauth", "~> 0.8.0")
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
-  spec.add_dependency("statsd-instrument", '~> 2.3', '>= 2.3.2')
+  spec.add_dependency("statsd-instrument", '~> 2.3.2')
   spec.add_dependency("oj", "~> 3.0")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
   spec.add_dependency("jsonpath", "~> 0.9.6")

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  VERSION = "0.28.0"
+  VERSION = "0.29.0"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Prevent kubernetes-deploy failures in statsd-instrument 

**How is this accomplished?**

statsd-instrument 2.5.0 introduces API incompatible changes that break our monkey patching. This pins the statsd-instrument.gem to 2.3.X line, which is currently 2.3.5

**What could go wrong?**

We need to update our monkey-patching as a proper long-term solution, but right now without this patch deploys will fail when they do a bundle update, as they try to emit metrics through a broken API interface.
