### PR TITLE
initial attempt at increased tolerance for daemonsets

### DIFF
--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -101,6 +101,10 @@ module KubernetesDeploy
       exists? && !@stream_logs # don't print them a second time
     end
 
+    def node_name
+      @instance_data.dig('spec', 'nodeName')
+    end
+
     private
 
     def failed_schedule_reason

--- a/test/fixtures/for_unit_tests/daemon_set.yml
+++ b/test/fixtures/for_unit_tests/daemon_set.yml
@@ -3,15 +3,17 @@ kind: DaemonSet
 metadata:
   name: ds-app
   generation: 2
+  uid: 'c31a9b4e-e6dd-11e9-8f47-e6322f98393a'
 spec:
   selector:
     matchLabels:
       app: ds-app
       name: ds-app
+  templateGeneration: 2
   template:
     metadata:
       labels:
-        app: hello-cloud
+        app: ds-app
         name: ds-app
     spec:
       containers:

--- a/test/fixtures/for_unit_tests/daemon_set_pod.yml
+++ b/test/fixtures/for_unit_tests/daemon_set_pod.yml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2019-10-07T16:05:37Z"
+  generateName: ds-app-
+  labels:
+    app: ds-app
+    controller-revision-hash: "2703261291"
+    name: ds-app
+    pod-template-generation: "2"
+  name: ds-app-hgjhh
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DaemonSet
+    name: ds-app
+    uid: c31a9b4e-e6dd-11e9-8f47-e6322f98393a
+  resourceVersion: "31010"
+  selfLink: /api/v1/namespaces/default/pods/ds-app-hgjhh
+  uid: 4cf14557-e91c-11e9-8f47-e6322f98393a
+spec:
+  containers:
+  - command:
+    - tail
+    - -f
+    - /dev/null
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    name: app
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-bwg9f
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/disk-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/memory-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/unschedulable
+    operator: Exists
+  volumes:
+  - name: default-token-bwg9f
+    secret:
+      defaultMode: 420
+      secretName: default-token-bwg9f
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:37Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:38Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:37Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://949e6b37ad1e85dfeca958bb5a54c459305ef3d87e12d03e1ba90e121701b572
+    image: busybox:latest
+    imageID: docker-pullable://busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+    lastState: {}
+    name: app
+    ready: true
+    restartCount: 0
+    state:
+      running:
+        startedAt: "2019-10-07T16:05:38Z"
+  hostIP: 192.168.64.3
+  phase: Running
+  podIP: 172.17.0.4
+  qosClass: BestEffort
+  startTime: "2019-10-07T16:05:37Z"

--- a/test/fixtures/for_unit_tests/daemon_set_pod_not_ready.yml
+++ b/test/fixtures/for_unit_tests/daemon_set_pod_not_ready.yml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2019-10-07T16:05:37Z"
+  generateName: ds-app-
+  labels:
+    app: ds-app
+    controller-revision-hash: "2703261291"
+    name: ds-app
+    pod-template-generation: "2"
+  name: ds-app-hgjhh
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DaemonSet
+    name: ds-app
+    uid: c31a9b4e-e6dd-11e9-8f47-e6322f98393a
+  resourceVersion: "31010"
+  selfLink: /api/v1/namespaces/default/pods/ds-app-hgjhh
+  uid: 4cf14557-e91c-11e9-8f47-e6322f98393a
+spec:
+  containers:
+  - command:
+    - tail
+    - -f
+    - /dev/null
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    name: app
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-bwg9f
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/disk-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/memory-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/unschedulable
+    operator: Exists
+  volumes:
+  - name: default-token-bwg9f
+    secret:
+      defaultMode: 420
+      secretName: default-token-bwg9f
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:37Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:38Z"
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2019-10-07T16:05:37Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://949e6b37ad1e85dfeca958bb5a54c459305ef3d87e12d03e1ba90e121701b572
+    image: busybox:latest
+    imageID: docker-pullable://busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+    lastState: {}
+    name: app
+    ready: true
+    restartCount: 0
+    state:
+      running:
+        startedAt: "2019-10-07T16:05:38Z"
+  hostIP: 192.168.64.3
+  phase: Running
+  podIP: 172.17.0.4
+  qosClass: BestEffort
+  startTime: "2019-10-07T16:05:37Z"

