### PR TITLE
Rescue `TaskConfigurationError` on `*Task.run()`

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -148,7 +148,7 @@ module KubernetesDeploy
     def run(*args)
       run!(*args)
       true
-    rescue FatalDeploymentError
+    rescue FatalDeploymentError, TaskConfigurationError
       false
     end
 

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -29,7 +29,7 @@ module KubernetesDeploy
     def run(*args)
       run!(*args)
       true
-    rescue KubernetesDeploy::FatalDeploymentError
+    rescue KubernetesDeploy::FatalDeploymentError, TaskConfigurationError
       false
     end
 

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -42,7 +42,7 @@ module KubernetesDeploy
     def run(*args)
       perform!(*args)
       true
-    rescue FatalDeploymentError
+    rescue FatalDeploymentError, TaskConfigurationError
       false
     end
     alias_method :perform, :run

--- a/lib/kubernetes-deploy/runner_task.rb
+++ b/lib/kubernetes-deploy/runner_task.rb
@@ -37,7 +37,7 @@ module KubernetesDeploy
     def run(*args)
       run!(*args)
       true
-    rescue DeploymentTimeoutError, FatalDeploymentError
+    rescue DeploymentTimeoutError, FatalDeploymentError, TaskConfigurationError
       false
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Make sure that `*Task.run()` won't raise in case of a `TaskConfigurationError`, returning `false` instead. This means that we'll keep the previous behaviour, essentially.

**How is this accomplished?**

I'm just rescuing the new exception (that replaced `FatalDeploymentError` in some cases).