### PR TITLE
Ensure instance data is synced with pod state before reporting DS success

### DIFF
--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -58,8 +58,8 @@ module Krane
       return true if rollout_data["desiredNumberScheduled"].to_i == rollout_data["numberReady"].to_i # all pods ready
       relevant_node_names = @nodes.map(&:name)
       considered_pods = @pods.select { |p| relevant_node_names.include?(p.node_name) }
-      @logger.debug("DaemonSet is reporting #{rollout_data['numberReady']} pods ready")
-      @logger.debug("Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes.")
+      @logger.debug("DaemonSet is reporting #{rollout_data['numberReady']} pods ready." \
+        " Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes.")
       considered_pods.present? &&
         considered_pods.all?(&:deploy_succeeded?) &&
         rollout_data["numberReady"].to_i >= considered_pods.length

--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -58,7 +58,8 @@ module Krane
       return true if rollout_data["desiredNumberScheduled"].to_i == rollout_data["numberReady"].to_i # all pods ready
       relevant_node_names = @nodes.map(&:name)
       considered_pods = @pods.select { |p| relevant_node_names.include?(p.node_name) }
-      @logger.debug("Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes")
+      @logger.debug("DaemonSet is reporting #{rollout_data['numberReady']} pods ready")
+      @logger.debug("Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes.")
       considered_pods.present? &&
         considered_pods.all?(&:deploy_succeeded?) &&
         rollout_data["numberReady"].to_i >= considered_pods.length

--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -61,7 +61,7 @@ module Krane
       @logger.debug("Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes")
       considered_pods.present? &&
         considered_pods.all?(&:deploy_succeeded?) &&
-        rollout_data["numberReady"].to_i == considered_pods.length
+        rollout_data["numberReady"].to_i >= considered_pods.length
     end
 
     def find_nodes(cache)

--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -59,7 +59,9 @@ module Krane
       relevant_node_names = @nodes.map(&:name)
       considered_pods = @pods.select { |p| relevant_node_names.include?(p.node_name) }
       @logger.debug("Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes")
-      considered_pods.present? && considered_pods.all?(&:deploy_succeeded?)
+      considered_pods.present? &&
+        considered_pods.all?(&:deploy_succeeded?) &&
+        rollout_data["numberReady"].to_i == considered_pods.length
     end
 
     def find_nodes(cache)

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -113,11 +113,16 @@ class DaemonSetTest < Krane::TestCase
       "updatedNumberScheduled": 1,
       "numberReady": 0,
     }
-    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    not_ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
     ready_pod_template = load_fixtures(filenames: ['daemon_set_pods.yml']).first # should be a pod in `Ready` state
     node_templates = load_fixtures(filenames: ['nodes.yml'])
-    ds = build_synced_ds(ds_template: ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
+    ds = build_synced_ds(ds_template: not_ready_ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
     refute_predicate(ds, :deploy_succeeded?)
+
+    status[:numberReady] = 1
+    ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    ds = build_synced_ds(ds_template: ready_ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
+    assert_predicate(ds, :deploy_succeeded?)
   end
 
   private

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -113,17 +113,17 @@ class DaemonSetTest < Krane::TestCase
       "updatedNumberScheduled": 1,
       "numberReady": 0,
     }
-    not_ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
     ready_pod_template = load_fixtures(filenames: ['daemon_set_pods.yml']).first # should be a pod in `Ready` state
     node_templates = load_fixtures(filenames: ['nodes.yml'])
-    ds = build_synced_ds(ds_template: not_ready_ds_template, pod_templates: [ready_pod_template],
-      node_templates: node_templates)
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
     refute_predicate(ds, :deploy_succeeded?)
 
     status[:numberReady] = 1
-    ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
-    ds = build_synced_ds(ds_template: ready_ds_template, pod_templates: [ready_pod_template],
-      node_templates: node_templates)
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: [ready_pod_template])
+    ds.sync(build_resource_cache)
     assert_predicate(ds, :deploy_succeeded?)
   end
 

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -107,6 +107,19 @@ class DaemonSetTest < Krane::TestCase
     refute_predicate(ds, :deploy_succeeded?)
   end
 
+  def test_deploy_waits_for_daemonset_status_to_converge_to_pod_states
+    status = {
+      "desiredNumberScheduled": 1,
+      "updatedNumberScheduled": 1,
+      "numberReady": 0,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    ready_pod_template = load_fixtures(filenames: ['daemon_set_pods.yml']).first # should be a pod in `Ready` state
+    node_templates = load_fixtures(filenames: ['nodes.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+  end
+
   private
 
   def build_ds_template(filename:, status: {})

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -116,12 +116,14 @@ class DaemonSetTest < Krane::TestCase
     not_ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
     ready_pod_template = load_fixtures(filenames: ['daemon_set_pods.yml']).first # should be a pod in `Ready` state
     node_templates = load_fixtures(filenames: ['nodes.yml'])
-    ds = build_synced_ds(ds_template: not_ready_ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
+    ds = build_synced_ds(ds_template: not_ready_ds_template, pod_templates: [ready_pod_template],
+      node_templates: node_templates)
     refute_predicate(ds, :deploy_succeeded?)
 
     status[:numberReady] = 1
     ready_ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
-    ds = build_synced_ds(ds_template: ready_ds_template, pod_templates: [ready_pod_template], node_templates: node_templates)
+    ds = build_synced_ds(ds_template: ready_ds_template, pod_templates: [ready_pod_template],
+      node_templates: node_templates)
     assert_predicate(ds, :deploy_succeeded?)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
#580 added more detailed handling of daemon set rollouts. In particular, the addition of new nodes during a deployment should not interfere with convergence logic. However, this has resulted in a flaky test where the DS deploy is considered successful, but is reporting:
`1 updatedNumberScheduled, 1 desiredNumberScheduled, 0 numberReady`

After some digging, it appears that we fail to ensure the state of the target DS pods is reflected in the instance data of the DS itself when checking `deploy_succeeded?`, leading to the situation where a deploy is successful (e.g. the pod(s) is/are up), but the DS itself hasn't converged to this reality.

**How is this accomplished?**
Add an extra check in `deploy_succeeded?` to ensure `considered_pods.length == rollout_data["numberReady"]

**What could go wrong?**
In the worst case, this adds additional sync loops while we wait for the DS to converge, but that's the real definition of success, so it was an error to ignore this in the first place 

It's also impossible to test this, since it relies on timing of sync loops between pods and the DS :( 