--- a/test/fixtures/for_unit_tests/daemon_set_pods.yml
+++ b/test/fixtures/for_unit_tests/daemon_set_pods.yml
@@ -1,0 +1,321 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    creationTimestamp: "2019-10-07T16:05:37Z"
+    generateName: ds-app-
+    labels:
+      app: ds-app
+      controller-revision-hash: "2703261291"
+      name: ds-app
+      pod-template-generation: "2"
+    name: ds-app-hgjhh1
+    namespace: default
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DaemonSet
+      name: ds-app
+      uid: c31a9b4e-e6dd-11e9-8f47-e6322f98393a
+    resourceVersion: "31010"
+    selfLink: /api/v1/namespaces/default/pods/ds-app-hgjhh1
+    uid: 4cf14557-e91c-11e9-8f47-e6322f98393a
+  spec:
+    containers:
+    - command:
+      - tail
+      - -f
+      - /dev/null
+      image: busybox
+      imagePullPolicy: IfNotPresent
+      name: app
+      ports:
+      - containerPort: 80
+        protocol: TCP
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-bwg9f
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    nodeName: minikube
+    priority: 0
+    restartPolicy: Always
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/disk-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/unschedulable
+      operator: Exists
+    volumes:
+    - name: default-token-bwg9f
+      secret:
+        defaultMode: 420
+        secretName: default-token-bwg9f
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:38Z"
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: null
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://949e6b37ad1e85dfeca958bb5a54c459305ef3d87e12d03e1ba90e121701b572
+      image: busybox:latest
+      imageID: docker-pullable://busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      lastState: {}
+      name: app
+      ready: true
+      restartCount: 0
+      state:
+        running:
+          startedAt: "2019-10-07T16:05:38Z"
+    hostIP: 192.168.64.3
+    phase: Running
+    podIP: 172.17.0.4
+    qosClass: BestEffort
+    startTime: "2019-10-07T16:05:37Z"
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    creationTimestamp: "2019-10-07T16:05:37Z"
+    generateName: ds-app-
+    labels:
+      app: ds-app
+      controller-revision-hash: "2703261291"
+      name: ds-app
+      pod-template-generation: "2"
+    name: ds-app-hgjhh2
+    namespace: default
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DaemonSet
+      name: ds-app
+      uid: c31a9b4e-e6dd-11e9-8f47-e6322f98393a
+    resourceVersion: "31010"
+    selfLink: /api/v1/namespaces/default/pods/ds-app-hgjhh2
+    uid: 4cf14557-e91c-11e9-8f47-e6322f98393a
+  spec:
+    containers:
+    - command:
+      - tail
+      - -f
+      - /dev/null
+      image: busybox
+      imagePullPolicy: IfNotPresent
+      name: app
+      ports:
+      - containerPort: 80
+        protocol: TCP
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-bwg9f
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    nodeName: minikube2
+    priority: 0
+    restartPolicy: Always
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/disk-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/unschedulable
+      operator: Exists
+    volumes:
+    - name: default-token-bwg9f
+      secret:
+        defaultMode: 420
+        secretName: default-token-bwg9f
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:38Z"
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: null
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://949e6b37ad1e85dfeca958bb5a54c459305ef3d87e12d03e1ba90e121701b572
+      image: busybox:latest
+      imageID: docker-pullable://busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      lastState: {}
+      name: app
+      ready: true
+      restartCount: 0
+      state:
+        running:
+          startedAt: "2019-10-07T16:05:38Z"
+    hostIP: 192.168.64.3
+    phase: Running
+    podIP: 172.17.0.4
+    qosClass: BestEffort
+    startTime: "2019-10-07T16:05:37Z"
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    creationTimestamp: "2019-10-07T16:05:37Z"
+    generateName: ds-app-
+    labels:
+      app: ds-app
+      controller-revision-hash: "2703261291"
+      name: ds-app
+      pod-template-generation: "2"
+    name: ds-app-hgjhh3
+    namespace: default
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DaemonSet
+      name: ds-app
+      uid: c31a9b4e-e6dd-11e9-8f47-e6322f98393a
+    resourceVersion: "31010"
+    selfLink: /api/v1/namespaces/default/pods/ds-app-hgjhh3
+    uid: 4cf14557-e91c-11e9-8f47-e6322f98393a
+  spec:
+    containers:
+    - command:
+      - tail
+      - -f
+      - /dev/null
+      image: busybox
+      imagePullPolicy: IfNotPresent
+      name: app
+      ports:
+      - containerPort: 80
+        protocol: TCP
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-bwg9f
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    nodeName: minikube3
+    priority: 0
+    restartPolicy: Always
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/disk-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/unschedulable
+      operator: Exists
+    volumes:
+    - name: default-token-bwg9f
+      secret:
+        defaultMode: 420
+        secretName: default-token-bwg9f
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:38Z"
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: null
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2019-10-07T16:05:37Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://949e6b37ad1e85dfeca958bb5a54c459305ef3d87e12d03e1ba90e121701b572
+      image: busybox:latest
+      imageID: docker-pullable://busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      lastState: {}
+      name: app
+      ready: true
+      restartCount: 0
+      state:
+        running:
+          startedAt: "2019-10-07T16:05:38Z"
+    hostIP: 192.168.64.3
+    phase: Running
+    podIP: 172.17.0.4
+    qosClass: BestEffort
+    startTime: "2019-10-07T16:05:37Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/fixtures/for_unit_tests/node.yml
+++ b/test/fixtures/for_unit_tests/node.yml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+    node.alpha.kubernetes.io/ttl: "0"
+    volumes.kubernetes.io/controller-managed-attach-detach: "true"
+  creationTimestamp: "2019-10-04T19:28:10Z"
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/hostname: minikube
+    node-role.kubernetes.io/master: ""
+  name: minikube
+  resourceVersion: "29256"
+  selfLink: /api/v1/nodes/minikube
+  uid: 19812251-e6dd-11e9-8f47-e6322f98393a
+spec: {}
+status:
+  addresses:
+  - address: 192.168.64.3
+    type: InternalIP
+  - address: minikube
+    type: Hostname
+  allocatable:
+    cpu: "2"
+    ephemeral-storage: "15625027559"
+    hugepages-2Mi: "0"
+    memory: 1887148Ki
+    pods: "110"
+  capacity:
+    cpu: "2"
+    ephemeral-storage: 16954240Ki
+    hugepages-2Mi: "0"
+    memory: 1989548Ki
+    pods: "110"
+  conditions:
+  - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+    lastTransitionTime: "2019-10-04T19:28:03Z"
+    message: kubelet has sufficient disk space available
+    reason: KubeletHasSufficientDisk
+    status: "False"
+    type: OutOfDisk
+  - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+    lastTransitionTime: "2019-10-04T19:28:03Z"
+    message: kubelet has sufficient memory available
+    reason: KubeletHasSufficientMemory
+    status: "False"
+    type: MemoryPressure
+  - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+    lastTransitionTime: "2019-10-04T19:28:03Z"
+    message: kubelet has no disk pressure
+    reason: KubeletHasNoDiskPressure
+    status: "False"
+    type: DiskPressure
+  - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+    lastTransitionTime: "2019-10-04T19:28:03Z"
+    message: kubelet has sufficient PID available
+    reason: KubeletHasSufficientPID
+    status: "False"
+    type: PIDPressure
+  - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+    lastTransitionTime: "2019-10-04T19:28:03Z"
+    message: kubelet is posting ready status
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
+  images:
+  - names:
+    - k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124
+    - k8s.gcr.io/etcd-amd64:3.2.18
+    sizeBytes: 218904307
+  - names:
+    - k8s.gcr.io/kube-apiserver-amd64@sha256:378cd9327666cc944a2f15f2b7877da8f090aaeb7d1a1a2871bf8c53ba9ffcd4
+    - k8s.gcr.io/kube-apiserver-amd64:v1.11.6
+    sizeBytes: 186736874
+  - names:
+    - k8s.gcr.io/kube-controller-manager-amd64@sha256:af281226e120d0f44ef91b59b47f265c6d5cc06d8831a69419f6c10cdc786167
+    - k8s.gcr.io/kube-controller-manager-amd64:v1.11.6
+    sizeBytes: 155332297
+  - names:
+    - k8s.gcr.io/kube-proxy-amd64@sha256:2de3e67c77e118dbfa82ec93e904af0a7124a24ca381eadb37f57e450255149f
+    - k8s.gcr.io/kube-proxy-amd64:v1.11.6
+    sizeBytes: 98120519
+  - names:
+    - kubernetesui/dashboard:v2.0.0-beta4
+    sizeBytes: 84034786
+  - names:
+    - k8s.gcr.io/kube-addon-manager:v9.0.2
+    sizeBytes: 83076028
+  - names:
+    - gcr.io/k8s-minikube/storage-provisioner:v1.8.1
+    sizeBytes: 80815640
+  - names:
+    - k8s.gcr.io/kube-scheduler-amd64@sha256:dc42eec94bde0394b02156071c014b4bbee579979a9778abfe33ec96283f83bd
+    - k8s.gcr.io/kube-scheduler-amd64:v1.11.6
+    sizeBytes: 56814410
+  - names:
+    - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8
+    sizeBytes: 50456751
+  - names:
+    - k8s.gcr.io/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
+    - k8s.gcr.io/coredns:1.1.3
+    sizeBytes: 45587362
+  - names:
+    - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+    sizeBytes: 42210862
+  - names:
+    - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+    sizeBytes: 40951779
+  - names:
+    - busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+    - busybox:latest
+    sizeBytes: 1219782
+  - names:
+    - busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0
+    - busybox:1.27
+    sizeBytes: 1129289
+  - names:
+    - k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
+    - k8s.gcr.io/pause:3.1
+    sizeBytes: 742472
+  nodeInfo:
+    architecture: amd64
+    bootID: 23beca4d-9f0a-417d-b029-9243db4e1e0c
+    containerRuntimeVersion: docker://18.9.9
+    kernelVersion: 4.15.0
+    kubeProxyVersion: v1.11.6
+    kubeletVersion: v1.11.6
+    machineID: 219c9f5531c94e468a47852c5b91cafe
+    operatingSystem: linux
+    osImage: Buildroot 2018.05.3
+    systemUUID: DBA111E9-0000-0000-98EA-ACDE48001122

