### PR TITLE
Support multiple filenames in krane deploy

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -13,7 +13,7 @@ module Krane
         "bindings" => { type: :array, banner: "foo=bar abc=def",
                         desc: "Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file "\
                           "(JSON or YAML) path prefixed by '@')" },
-        "filenames" => { type: :string, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
+        "filenames" => { type: :array, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
                          desc: "Path to file or directory that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
                               desc: "Max duration to monitor workloads correctly deployed" },
@@ -51,7 +51,7 @@ module Krane
           protected_namespaces = []
         end
 
-        KubernetesDeploy::OptionsHelper.with_processed_template_paths([options[:filenames]],
+        KubernetesDeploy::OptionsHelper.with_processed_template_paths(options[:filenames],
           require_explicit_path: true) do |paths|
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -13,8 +13,9 @@ module Krane
         "bindings" => { type: :array, banner: "foo=bar abc=def",
                         desc: "Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file "\
                           "(JSON or YAML) path prefixed by '@')" },
-        "filenames" => { type: :array, banner: '/tmp/my-resource.yml', aliases: :f, required: true,
-                         desc: "Path to file or directory that contains the configuration to apply" },
+        "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
+                         aliases: :f, required: true,
+                         desc: "Directories and files that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
                               desc: "Max duration to monitor workloads correctly deployed" },
         "protected-namespaces" => { type: :array, banner: "namespace1 namespace2 namespaceN",

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -4,8 +4,9 @@ module Krane
   module CLI
     class RenderCommand
       OPTIONS = {
-        bindings: { type: :array, desc: 'Bindings for erb' },
-        filenames: { type: :array, required: true, aliases: 'f', desc: 'Directories and files to render' },
+        bindings: { type: :array, banner: "foo=bar abc=def", desc: 'Bindings for erb' },
+        filenames: { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
+                     required: true, aliases: 'f', desc: 'Directories and files to render' },
       }
 
       def self.from_options(options)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Currently the `-f` flag in for `krane deploy` only supports a single filename or directly. This appears to be an oversight from waiting for thor to handle repeated flags.  `Krane render` supports the multiple files/directories. 

**How is this accomplished?**
Change thor type to an array. 

**What could go wrong?**
We don't support csv only white space separated. 