### PR TITLE
Support 1.16

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,4 +1,11 @@
 steps:
+  - name: 'Run Test Suite (:kubernetes: 1.16-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: 4
+      KUBERNETES_VERSION: v1.16-latest
   - name: 'Run Test Suite (:kubernetes: 1.15-latest)'
     command: bin/ci
     agents:

--- a/.shopify-build/kubernetes-deploy.yml
+++ b/.shopify-build/kubernetes-deploy.yml
@@ -9,6 +9,13 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
+  - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.16-latest
   - label: 'Run Test Suite (:kubernetes: 1.15-latest)'
     command: bin/ci
     agents:

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -88,18 +88,31 @@ module KubernetesDeploy
         core/v1/PodTemplate
         core/v1/PersistentVolumeClaim
         batch/v1/Job
-        extensions/v1beta1/ReplicaSet
-        extensions/v1beta1/DaemonSet
-        extensions/v1beta1/Deployment
         extensions/v1beta1/Ingress
         networking.k8s.io/v1/NetworkPolicy
-        apps/v1beta1/StatefulSet
         autoscaling/v1/HorizontalPodAutoscaler
         policy/v1beta1/PodDisruptionBudget
         batch/v1beta1/CronJob
         rbac.authorization.k8s.io/v1/Role
         rbac.authorization.k8s.io/v1/RoleBinding
       )
+      pre_1_16 = %w(
+        extensions/v1beta1/ReplicaSet
+        extensions/v1beta1/DaemonSet
+        extensions/v1beta1/Deployment
+        apps/v1beta1/StatefulSet
+      )
+      post_1_16 = %w(
+        apps/v1/ReplicaSet
+        apps/v1/DaemonSet
+        apps/v1/Deployment
+        apps/v1/StatefulSet
+      )
+      wl += if server_version < Gem::Version.new("1.16.0")
+        pre_1_16
+      else
+        post_1_16
+      end
       wl + cluster_resource_discoverer.crds.select(&:prunable?).map(&:group_version_kind)
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Add support for 1.16
Fixes: https://github.com/Shopify/kubernetes-deploy/issues/592

**How is this accomplished?**
Update resource versions in prune white list https://github.com/redmcg/kubernetes-deploy/commit/73e03f23f3efd6813b0b0b7e0a505cc45c5ed754

**What could go wrong?**
We're already not compatible with 1.16 so unlikely this will make it worse. 