--- a/test/fixtures/for_unit_tests/nodes.yml
+++ b/test/fixtures/for_unit_tests/nodes.yml
@@ -1,0 +1,414 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2019-10-04T19:28:10Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/hostname: minikube
+      node-role.kubernetes.io/master: ""
+    name: minikube
+    resourceVersion: "29256"
+    selfLink: /api/v1/nodes/minikube
+    uid: 19812251-e6dd-11e9-8f47-e6322f98393a
+  spec: {}
+  status:
+    addresses:
+    - address: 192.168.64.3
+      type: InternalIP
+    - address: minikube
+      type: Hostname
+    allocatable:
+      cpu: "2"
+      ephemeral-storage: "15625027559"
+      hugepages-2Mi: "0"
+      memory: 1887148Ki
+      pods: "110"
+    capacity:
+      cpu: "2"
+      ephemeral-storage: 16954240Ki
+      hugepages-2Mi: "0"
+      memory: 1989548Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient disk space available
+      reason: KubeletHasSufficientDisk
+      status: "False"
+      type: OutOfDisk
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124
+      - k8s.gcr.io/etcd-amd64:3.2.18
+      sizeBytes: 218904307
+    - names:
+      - k8s.gcr.io/kube-apiserver-amd64@sha256:378cd9327666cc944a2f15f2b7877da8f090aaeb7d1a1a2871bf8c53ba9ffcd4
+      - k8s.gcr.io/kube-apiserver-amd64:v1.11.6
+      sizeBytes: 186736874
+    - names:
+      - k8s.gcr.io/kube-controller-manager-amd64@sha256:af281226e120d0f44ef91b59b47f265c6d5cc06d8831a69419f6c10cdc786167
+      - k8s.gcr.io/kube-controller-manager-amd64:v1.11.6
+      sizeBytes: 155332297
+    - names:
+      - k8s.gcr.io/kube-proxy-amd64@sha256:2de3e67c77e118dbfa82ec93e904af0a7124a24ca381eadb37f57e450255149f
+      - k8s.gcr.io/kube-proxy-amd64:v1.11.6
+      sizeBytes: 98120519
+    - names:
+      - kubernetesui/dashboard:v2.0.0-beta4
+      sizeBytes: 84034786
+    - names:
+      - k8s.gcr.io/kube-addon-manager:v9.0.2
+      sizeBytes: 83076028
+    - names:
+      - gcr.io/k8s-minikube/storage-provisioner:v1.8.1
+      sizeBytes: 80815640
+    - names:
+      - k8s.gcr.io/kube-scheduler-amd64@sha256:dc42eec94bde0394b02156071c014b4bbee579979a9778abfe33ec96283f83bd
+      - k8s.gcr.io/kube-scheduler-amd64:v1.11.6
+      sizeBytes: 56814410
+    - names:
+      - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8
+      sizeBytes: 50456751
+    - names:
+      - k8s.gcr.io/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
+      - k8s.gcr.io/coredns:1.1.3
+      sizeBytes: 45587362
+    - names:
+      - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+      sizeBytes: 42210862
+    - names:
+      - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+      sizeBytes: 40951779
+    - names:
+      - busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      - busybox:latest
+      sizeBytes: 1219782
+    - names:
+      - busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0
+      - busybox:1.27
+      sizeBytes: 1129289
+    - names:
+      - k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
+      - k8s.gcr.io/pause:3.1
+      sizeBytes: 742472
+    nodeInfo:
+      architecture: amd64
+      bootID: 23beca4d-9f0a-417d-b029-9243db4e1e0c
+      containerRuntimeVersion: docker://18.9.9
+      kernelVersion: 4.15.0
+      kubeProxyVersion: v1.11.6
+      kubeletVersion: v1.11.6
+      machineID: 219c9f5531c94e468a47852c5b91cafe
+      operatingSystem: linux
+      osImage: Buildroot 2018.05.3
+      systemUUID: DBA111E9-0000-0000-98EA-ACDE48001122
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2019-10-04T19:28:10Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/hostname: minikube2
+      node-role.kubernetes.io/master: ""
+    name: minikube2
+    resourceVersion: "29256"
+    selfLink: /api/v1/nodes/minikube2
+    uid: 19812251-e6dd-11e9-8f47-e6322f98393b
+  spec: {}
+  status:
+    addresses:
+    - address: 192.168.64.3
+      type: InternalIP
+    - address: minikube2
+      type: Hostname
+    allocatable:
+      cpu: "2"
+      ephemeral-storage: "15625027559"
+      hugepages-2Mi: "0"
+      memory: 1887148Ki
+      pods: "110"
+    capacity:
+      cpu: "2"
+      ephemeral-storage: 16954240Ki
+      hugepages-2Mi: "0"
+      memory: 1989548Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient disk space available
+      reason: KubeletHasSufficientDisk
+      status: "False"
+      type: OutOfDisk
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124
+      - k8s.gcr.io/etcd-amd64:3.2.18
+      sizeBytes: 218904307
+    - names:
+      - k8s.gcr.io/kube-apiserver-amd64@sha256:378cd9327666cc944a2f15f2b7877da8f090aaeb7d1a1a2871bf8c53ba9ffcd4
+      - k8s.gcr.io/kube-apiserver-amd64:v1.11.6
+      sizeBytes: 186736874
+    - names:
+      - k8s.gcr.io/kube-controller-manager-amd64@sha256:af281226e120d0f44ef91b59b47f265c6d5cc06d8831a69419f6c10cdc786167
+      - k8s.gcr.io/kube-controller-manager-amd64:v1.11.6
+      sizeBytes: 155332297
+    - names:
+      - k8s.gcr.io/kube-proxy-amd64@sha256:2de3e67c77e118dbfa82ec93e904af0a7124a24ca381eadb37f57e450255149f
+      - k8s.gcr.io/kube-proxy-amd64:v1.11.6
+      sizeBytes: 98120519
+    - names:
+      - kubernetesui/dashboard:v2.0.0-beta4
+      sizeBytes: 84034786
+    - names:
+      - k8s.gcr.io/kube-addon-manager:v9.0.2
+      sizeBytes: 83076028
+    - names:
+      - gcr.io/k8s-minikube/storage-provisioner:v1.8.1
+      sizeBytes: 80815640
+    - names:
+      - k8s.gcr.io/kube-scheduler-amd64@sha256:dc42eec94bde0394b02156071c014b4bbee579979a9778abfe33ec96283f83bd
+      - k8s.gcr.io/kube-scheduler-amd64:v1.11.6
+      sizeBytes: 56814410
+    - names:
+      - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8
+      sizeBytes: 50456751
+    - names:
+      - k8s.gcr.io/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
+      - k8s.gcr.io/coredns:1.1.3
+      sizeBytes: 45587362
+    - names:
+      - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+      sizeBytes: 42210862
+    - names:
+      - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+      sizeBytes: 40951779
+    - names:
+      - busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      - busybox:latest
+      sizeBytes: 1219782
+    - names:
+      - busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0
+      - busybox:1.27
+      sizeBytes: 1129289
+    - names:
+      - k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
+      - k8s.gcr.io/pause:3.1
+      sizeBytes: 742472
+    nodeInfo:
+      architecture: amd64
+      bootID: 23beca4d-9f0a-417d-b029-9243db4e1e0c
+      containerRuntimeVersion: docker://18.9.9
+      kernelVersion: 4.15.0
+      kubeProxyVersion: v1.11.6
+      kubeletVersion: v1.11.6
+      machineID: 219c9f5531c94e468a47852c5b91cafe
+      operatingSystem: linux
+      osImage: Buildroot 2018.05.3
+      systemUUID: DBA111E9-0000-0000-98EA-ACDE48001122
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2019-10-04T19:28:10Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/hostname: minikube3
+      node-role.kubernetes.io/master: ""
+    name: minikube3
+    resourceVersion: "29256"
+    selfLink: /api/v1/nodes/minikube3
+    uid: 19812251-e6dd-11e9-8f47-e6322f98393c
+  spec: {}
+  status:
+    addresses:
+    - address: 192.168.64.3
+      type: InternalIP
+    - address: minikube3
+      type: Hostname
+    allocatable:
+      cpu: "2"
+      ephemeral-storage: "15625027559"
+      hugepages-2Mi: "0"
+      memory: 1887148Ki
+      pods: "110"
+    capacity:
+      cpu: "2"
+      ephemeral-storage: 16954240Ki
+      hugepages-2Mi: "0"
+      memory: 1989548Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient disk space available
+      reason: KubeletHasSufficientDisk
+      status: "False"
+      type: OutOfDisk
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2019-10-07T15:42:42Z"
+      lastTransitionTime: "2019-10-04T19:28:03Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124
+      - k8s.gcr.io/etcd-amd64:3.2.18
+      sizeBytes: 218904307
+    - names:
+      - k8s.gcr.io/kube-apiserver-amd64@sha256:378cd9327666cc944a2f15f2b7877da8f090aaeb7d1a1a2871bf8c53ba9ffcd4
+      - k8s.gcr.io/kube-apiserver-amd64:v1.11.6
+      sizeBytes: 186736874
+    - names:
+      - k8s.gcr.io/kube-controller-manager-amd64@sha256:af281226e120d0f44ef91b59b47f265c6d5cc06d8831a69419f6c10cdc786167
+      - k8s.gcr.io/kube-controller-manager-amd64:v1.11.6
+      sizeBytes: 155332297
+    - names:
+      - k8s.gcr.io/kube-proxy-amd64@sha256:2de3e67c77e118dbfa82ec93e904af0a7124a24ca381eadb37f57e450255149f
+      - k8s.gcr.io/kube-proxy-amd64:v1.11.6
+      sizeBytes: 98120519
+    - names:
+      - kubernetesui/dashboard:v2.0.0-beta4
+      sizeBytes: 84034786
+    - names:
+      - k8s.gcr.io/kube-addon-manager:v9.0.2
+      sizeBytes: 83076028
+    - names:
+      - gcr.io/k8s-minikube/storage-provisioner:v1.8.1
+      sizeBytes: 80815640
+    - names:
+      - k8s.gcr.io/kube-scheduler-amd64@sha256:dc42eec94bde0394b02156071c014b4bbee579979a9778abfe33ec96283f83bd
+      - k8s.gcr.io/kube-scheduler-amd64:v1.11.6
+      sizeBytes: 56814410
+    - names:
+      - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8
+      sizeBytes: 50456751
+    - names:
+      - k8s.gcr.io/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
+      - k8s.gcr.io/coredns:1.1.3
+      sizeBytes: 45587362
+    - names:
+      - k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
+      sizeBytes: 42210862
+    - names:
+      - k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
+      sizeBytes: 40951779
+    - names:
+      - busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
+      - busybox:latest
+      sizeBytes: 1219782
+    - names:
+      - busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0
+      - busybox:1.27
+      sizeBytes: 1129289
+    - names:
+      - k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
+      - k8s.gcr.io/pause:3.1
+      sizeBytes: 742472
+    nodeInfo:
+      architecture: amd64
+      bootID: 23beca4d-9f0a-417d-b029-9243db4e1e0c
+      containerRuntimeVersion: docker://18.9.9
+      kernelVersion: 4.15.0
+      kubeProxyVersion: v1.11.6
+      kubeletVersion: v1.11.6
+      machineID: 219c9f5531c94e468a47852c5b91cafe
+      operatingSystem: linux
+      osImage: Buildroot 2018.05.3
+      systemUUID: DBA111E9-0000-0000-98EA-ACDE48001122
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/daemon_set_test.rb
@@ -5,8 +5,8 @@ class DaemonSetTest < KubernetesDeploy::TestCase
   include ResourceCacheTestHelper
 
   def test_deploy_not_successful_when_updated_available_does_not_match
