### PR TITLE
Add optional revision flag

### DIFF
--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -17,6 +17,7 @@ bindings = {}
 verbose_log_prefix = false
 max_watch_seconds = nil
 selector = nil
+revision = ENV["REVISION"]
 
 ARGV.options do |opts|
   parser = Krane::BindingsParser.new
@@ -52,6 +53,7 @@ ARGV.options do |opts|
     puts "v#{Krane::VERSION}"
     exit
   end
+  opts.on("--revision=REVISION", "Expose SHA `current_sha` in ERB bindings") { |r| revision = r }
   opts.parse!
   bindings = parser.parse
 end
@@ -72,7 +74,7 @@ begin
     runner = KubernetesDeploy::DeployTask.new(
       namespace: namespace,
       context: context,
-      current_sha: ENV["REVISION"],
+      current_sha: revision,
       template_paths: paths,
       bindings: bindings,
       logger: logger,

--- a/exe/kubernetes-deploy
+++ b/exe/kubernetes-deploy
@@ -17,7 +17,7 @@ bindings = {}
 verbose_log_prefix = false
 max_watch_seconds = nil
 selector = nil
-revision = ENV["REVISION"]
+current_sha = ENV["REVISION"]
 
 ARGV.options do |opts|
   parser = Krane::BindingsParser.new
@@ -53,7 +53,7 @@ ARGV.options do |opts|
     puts "v#{Krane::VERSION}"
     exit
   end
-  opts.on("--revision=REVISION", "Expose SHA `current_sha` in ERB bindings") { |r| revision = r }
+  opts.on("--current-sha=CURRENT_SHA", "Expose SHA `current_sha` in ERB bindings") { |r| current_sha = r }
   opts.parse!
   bindings = parser.parse
 end
@@ -74,7 +74,7 @@ begin
     runner = KubernetesDeploy::DeployTask.new(
       namespace: namespace,
       context: context,
-      current_sha: revision,
+      current_sha: current_sha,
       template_paths: paths,
       bindings: bindings,
       logger: logger,

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -9,6 +9,7 @@ require 'optparse'
 
 template_dir = []
 bindings = {}
+revision = ENV["REVISION"]
 
 ARGV.options do |opts|
   parser = Krane::BindingsParser.new
@@ -17,6 +18,7 @@ ARGV.options do |opts|
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT).") do |d|
     template_dir = [d]
   end
+  opts.on("--revision=REVISION", "Expose SHA `current_sha` in ERB bindings") { |r| revision = r }
   opts.parse!
   bindings = parser.parse
 end
@@ -27,7 +29,7 @@ logger = Krane::FormattedLogger.build(verbose_prefix: false)
 begin
   Krane::OptionsHelper.with_processed_template_paths(template_dir) do |dir|
     runner = KubernetesDeploy::RenderTask.new(
-      current_sha: ENV["REVISION"],
+      current_sha: revision,
       template_dir: dir.first,
       bindings: bindings,
     )

--- a/exe/kubernetes-render
+++ b/exe/kubernetes-render
@@ -9,7 +9,7 @@ require 'optparse'
 
 template_dir = []
 bindings = {}
-revision = ENV["REVISION"]
+current_sha = ENV["REVISION"]
 
 ARGV.options do |opts|
   parser = Krane::BindingsParser.new
@@ -18,7 +18,7 @@ ARGV.options do |opts|
   opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT).") do |d|
     template_dir = [d]
   end
-  opts.on("--revision=REVISION", "Expose SHA `current_sha` in ERB bindings") { |r| revision = r }
+  opts.on("--current-sha=CURRENT_SHA", "Expose SHA `current_sha` in ERB bindings") { |r| current_sha = r }
   opts.parse!
   bindings = parser.parse
 end
@@ -29,7 +29,7 @@ logger = Krane::FormattedLogger.build(verbose_prefix: false)
 begin
   Krane::OptionsHelper.with_processed_template_paths(template_dir) do |dir|
     runner = KubernetesDeploy::RenderTask.new(
-      current_sha: revision,
+      current_sha: current_sha,
       template_dir: dir.first,
       bindings: bindings,
     )

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -31,7 +31,7 @@ module Krane
                                   default: true },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
