### PR TITLE
Support k8s 1.16

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -1,4 +1,11 @@
 steps:
+  - name: 'Run Test Suite (:kubernetes: 1.16-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: 4
+      KUBERNETES_VERSION: v1.16-latest
   - name: 'Run Test Suite (:kubernetes: 1.15-latest)'
     command: bin/ci
     agents:

--- a/.shopify-build/kubernetes-deploy.yml
+++ b/.shopify-build/kubernetes-deploy.yml
@@ -9,6 +9,13 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
+  - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.16-latest
   - label: 'Run Test Suite (:kubernetes: 1.15-latest)'
     command: bin/ci
     agents:

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ The following command will restart all pods in the `web` and `jobs` deployments:
 Add the annotation `shipit.shopify.io/restart` to all the deployments you want to target, like this:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web

--- a/lib/krane/kubeclient_builder.rb
+++ b/lib/krane/kubeclient_builder.rb
@@ -55,6 +55,14 @@ module Krane
       )
     end
 
+    def build_apps_v1_kubeclient(context)
+      build_kubeclient(
+        api_version: "v1",
+        context: context,
+        endpoint_path: "/apis/apps"
+      )
+    end
+
     def build_apps_v1beta1_kubeclient(context)
       build_kubeclient(
         api_version: "v1beta1",

--- a/lib/krane/kubeclient_builder.rb
+++ b/lib/krane/kubeclient_builder.rb
@@ -63,14 +63,6 @@ module Krane
       )
     end
 