-    ds_template = build_ds_template
-    ds = build_synced_ds(template: ds_template)
+    ds_template = build_ds_template(filename: 'daemon_set.yml')
+    ds = build_synced_ds(ds_template: ds_template)
     refute_predicate(ds, :deploy_succeeded?)
   end
 
@@ -17,14 +17,14 @@ class DaemonSetTest < KubernetesDeploy::TestCase
       "desiredNumberScheduled": 2,
       "updatedNumberScheduled": 2,
     }
-    ds_template = build_ds_template(status: status)
-    ds = build_synced_ds(template: ds_template)
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    ds = build_synced_ds(ds_template: ds_template)
     refute_predicate(ds, :deploy_succeeded?)
   end
 
   def test_deploy_failed_ensures_controller_has_observed_deploy
-    ds_template = build_ds_template(status: { "observedGeneration": 1 })
-    ds = build_synced_ds(template: ds_template)
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: { "observedGeneration": 1 })
+    ds = build_synced_ds(ds_template: ds_template)
     ds.stubs(:pods).returns([stub(deploy_failed?: true)])
     refute_predicate(ds, :deploy_failed?)
   end
@@ -38,22 +38,98 @@ class DaemonSetTest < KubernetesDeploy::TestCase
       "observedGeneration": 2,
     }
 