-        "revision" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
+        "current-sha" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
 
       }
 
@@ -59,7 +59,7 @@ module Krane
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,
             context: context,
-            current_sha: options.fetch(:revision, ENV["REVISION"]),
+            current_sha: options['current-sha'],
             template_paths: paths,
             bindings: bindings_parser.parse,
             logger: logger,

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -31,6 +31,8 @@ module Krane
                                   default: true },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
+        "revision" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
+
       }
 
       def self.from_options(namespace, context, options)
@@ -57,7 +59,7 @@ module Krane
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,
             context: context,
-            current_sha: ENV["REVISION"],
+            current_sha: options.fetch(:revision, ENV["REVISION"]),
             template_paths: paths,
             bindings: bindings_parser.parse,
             logger: logger,

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -7,7 +7,7 @@ module Krane
         bindings: { type: :array, banner: "foo=bar abc=def", desc: 'Bindings for erb' },
         filenames: { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                      required: true, aliases: 'f', desc: 'Directories and files to render' },
-        revision: { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
+        'current-sha': { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
       }
 
       def self.from_options(options)
@@ -20,7 +20,7 @@ module Krane
 
         ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames]) do |paths|
           runner = ::Krane::RenderTask.new(
-            current_sha: options.fetch(:revision, ENV["REVISION"]),
+            current_sha: options['current-sha'],
             template_paths: paths,
             bindings: bindings_parser.parse,
           )

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -7,6 +7,7 @@ module Krane
         bindings: { type: :array, banner: "foo=bar abc=def", desc: 'Bindings for erb' },
         filenames: { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                      required: true, aliases: 'f', desc: 'Directories and files to render' },
+        revision: { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
       }
 
       def self.from_options(options)
@@ -19,7 +20,7 @@ module Krane
 
         ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames]) do |paths|
           runner = ::Krane::RenderTask.new(
-            current_sha: ENV["REVISION"],
+            current_sha: options.fetch(:revision, ENV["REVISION"]),
             template_paths: paths,
             bindings: bindings_parser.parse,
           )

--- a/lib/krane/deprecated_deploy_task.rb
+++ b/lib/krane/deprecated_deploy_task.rb
@@ -597,7 +597,8 @@ module Krane
     end
 
     def statsd_tags
