### PR TITLE
Allow Krane to deploy resources which use generateName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *Important!*
 - The next release will be 1.0.0, which means that master will contain breaking changes.
 
+*Enhancements*
+- Add support for deploying resources that use `generateName` ([#608](https://github.com/Shopify/kubernetes-deploy/pull/608))
+
 ## 0.30.0
 
 *Enhancements*

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -46,10 +46,6 @@ module Krane
       @definition.dig("spec", "names", "kind")
     end
 
-    def name
-      @definition.dig("metadata", "name")
-    end
-
     def prunable?
       prunable = krane_annotation_value("prunable")
       prunable == "true"

--- a/lib/krane/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/krane/kubernetes_resource/pod_disruption_budget.rb
@@ -13,7 +13,7 @@ module Krane
 
     def deploy_method
       # Required until https://github.com/kubernetes/kubernetes/issues/45398 changes
-      :replace_force
+      uses_generate_name? ? :create : :replace_force
     end
 
     def timeout_message

--- a/test/fixtures/generateName/bad_secret.yml
+++ b/test/fixtures/generateName/bad_secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  generateName: generate-name-secret-
+type: Opaque
+data:
+  username: YWRt\\\\\/////aW4=
+  password: cGFzc3dvcmQ=

--- a/test/fixtures/generateName/pdb.yml
+++ b/test/fixtures/generateName/pdb.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  generateName: test-
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      type: pod-using-generate-name

--- a/test/fixtures/generateName/pod.yml
+++ b/test/fixtures/generateName/pod.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-using-generate-name-
+  annotations:
+    krane.shopify.io/timeout-override: 60s
+  labels:
+    type: pod-using-generate-name
+    name: pod-using-generate-name
+spec:
+  activeDeadlineSeconds: 60
+  restartPolicy: Never
+  containers:
+  - name: busybox-container
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "echo 'Hello from the command runner!' && test 1 -eq 1"]

--- a/test/fixtures/generateName/secret.yml
+++ b/test/fixtures/generateName/secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  generateName: generate-name-secret-
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -101,17 +101,6 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
   private
 
-  def stub_dry_run_validation_request
-    stub_kubectl_response("apply", "-f", anything, "--dry-run", "--output=name",
-      resp: dummy_secret_hash, json: false,
-      kwargs: {
-        log_failure: false,
-        output_is_sensitive: true,
-        retry_whitelist: [:client_timeout],
-        attempts: 3,
-      })
-  end
-
   def stub_server_dry_run_validation_request
     stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
       resp: dummy_secret_hash, json: false,


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

~Fix bug~ Allow Krane to deploy resources which use generateName.
In short, Kubernetes doesn't support using `apply` on templates that contain `generateName`, One must specify a `name`. [See here](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply).

**How is this accomplished?**

Support `create` when `name` is blank and `generateName` is present!
This involves some hackery though, notably setting `@file` to `nil` and setting `@name` explicitly.
Had to also update our `dry-run` validations to use `create` rather than `apply`.

**What could go wrong?**

Could break deploys in general maybe?

Feedback would be greatly appreciated!

EDIT I had this written as if this fixes a bug but this has been the behaviour forever so maybe that's not fair.