-    ds_template = build_ds_template(status: status)
-    ds = build_synced_ds(template: ds_template)
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    ds = build_synced_ds(ds_template: ds_template)
     assert_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_passes_when_ready_pods_for_one_node
+    status = {
+      "desiredNumberScheduled": 1,
+      "updatedNumberScheduled": 1,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pod.yml'])
+    node_templates = load_fixtures(filenames: ['node.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    assert_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_passes_when_ready_pods_but_nodes_added
+    status = {
+      "desiredNumberScheduled": 1,
+      "updatedNumberScheduled": 1,
+      "numberReady": 0,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pod_not_ready.yml'])
+    node_templates = load_fixtures(filenames: ['node.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+
+    node_added_status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: node_added_status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: pod_templates)
+    ds.sync(build_resource_cache)
+    assert_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_fails_when_not_all_pods_updated
+    status = {
+      "desiredNumberScheduled": 2,
+      "updatedNumberScheduled": 1,
+      "numberReady": 1,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pod.yml'])
+    node_templates = load_fixtures(filenames: ['node.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_fails_when_not_all_pods_ready
+    status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+    node_templates = load_fixtures(filenames: ['nodes.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
   end
 
   private
 
-  def build_ds_template(status: {})
-    base_ds_maifest = YAML.load_stream(File.read(File.join(fixture_path('for_unit_tests'), 'daemon_set.yml'))).first
-    base_ds_maifest.deep_merge("status" => status)
+  def build_ds_template(filename:, status: {})
+    base_ds_manifest = YAML.load_stream(File.read(File.join(fixture_path('for_unit_tests'), filename))).first
+    base_ds_manifest.deep_merge("status" => status)
   end
 
-  def build_synced_ds(template:)
-    ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
-    stub_kind_get("DaemonSet", items: [template])
-    stub_kind_get("Pod", items: [])
+  def load_fixtures(filenames:)
+    filenames.each_with_object([]) do |filename, manifests|
+      manifest = YAML.load(File.read(File.join(fixture_path('for_unit_tests'), filename)))
+      if manifest['kind'] == 'List'
+        manifests.concat(manifest['items'])
+      else
+        manifests << manifest
+      end
+    end
+  end
+
+  def build_synced_ds(ds_template:, pod_templates: [], node_templates: [])
+    ds = KubernetesDeploy::DaemonSet.new(namespace: "test", context: "nope", logger: logger, definition: ds_template)
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: pod_templates)
+    stub_kind_get("Node", items: node_templates)
     ds.sync(build_resource_cache)
     ds
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Provide a solution to issue #565 

**How is this accomplished?**

    Support treating daemonsets as successful if new nodes added
    
    This allows for the daemonset to be treated as successful even if
    the daemonset is not 100% converged, so long as:
    
    - The desired and scheduled number of pods match
    - All desired pods for which there was an associated node at the
    start of the deploy process are in the Ready state
    
    This should allow for better toleration of autoscaling events, which
    can currently prevent convergence on daemonsets as new nodes may be
    added in the middle of the deploy.


**What could go wrong?**

If I am missing edge cases, it is possible that deploys could be prematurely and incorrectly marked as successful, which is not desirable.