-      %W(namespace:#{@namespace} sha:#{@current_sha} context:#{@context}) | @namespace_tags
+      tags = %W(namespace:#{@namespace} context:#{@context}) | @namespace_tags
+      @current_sha.nil? ? tags : %W(sha:#{@current_sha}) | tags
     end
 
     def with_retries(limit)

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -4,8 +4,6 @@ require 'krane/cli/krane'
 require 'krane/bindings_parser'
 
 class DeployTest < Krane::TestCase
-  include EnvTestHelper
-
   def test_deploy_with_default_options
     set_krane_deploy_expectations
     krane_deploy!
@@ -81,27 +79,10 @@ class DeployTest < Krane::TestCase
     end
   end
 
-  def test_deploy_uses_revision_env_var
-    test_sha = "TEST"
-    with_env("REVISION", test_sha) do
-      set_krane_deploy_expectations(new_args: { current_sha: test_sha })
-      krane_deploy!
-    end
-  end
-
-  def test_deploy_uses_revision
+  def test_deploy_uses_current_sha
     test_sha = "TEST"
     set_krane_deploy_expectations(new_args: { current_sha: test_sha })
-    krane_deploy!(flags: "--revision #{test_sha}")
-  end
-
-  def test_render_uses_revision_flag_over_env_var
-    env_test_sha = "NOT_TEST_VALUE_TEST"
-    test_sha = "TEST"
-    with_env("REVISION", env_test_sha) do
-      set_krane_deploy_expectations(new_args: { current_sha: test_sha })
-      krane_deploy!(flags: "--revision #{test_sha}")
-    end
+    krane_deploy!(flags: "--current-sha #{test_sha}")
   end
 
   private

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -4,6 +4,8 @@ require 'krane/cli/krane'
 require 'krane/bindings_parser'
 
 class DeployTest < Krane::TestCase
+  include EnvTestHelper
+
   def test_deploy_with_default_options
     set_krane_deploy_expectations
     krane_deploy!
@@ -76,6 +78,29 @@ class DeployTest < Krane::TestCase
     )
     assert_raises_message(Thor::RequiredArgumentMissingError, "No value provided for required options '--filenames'") do
       krane.invoke("deploy")
+    end
+  end
+
+  def test_deploy_uses_revision_env_var
+    test_sha = "TEST"
+    with_env("REVISION", test_sha) do
+      set_krane_deploy_expectations(new_args: { current_sha: test_sha })
+      krane_deploy!
+    end
+  end
+
+  def test_deploy_uses_revision
+    test_sha = "TEST"
+    set_krane_deploy_expectations(new_args: { current_sha: test_sha })
+    krane_deploy!(flags: "--revision #{test_sha}")
+  end
+
+  def test_render_uses_revision_flag_over_env_var
+    env_test_sha = "NOT_TEST_VALUE_TEST"
+    test_sha = "TEST"
+    with_env("REVISION", env_test_sha) do
+      set_krane_deploy_expectations(new_args: { current_sha: test_sha })
+      krane_deploy!(flags: "--revision #{test_sha}")
     end
   end
 

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -31,6 +31,21 @@ class RendertTest < Krane::TestCase
     end
   end
 
+  def test_render_uses_revision
+    test_sha = "TEST"
+    install_krane_render_expectations(current_sha: test_sha)
+    krane_render!("--revision #{test_sha}")
+  end
+
+  def test_render_uses_revision_flag_over_env_current_sha
+    env_test_sha = "NOT_TEST_VALUE_TEST"
+    test_sha = "TEST"
+    with_env("REVISION", env_test_sha) do
+      install_krane_render_expectations(current_sha: test_sha)
+      krane_render!("--revision #{test_sha}")
+    end
+  end
+
   private
 
   def install_krane_render_expectations(new_args = {})
@@ -40,7 +55,8 @@ class RendertTest < Krane::TestCase
     Krane::RenderTask.expects(:new).with(options).returns(response)
   end
 
-  def krane_render!(flags = '-f /dev/null')
+  def krane_render!(flags = "")
+    flags += ' -f /dev/null' unless flags.include?("-f")
     krane = Krane::CLI::Krane.new(
       [],
       flags.split

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 require 'krane/cli/krane'
 
 class RendertTest < Krane::TestCase
-  include EnvTestHelper
   def test_render_with_default_options
     install_krane_render_expectations
     krane_render!
@@ -25,25 +24,8 @@ class RendertTest < Krane::TestCase
 
   def test_render_uses_current_sha
     test_sha = "TEST"
-    with_env("REVISION", test_sha) do
-      install_krane_render_expectations
-      krane_render!
-    end
-  end
-
-  def test_render_uses_revision
-    test_sha = "TEST"
     install_krane_render_expectations(current_sha: test_sha)
-    krane_render!("--revision #{test_sha}")
-  end
-
-  def test_render_uses_revision_flag_over_env_current_sha
-    env_test_sha = "NOT_TEST_VALUE_TEST"
-    test_sha = "TEST"
-    with_env("REVISION", env_test_sha) do
-      install_krane_render_expectations(current_sha: test_sha)
-      krane_render!("--revision #{test_sha}")
-    end
+    krane_render!("--current-sha #{test_sha}")
   end
 
   private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

As part of the [krane 1.0 migration](https://docs.google.com/document/d/1oInUsKplYGNWTymPY48xtDCx3x4Cwc-phcEKUkt2v4U/view) we decided to add a ~`--revision`~ `--current-sha` flag. 

~This PR adds the flag with higher precedence than `ENV["REVISION"]`.~

I've added it to the old tasks so that transitioning to `krane` is easier.
 
closes: https://github.com/Shopify/kubernetes-deploy/issues/605

**How is this accomplished?**
~Add a `--revision` flag that is used over `ENV["REVISION"]`~

Add a `--current-sha` flag and remove usage of `ENV["REVISION"]` in Krane (we still use that as a fallback in `kubernetes-deploy` and `kubernetes-render`)

**What could go wrong?**
~People get confused  about the priority.~
