### PR TITLE
Fix the vast majority of Ruby warnings

### DIFF
--- a/lib/kubernetes-deploy/container_logs.rb
+++ b/lib/kubernetes-deploy/container_logs.rb
@@ -14,6 +14,7 @@ module KubernetesDeploy
       @lines = []
       @next_print_index = 0
       @printed_latest = false
+      @last_timestamp = nil
     end
 
     def sync

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -112,6 +112,7 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, definition:, logger:, statsd_tags: [])
       # subclasses must also set these if they define their own initializer
+      @deploy_started_at = nil
       @name = definition.dig("metadata", "name").to_s
       @optional_statsd_tags = statsd_tags
       @namespace = namespace
@@ -124,6 +125,9 @@ module KubernetesDeploy
       @validation_warnings = []
       @instance_data = {}
       @server_dry_run_validated = false
+      @type = nil
+      @debug_events = nil
+      @debug_logs = nil
     end
 
     def to_kubeclient_resource

--- a/lib/kubernetes-deploy/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/custom_resource_definition.rb
@@ -7,6 +7,11 @@ module KubernetesDeploy
     TIMEOUT_FOR_INSTANCE_ANNOTATION = "krane.shopify.io/instance-timeout"
     GLOBAL = true
 
+    def initialize(*)
+      super
+      @rollout_conditions_validated = nil
+    end
+
     def deploy_succeeded?
       names_accepted_status == "True"
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -5,6 +5,11 @@ module KubernetesDeploy
     TIMEOUT = 5.minutes
     attr_reader :pods
 
+    def initialize(_)
+      super
+      @nodes = nil
+    end
+
     def sync(cache)
       super
       @pods = exists? ? find_pods(cache) : []

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -13,6 +13,10 @@ module KubernetesDeploy
 
     def initialize(namespace:, context:, definition:, logger:,
       statsd_tags: nil, parent: nil, deploy_started_at: nil, stream_logs: false)
+
+      super(namespace: namespace, context: context, definition: definition,
+            logger: logger, statsd_tags: statsd_tags)
+
       @parent = parent
       @deploy_started_at = deploy_started_at
 
@@ -23,8 +27,7 @@ module KubernetesDeploy
       end
       @containers += definition["spec"].fetch("initContainers", []).map { |c| Container.new(c, init_container: true) }
       @stream_logs = stream_logs
-      super(namespace: namespace, context: context, definition: definition,
-            logger: logger, statsd_tags: statsd_tags)
+
     end
 
     def sync(_cache)

--- a/lib/kubernetes-deploy/remote_logs.rb
+++ b/lib/kubernetes-deploy/remote_logs.rb
@@ -17,6 +17,7 @@ module KubernetesDeploy
           context: context
         )
       end
+      @already_displayed = nil
     end
 
     def empty?

--- a/lib/kubernetes-deploy/template_sets.rb
+++ b/lib/kubernetes-deploy/template_sets.rb
@@ -13,6 +13,7 @@ module KubernetesDeploy
         @template_dir = template_dir
         @files = file_whitelist
         @logger = logger
+        @renderer = nil
       end
 
       def with_resource_definitions_and_filename(render_erb: false, current_sha: nil, bindings: nil, raw: false)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,6 +62,7 @@ module KubernetesDeploy
 
     def run
       ban_net_connect? ? WebMock.disable_net_connect! : WebMock.allow_net_connect!
+      @namespace = nil
       yield if block_given?
       super
     end

--- a/test/unit/kubernetes-deploy/kubernetes_resource/custom_resource_definition_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource/custom_resource_definition_test.rb
@@ -93,7 +93,7 @@ class CustomResourceDefinitionTest < KubernetesDeploy::TestCase
   def test_cr_instance_fails_validation_when_rollout_conditions_for_crd_invalid
     crd = build_crd(merge_rollout_annotation('bad string'))
     cr = KubernetesDeploy::KubernetesResource.build(namespace: "test", context: "test",
-      logger: @logger, statsd_tags: @statsd_tags, crd: crd,
+      logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
         "metadata" => { "name" => "test" },

--- a/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
+++ b/test/unit/kubernetes-deploy/kubernetes_resource_test.rb
@@ -11,6 +11,7 @@ class KubernetesResourceTest < KubernetesDeploy::TestCase
       definition = { "kind" => "DummyResource", "metadata" => { "name" => "test" } }.merge(definition_extras)
       super(namespace: 'test', context: 'test', definition: definition, logger: ::Logger.new($stderr))
       @succeeded = false
+      @deploy_failed = false
     end
 
     def exists?


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

When running `rake` to run the test suite using macOS system Ruby, the output is 90% Ruby warnings, because this `rake` version runs with warnings enabled. Most of the warnings are caused by uninitialized instance variables.

**How is this accomplished?**

Initializing instance variables before using them makes them go away. There are two wranings coming from dependencies that this doesn't address.

**What could go wrong?**

Unsure. It's theoretically possible that this breaks something, but it's highly unlikely. The more important question is whether we care about these warnings or not.