-    def build_apps_v1beta1_kubeclient(context)
-      build_kubeclient(
-        api_version: "v1beta1",
-        context: context,
-        endpoint_path: "/apis/apps"
-      )
-    end
-
     def build_apiextensions_v1beta1_kubeclient(context)
       build_kubeclient(
         api_version: "v1beta1",

--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'krane/kubernetes_resource/pod_set_base'
+require "krane/kubernetes_resource/pod_set_base"
 module Krane
   class DaemonSet < PodSetBase
     TIMEOUT = 5.minutes
@@ -78,9 +78,13 @@ module Krane
 
     def parent_of_pod?(pod_data)
       return false unless pod_data.dig("metadata", "ownerReferences")
+
+      template_generation = @instance_data.dig("spec", "templateGeneration") ||
+        @instance_data.dig("metadata", "annotations", "deprecated.daemonset.template.generation")
+      return false unless template_generation.present?
+
       pod_data["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == @instance_data["metadata"]["uid"] } &&
-      pod_data["metadata"]["labels"]["pod-template-generation"].to_i ==
-        @instance_data["spec"]["templateGeneration"].to_i
+      pod_data["metadata"]["labels"]["pod-template-generation"].to_i == template_generation.to_i
     end
   end
 end

--- a/test/fixtures/branched/web.yml.erb
+++ b/test/fixtures/branched/web.yml.erb
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: <%= branch %>-web

--- a/test/fixtures/collection-with-erb/web_collection.yml.erb
+++ b/test/fixtures/collection-with-erb/web_collection.yml.erb
@@ -1,10 +1,13 @@
 <% %w(one two three).each do |name| %>
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: <%= "web-#{name}" %>
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: <%= "web-#{name}" %>
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/ejson-cloud/web.yaml
+++ b/test/fixtures/ejson-cloud/web.yaml
@@ -1,10 +1,17 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: ejson-cloud
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: ejson-cloud
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/ejson-cloud2/web.yml
+++ b/test/fixtures/ejson-cloud2/web.yml
@@ -1,10 +1,17 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web2
+  labels:
+    name: web2
+    app: ejson-cloud
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web2
+      app: ejson-cloud
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/for_unit_tests/daemon_set.yml
+++ b/test/fixtures/for_unit_tests/daemon_set.yml
@@ -1,7 +1,10 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ds-app
+  labels:
+    app: ds-app
+    name: ds-app
   generation: 2
   uid: 'c31a9b4e-e6dd-11e9-8f47-e6322f98393a'
 spec:

--- a/test/fixtures/for_unit_tests/deployment_test.yml
+++ b/test/fixtures/for_unit_tests/deployment_test.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
@@ -40,7 +40,7 @@ status:
     lastUpdateTime: "2018-01-09 22:56:45 UTC"
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: web-1

--- a/test/fixtures/for_unit_tests/pod_disruption_budget_test.yml
+++ b/test/fixtures/for_unit_tests/pod_disruption_budget_test.yml
@@ -3,6 +3,9 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: test
+  labels:
+    name: web
+    app: hello-cloud
   generation: 2
 spec:
   minAvailable: 2

--- a/test/fixtures/for_unit_tests/replica_set_test.yml
+++ b/test/fixtures/for_unit_tests/replica_set_test.yml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: test
   generation: 2
+  labels:
+    app: hello-cloud
+    name: test
 spec:
   replicas: 3
   selector:

--- a/test/fixtures/for_unit_tests/service_test.yml
+++ b/test/fixtures/for_unit_tests/service_test.yml
@@ -22,7 +22,7 @@ metadata:
 spec:
   type: ClusterIP
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: standard
@@ -72,7 +72,7 @@ spec:
   selector:
     type: zero-replica
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zero-replica
@@ -100,7 +100,7 @@ spec:
   selector:
     type: zero-replica-multiple
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zero-replica-multiple-1
@@ -120,7 +120,7 @@ spec:
       - name: app
         image: busybox
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zero-replica-multiple-2
@@ -148,14 +148,20 @@ spec:
   selector:
     type: zero-replica-statefulset
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app: hello-cloud
+    name: stateful-busybox
     type: zero-replica-statefulset
   name: stateful-busybox
 spec:
   serviceName: "zero-replica-statefulset"
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: stateful-busybox
   replicas: 0
   template:
     metadata:
@@ -181,7 +187,7 @@ spec:
   selector:
     type: mis-matched-pod
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mis-matched-deployment

--- a/test/fixtures/for_unit_tests/stateful_set_test.yml
+++ b/test/fixtures/for_unit_tests/stateful_set_test.yml
@@ -1,8 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: test-ss
   generation: 2
+  labels:
+    app: hello-cloud
+    name: test-ss
 spec:
   selector:
     matchLabels:

--- a/test/fixtures/hello-cloud/bare_replica_set.yml
+++ b/test/fixtures/hello-cloud/bare_replica_set.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   labels:

--- a/test/fixtures/hello-cloud/daemon_set.yml
+++ b/test/fixtures/hello-cloud/daemon_set.yml
@@ -1,8 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ds-app
+  labels:
+    app: hello-cloud
+    name: ds-app
 spec:
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: ds-app
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/persistent_volume_claim.yml
+++ b/test/fixtures/hello-cloud/persistent_volume_claim.yml
@@ -5,6 +5,7 @@ metadata:
   name: hello-pv-claim
   labels:
     app: hello-cloud
+    name: hello-pv-claim
 spec:
   accessModes:
   - ReadWriteOnce

--- a/test/fixtures/hello-cloud/redis.yml
+++ b/test/fixtures/hello-cloud/redis.yml
@@ -59,12 +59,19 @@ spec:
     requests:
       storage: 100M
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
+  labels:
+    name: redis
+    app: hello-cloud
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: redis
+      app: hello-cloud
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/hello-cloud/stateful_set.yml
+++ b/test/fixtures/hello-cloud/stateful_set.yml
@@ -15,13 +15,20 @@ spec:
     name: stateful-busybox
     app: hello-cloud
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: stateful-busybox
+  labels:
+    name: stateful-busybox
+    app: hello-cloud
 spec:
   serviceName: "stateful-busybox"
   replicas: 2
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: stateful-busybox
   template:
     metadata:
       labels:

--- a/test/fixtures/hello-cloud/web.yml.erb
+++ b/test/fixtures/hello-cloud/web.yml.erb
@@ -30,14 +30,21 @@ spec:
     name: web
     app: hello-cloud
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
   annotations:
     shipit.shopify.io/restart: "true"
+  labels:
+    name: web
+    app: hello-cloud
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/invalid-partials/include-invalid-partial.yml.erb
+++ b/test/fixtures/invalid-partials/include-invalid-partial.yml.erb
@@ -1,10 +1,17 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: crash-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: crash-app
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/bad_probe.yml
+++ b/test/fixtures/invalid/bad_probe.yml
@@ -1,9 +1,16 @@
-apiVersion: extensions/v1beta1 # keep as long as this group is valid
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bad-probe
+  labels:
+    name: bad-probe
+    app: crash-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: bad-probe
+      app: crash-app
   # progressDeadlineSeconds: 10 -- do not add: this is used to test the hard deadline
   template:
     metadata:

--- a/test/fixtures/invalid/cannot_run.yml
+++ b/test/fixtures/invalid/cannot_run.yml
@@ -1,9 +1,16 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cannot-run
+  labels:
+    name: cannot-run
+    app: crash-app
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: cannot-run
+      app: crash-app
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/invalid/crash_loop.yml
+++ b/test/fixtures/invalid/crash_loop.yml
@@ -1,9 +1,16 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crash-loop
+  labels:
+    name: crash-loop
+    app: crash-app
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: crash-loop
+      app: crash-app
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/invalid/crash_loop_daemon_set.yml
+++ b/test/fixtures/invalid/crash_loop_daemon_set.yml
@@ -1,8 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: crash-loop
+  labels:
+    name: crash-loop
+    app: crash-app
 spec:
+  selector:
+    matchLabels:
+      name: crash-loop
+      app: crash-app
   template:
     metadata:
       labels:

--- a/test/fixtures/invalid/init_crash.yml
+++ b/test/fixtures/invalid/init_crash.yml
@@ -1,9 +1,16 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: init-crash
+  labels:
+    name: init-crash
+    app: crash-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: init-crash
+      app: crash-app
   progressDeadlineSeconds: 60
   template:
     metadata:

--- a/test/fixtures/invalid/missing_volumes.yml
+++ b/test/fixtures/invalid/missing_volumes.yml
@@ -1,9 +1,16 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: missing-volumes
+  labels:
+    name: missing-volumes
+    app: crash-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: missing-volumes
+      app: crash-app
   progressDeadlineSeconds: 15
   template:
     metadata:

--- a/test/fixtures/long-running/undying-deployment.yml.erb
+++ b/test/fixtures/long-running/undying-deployment.yml.erb
@@ -11,12 +11,19 @@ spec:
     name: undying
     app: fixtures
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: undying
+  labels:
+    name: undying
+    app: fixtures
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: undying
+      app: fixtures
   progressDeadlineSeconds: 60
   revisionHistoryLimit: 1
   strategy:

--- a/test/fixtures/resource-quota/web.yml
+++ b/test/fixtures/resource-quota/web.yml
@@ -1,11 +1,18 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: hello-cloud
   annotations:
     shipit.shopify.io/restart: "true"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
   progressDeadlineSeconds: 20 # Don't set too high--fixture is used in timeout tests
   template:
     metadata:

--- a/test/fixtures/slow-cloud/web.yml.erb
+++ b/test/fixtures/slow-cloud/web.yml.erb
@@ -1,7 +1,10 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: slow-cloud
   annotations:
     shipit.shopify.io/restart: "true"
     krane.shopify.io/required-rollout: maxUnavailable

--- a/test/fixtures/some-invalid/stateful_set.yml
+++ b/test/fixtures/some-invalid/stateful_set.yml
@@ -1,9 +1,16 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: stateful-busybox
+  labels:
+    app: hello-cloud
+    name: stateful-busybox
 spec:
   serviceName: "stateful-busybox"
+  selector:
+    matchLabels:
+      app: hello-cloud
+      name: stateful-busybox
   replicas: 2
   template:
     metadata:

--- a/test/fixtures/test-partials/deployment.yaml.erb
+++ b/test/fixtures/test-partials/deployment.yaml.erb
@@ -1,10 +1,17 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
+  labels:
+    name: web
+    app: test-partials
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: test-partials
   template:
     metadata:
       labels:

--- a/test/fixtures/test-partials2/deployment.yml.erb
+++ b/test/fixtures/test-partials2/deployment.yml.erb
@@ -1,4 +1,4 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 <<: <%= partial 'pod' %>  # Use same partial name as `test-partials` dir to ensure no naming collision

--- a/test/fixtures/test-partials2/partials/pod.yaml.erb
+++ b/test/fixtures/test-partials2/partials/pod.yaml.erb
@@ -1,7 +1,14 @@
 metadata:
   name: web-from-partial
+  labels:
+    name: web-from-partial
+    app: test-partials
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: web-from-partial
+      app: test-partials
   template:
     metadata:
       labels:

--- a/test/fixtures/unrecognized-type/test-rc.yml.erb
+++ b/test/fixtures/unrecognized-type/test-rc.yml.erb
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: test-rc
+  labels:
+    name: test-rc
+    app: unrecognized-type
 spec:
   replicas: 0
   template:

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -50,7 +50,7 @@ module FixtureSetAssertions
     end
 
     def refute_web_resources_exist
-      refute_resource_exists("deployment", "web", beta: true)
+      refute_resource_exists("deployment", "web")
       refute_resource_exists("ingress", "web", beta: true)
       refute_resource_exists("service", "web")
     end
@@ -63,7 +63,7 @@ module FixtureSetAssertions
     end
 
     def refute_redis_resources_exist(expect_pvc: false)
-      refute_resource_exists("deployment", "redis", beta: true)
+      refute_resource_exists("deployment", "redis")
       refute_resource_exists("service", "redis")
       if expect_pvc
         assert_pvc_status("redis", "Bound")

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -24,10 +24,6 @@ module KubeclientHelper
     @apps_v1_kubeclient ||= kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
   end
 
-  def apps_v1beta1_kubeclient
-    @apps_v1beta1_kubeclient ||= kubeclient_builder.build_apps_v1beta1_kubeclient(TEST_CONTEXT)
-  end
-
   def batch_v1beta1_kubeclient
     @batch_v1beta1_kubeclient ||= kubeclient_builder.build_batch_v1beta1_kubeclient(TEST_CONTEXT)
   end

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -20,6 +20,10 @@ module KubeclientHelper
     @policy_v1beta1_kubeclient ||= kubeclient_builder.build_policy_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
+  def apps_v1_kubeclient
+    @apps_v1_kubeclient ||= kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
+  end
+
   def apps_v1beta1_kubeclient
     @apps_v1beta1_kubeclient ||= kubeclient_builder.build_apps_v1beta1_kubeclient(TEST_CONTEXT)
   end

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -103,7 +103,7 @@ class KraneTest < Krane::IntegrationTest
   end
 
   def fetch_restarted_at(deployment_name)
-    deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
+    deployment = apps_v1_kubeclient.get_deployment(deployment_name, @namespace)
     containers = deployment.spec.template.spec.containers
     app_container = containers.find { |c| c["name"] == "app" }
     app_container&.env&.find { |n| n.name == "RESTARTED_AT" }

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -85,12 +85,19 @@ class RenderTaskTest < Krane::TestCase
     stdout_assertion do |output|
       expected = <<~RENDERED
         ---
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: web
+          labels:
+            name: web
+            app: test-partials
         spec:
           replicas: 1
+          selector:
+            matchLabels:
+              name: web
+              app: test-partials
           template:
             metadata:
               labels:

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -342,7 +342,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def fetch_restarted_at(deployment_name)
-    deployment = v1beta1_kubeclient.get_deployment(deployment_name, @namespace)
+    deployment = apps_v1_kubeclient.get_deployment(deployment_name, @namespace)
     containers = deployment.spec.template.spec.containers
     app_container = containers.find { |c| c["name"] == "app" }
     app_container&.env&.find { |n| n.name == "RESTARTED_AT" }

--- a/test/setup/metrics-server/metrics-server-deployment.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server

--- a/test/setup/metrics-server/metrics-server-deployment.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.1
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         imagePullPolicy: Always
         args: ["--kubelet-insecure-tls"]
         volumeMounts:

--- a/test/setup/metrics-server/metrics-server-deployment_021.yaml
+++ b/test/setup/metrics-server/metrics-server-deployment_021.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Support Kubernetes 1.16.

** Kubernetes 1.16 changes

- https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16

**How is this accomplished?**

-  Build/Test krane with k8s 1.16
- Update k8s templates to apps/v1
- [Update k8s-ci metrics-server to 0.3.6](https://github.com/Shopify/k8s-ci/pull/32)
- Upgrade metrics-server container to v0.3.6
- Add support for apps/v1 k8s API client
- Improve template generation detection for k8s 1.16
- Fallback to deprecated fields if count and lastTimestamp aren't present 

**What could go wrong?**

This is a big change in the sense that in order to support `kubernetes 1.16`, we needed to migrate to `v1`API for `DaemonSet`, `Deployment`,  `ReplicaSet`, and `StatefulSet`.

I think the problems that this PR could bring are related to the changes needed in user projects to support Kubernetes 1.16 and `v1` API.
