### PR TITLE
Make task arguments match the new flag names

### DIFF
--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -15,16 +15,6 @@ custom resources. See [blacklist](https://github.com/Shopify/kubernetes-deploy/b
 
 ## Public API changes
 
-<<<<<<< HEAD
-Important changes:
-- Removed `KubernetesDeploy#*`: use the appropriate `Krane::*` class instead.
-- Removed `template_dir` from `DeployTask#initialize`: use `template_paths` instead.
-- Removed `allow_protected_ns` from `DeployTask#run`: use `protected_namespaces` instead.
-- Removed `template_dir` from `RenderTask#initialize` and `only_filenames` from `RenderTask#run`: use `template_paths` instead.
-- Removed `allow_globals` from `DeployTask`: use `GlobalDeployTask` instead.
-
-If you want to see the current state of this API, check the comment-based docs on these classes or the [rendered documentation at RubyGems.org](https://www.rubydoc.info/gems/kubernetes-deploy/1.0.0/KubernetesDeploy/DeployTask).
-=======
 Besides the renaming of the `KubernetesDeploy` namespace to `Krane`, we made the public interfaces of the major public classes (`DeployTask`, `RenderTask`, `RunnerTask`, and `RestartTask`) match the CLI flag names more closely.
 
 If you're curious about this API, check the comment-based docs on these classes or the [rendered documentation at RubyGems.org](https://www.rubydoc.info/gems/kubernetes-deploy/1.0.0/KubernetesDeploy/DeployTask).
@@ -76,7 +66,6 @@ Old name | New name | Comments
 --- | --- | ---
 template_paths | filenames |
 max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
->>>>>>> 86f0aa9... Add information about public API changes
 
 ## Command-line interface changes
 

--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -68,6 +68,18 @@ task_template | filename |
 entrypoint | command |
 args | arguments |
 
+Method signature changed from this:
+
+```ruby
+def run(stream)
+```
+
+... to this, to maintain the convention of using keyword arguments for all the public interfaces:
+
+```ruby
+def run(stream:)
+```
+
 #### `RenderTask#new`
 
 Old name | New name | Comments

--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -19,14 +19,22 @@ Besides the renaming of the `KubernetesDeploy` namespace to `Krane`, we made the
 
 If you're curious about this API, check the comment-based docs on these classes or the [rendered documentation at RubyGems.org](https://www.rubydoc.info/gems/kubernetes-deploy/1.0.0/KubernetesDeploy/DeployTask).
 
-#### `DeployTask#initialize`
+#### `DeployTask#new`
 
 Old name | New name | Comments
 --- | --- | ---
 template_paths | filenames |
 max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+template_dir | [none] | Removed in favour of `filenames`
+allow_globals | [none] | Removed. Use `GlobalDeployTask` instead
 
-#### `RestartTask#initialize`
+#### `DeployTask#run`
+
+Old name | New name | Comments
+--- | --- | ---
+allow_protected_ns | [none] | This is now an implicit argument derived from the usage of `protected_namespaces` instead
+
+#### `RestartTask#new`
 
 Old name | New name | Comments
 --- | --- | ---
@@ -46,7 +54,7 @@ def run(deployments, selector:)
 def run(deployments:, selector:)
 ```
 
-#### `RunnerTask#initialize`
+#### `RunnerTask#new`
 
 Old name | New name | Comments
 --- | --- | ---
@@ -60,12 +68,19 @@ task_template | filename |
 entrypoint | command |
 args | arguments |
 
-#### `RenderTask#initialize`
+#### `RenderTask#new`
 
 Old name | New name | Comments
 --- | --- | ---
 template_paths | filenames |
 max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+template_dir | [none] | Removed in favour of `filenames`
+
+#### `RenderTask#run`
+
+Old name | New name | Comments
+--- | --- | ---
+only_filenames | [none] | Removed in favour of `filenames` in `RenderTask#new`
 
 ## Command-line interface changes
 

--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -15,6 +15,7 @@ custom resources. See [blacklist](https://github.com/Shopify/kubernetes-deploy/b
 
 ## Public API changes
 
+<<<<<<< HEAD
 Important changes:
 - Removed `KubernetesDeploy#*`: use the appropriate `Krane::*` class instead.
 - Removed `template_dir` from `DeployTask#initialize`: use `template_paths` instead.
@@ -23,6 +24,59 @@ Important changes:
 - Removed `allow_globals` from `DeployTask`: use `GlobalDeployTask` instead.
 
 If you want to see the current state of this API, check the comment-based docs on these classes or the [rendered documentation at RubyGems.org](https://www.rubydoc.info/gems/kubernetes-deploy/1.0.0/KubernetesDeploy/DeployTask).
+=======
+Besides the renaming of the `KubernetesDeploy` namespace to `Krane`, we made the public interfaces of the major public classes (`DeployTask`, `RenderTask`, `RunnerTask`, and `RestartTask`) match the CLI flag names more closely.
+
+If you're curious about this API, check the comment-based docs on these classes or the [rendered documentation at RubyGems.org](https://www.rubydoc.info/gems/kubernetes-deploy/1.0.0/KubernetesDeploy/DeployTask).
+
+#### `DeployTask#initialize`
+
+Old name | New name | Comments
+--- | --- | ---
+template_paths | filenames |
+max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+
+#### `RestartTask#initialize`
+
+Old name | New name | Comments
+--- | --- | ---
+max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+
+#### `RestartTask#run`
+
+Method signature changed from this:
+
+```ruby
+def run(deployments, selector:)
+```
+
+... to this, to maintain the convention of using keyword arguments for all the public interfaces:
+
+```ruby
+def run(deployments:, selector:)
+```
+
+#### `RunnerTask#initialize`
+
+Old name | New name | Comments
+--- | --- | ---
+max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+
+#### `RunnerTask#run`
+
+Old name | New name | Comments
+--- | --- | ---
+task_template | filename |
+entrypoint | command |
+args | arguments |
+
+#### `RenderTask#initialize`
+
+Old name | New name | Comments
+--- | --- | ---
+template_paths | filenames |
+max_watch_seconds | global_timeout | This is now a duration that can be expressed in a more user-friendly language (e.g. `30s` or `1h`)
+>>>>>>> 86f0aa9... Add information about public API changes
 
 ## Command-line interface changes
 

--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -68,17 +68,6 @@ task_template | filename |
 entrypoint | command |
 args | arguments |
 
-Method signature changed from this:
-
-```ruby
-def run(stream)
-```
-
-... to this, to maintain the convention of using keyword arguments for all the public interfaces:
-
-```ruby
-def run(stream:)
-```
 
 #### `RenderTask#new`
 
@@ -93,6 +82,18 @@ template_dir | [none] | Removed in favour of `filenames`
 Old name | New name | Comments
 --- | --- | ---
 only_filenames | [none] | Removed in favour of `filenames` in `RenderTask#new`
+
+Method signature changed from this:
+
+```ruby
+def run(stream, only_filenames = [])
+```
+
+... to this, to maintain the convention of using keyword arguments for all the public interfaces:
+
+```ruby
+def run(stream:)
+```
 
 ## Command-line interface changes
 

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -68,10 +68,10 @@ module Krane
             namespace: namespace,
             context: context,
             current_sha: options['current-sha'],
-            template_paths: paths,
+            filenames: paths,
             bindings: bindings_parser.parse,
             logger: logger,
-            max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
+            global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
             protected_namespaces: protected_namespaces,
           )

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -68,7 +68,7 @@ module Krane
             namespace: namespace,
             context: context,
             current_sha: options['current-sha'],
-            filenames: paths,
+            filenames: filenames,
             bindings: bindings_parser.parse,
             logger: logger,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -68,7 +68,7 @@ module Krane
             namespace: namespace,
             context: context,
             current_sha: options['current-sha'],
-            filenames: filenames,
+            filenames: paths,
             bindings: bindings_parser.parse,
             logger: logger,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -29,7 +29,7 @@ module Krane
         ::Krane::OptionsHelper.with_processed_template_paths(filenames) do |paths|
           runner = ::Krane::RenderTask.new(
             current_sha: options['current-sha'],
-            template_paths: paths,
+            filenames: paths,
             bindings: bindings_parser.parse,
           )
           runner.run!(STDOUT)

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -27,12 +27,12 @@ module Krane
         end
 
         ::Krane::OptionsHelper.with_processed_template_paths(filenames) do |paths|
-          runner = ::Krane::RenderTask.new(
+          renderer = ::Krane::RenderTask.new(
             current_sha: options['current-sha'],
             filenames: paths,
             bindings: bindings_parser.parse,
           )
-          runner.run!(STDOUT)
+          renderer.run!(stream: STDOUT)
         end
       end
     end

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -21,7 +21,7 @@ module Krane
         restart = ::Krane::RestartTask.new(
           namespace: namespace,
           context: context,
-          max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
+          global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
         )
         restart.run!(
           options[:deployments],

--- a/lib/krane/cli/restart_command.rb
+++ b/lib/krane/cli/restart_command.rb
@@ -24,7 +24,7 @@ module Krane
           global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
         )
         restart.run!(
-          options[:deployments],
+          deployments: options[:deployments],
           selector: selector,
           verify_result: options["verify-result"]
         )

--- a/lib/krane/cli/run_command.rb
+++ b/lib/krane/cli/run_command.rb
@@ -37,14 +37,14 @@ module Krane
         runner = ::Krane::RunnerTask.new(
           namespace: namespace,
           context: context,
-          max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
+          global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
         )
 
         runner.run!(
           verify_result: options['verify-result'],
-          task_template: options['template'],
-          entrypoint: options['command'],
-          args: options['arguments']&.split(" "),
+          template: options['template'],
+          command: options['command'],
+          arguments: options['arguments']&.split(" "),
           env_vars: options['env-vars'].split(','),
         )
       end

--- a/lib/krane/cli/run_command.rb
+++ b/lib/krane/cli/run_command.rb
@@ -19,7 +19,7 @@ module Krane
         },
         "verify-result" => { type: :boolean, desc: "Wait for completion and verify pod success", default: true },
         "command" => { type: :array, desc: "Override the default command in the container image" },
-        "filename" => {
+        "template" => {
           type: :string,
           desc: "The template file you'll be rendering",
           required: true,
@@ -43,7 +43,7 @@ module Krane
 
         runner.run!(
           verify_result: options['verify-result'],
-          filename: options['filename'],
+          template: options['template'],
           command: options['command'],
           arguments: options['arguments']&.split(" "),
           env_vars: options['env-vars'].split(','),

--- a/lib/krane/cli/run_command.rb
+++ b/lib/krane/cli/run_command.rb
@@ -19,10 +19,11 @@ module Krane
         },
         "verify-result" => { type: :boolean, desc: "Wait for completion and verify pod success", default: true },
         "command" => { type: :array, desc: "Override the default command in the container image" },
-        "template" => {
+        "filename" => {
           type: :string,
           desc: "The template file you'll be rendering",
           required: true,
+          aliases: :f,
         },
         "env-vars" => {
           type: :string,
@@ -42,7 +43,7 @@ module Krane
 
         runner.run!(
           verify_result: options['verify-result'],
-          template: options['template'],
+          filename: options['filename'],
           command: options['command'],
           arguments: options['arguments']&.split(" "),
           env_vars: options['env-vars'].split(','),

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -32,7 +32,7 @@ module Krane
     # @param context [String] Kubernetes context
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector
-    # @param template_paths [Array<String>] An array of template paths
+    # @param filenames [Array<String>] An array of template paths
     def initialize(context:, global_timeout: nil, selector: nil, filenames: [], logger: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 
@@ -104,7 +104,7 @@ module Krane
 
     def deploy!(resources, verify_result, prune)
       resource_deployer = ResourceDeployer.new(task_config: @task_config,
-        prune_whitelist: prune_whitelist, max_watch_seconds: @global_timeout,
+        prune_whitelist: prune_whitelist, global_timeout: @global_timeout,
         selector: @selector, statsd_tags: statsd_tags)
       resource_deployer.deploy!(resources, verify_result, prune)
     end

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -29,10 +29,10 @@ module Krane
 
     # Initializes the deploy task
     #
-    # @param context [String] Kubernetes context
+    # @param context [String] Kubernetes context (*required*)
     # @param global_timeout [Integer] Timeout in seconds
-    # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector
-    # @param filenames [Array<String>] An array of template paths
+    # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector (*required*)
+    # @param filenames [Array<String>] An array of template paths (*required*)
     def initialize(context:, global_timeout: nil, selector: nil, filenames: [], logger: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -32,7 +32,7 @@ module Krane
     # @param context [String] Kubernetes context (*required*)
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector (*required*)
-    # @param filenames [Array<String>] An array of template paths (*required*)
+    # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
     def initialize(context:, global_timeout: nil, selector: nil, filenames: [], logger: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -36,7 +36,7 @@ module Krane
     # @param stream [IO] Place to stream the output to
     #
     # @return [nil]
-    def run!(stream)
+    def run!(stream:)
       @logger.reset
       @logger.phase_heading("Initializing render task")
 

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -12,11 +12,11 @@ module Krane
     #
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param current_sha [String] The SHA of the commit
-    # @param template_paths [Array<String>] An array of template paths to render
+    # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
     # @param bindings [Hash] Bindings parsed by Krane::BindingsParser
-    def initialize(logger: nil, current_sha:, template_paths: [], bindings:)
+    def initialize(logger: nil, current_sha:, filenames: [], bindings:)
       @logger = logger || Krane::FormattedLogger.build
-      @template_paths = template_paths.map { |path| File.expand_path(path) }
+      @filenames = filenames.map { |path| File.expand_path(path) }
       @bindings = bindings
       @current_sha = current_sha
     end
@@ -40,7 +40,7 @@ module Krane
       @logger.reset
       @logger.phase_heading("Initializing render task")
 
-      ts = TemplateSets.from_dirs_and_files(paths: @template_paths, logger: @logger)
+      ts = TemplateSets.from_dirs_and_files(paths: @filenames, logger: @logger)
 
       validate_configuration(ts)
       count = render_templates(stream, ts)
@@ -88,8 +88,8 @@ module Krane
     def validate_configuration(template_sets)
       @logger.info("Validating configuration")
       errors = []
-      if @template_paths.blank?
-        errors << "template_paths must be set"
+      if @filenames.blank?
+        errors << "filenames must be set"
       end
       errors += template_sets.validate
 

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -11,10 +11,10 @@ module Krane
     delegate :logger, to: :@task_config
     attr_reader :statsd_tags
 
-    def initialize(task_config:, prune_whitelist:, max_watch_seconds:, current_sha: nil, selector:, statsd_tags:)
+    def initialize(task_config:, prune_whitelist:, global_timeout:, current_sha: nil, selector:, statsd_tags:)
       @task_config = task_config
       @prune_whitelist = prune_whitelist
-      @max_watch_seconds = max_watch_seconds
+      @global_timeout = global_timeout
       @current_sha = current_sha
       @selector = selector
       @statsd_tags = statsd_tags
@@ -119,7 +119,7 @@ module Krane
 
       if verify
         watcher = Krane::ResourceWatcher.new(resources: resources, deploy_started_at: deploy_started_at,
-          timeout: @max_watch_seconds, task_config: @task_config, sha: @current_sha)
+          timeout: @global_timeout, task_config: @task_config, sha: @current_sha)
         watcher.run(record_summary: record_summary)
       end
     end

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -24,8 +24,8 @@ module Krane
 
     # Initializes the restart task
     #
-    # @param context [String] Kubernetes context / cluster
-    # @param namespace [String] Kubernetes namespace
+    # @param context [String] Kubernetes context / cluster (*required*)
+    # @param namespace [String] Kubernetes namespace (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
     def initialize(context:, namespace:, logger: nil, global_timeout: nil)

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -54,7 +54,7 @@ module Krane
     # @param verify_result [Boolean] Wait for completion and verify success
     #
     # @return [nil]
-    def run!(deployments = nil, selector: nil, verify_result: true)
+    def run!(deployments: nil, selector: nil, verify_result: true)
       start = Time.now.utc
       @logger.reset
 

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -43,24 +43,24 @@ module Krane
 
     # Runs the task, raising exceptions in case of issues
     #
-    # @param filename [String] The filename of the template you'll be rendering (*required*)
+    # @param template [String] The filename of the template you'll be rendering (*required*)
     # @param command [Array<String>] Override the default command in the container image
     # @param arguments [Array<String>] Override the default arguments for the command
     # @param env_vars [Array<String>] List of env vars
     # @param verify_result [Boolean] Wait for completion and verify pod success
     #
     # @return [nil]
-    def run!(filename:, command:, arguments:, env_vars: [], verify_result: true)
+    def run!(template:, command:, arguments:, env_vars: [], verify_result: true)
       start = Time.now.utc
       @logger.reset
 
       @logger.phase_heading("Initializing task")
 
       @logger.info("Validating configuration")
-      verify_config!(filename)
+      verify_config!(template)
       @logger.info("Using namespace '#{@namespace}' in context '#{@context}'")
 
-      pod = build_pod(filename, command, arguments, env_vars, verify_result)
+      pod = build_pod(template, command, arguments, env_vars, verify_result)
       validate_pod(pod)
 
       @logger.phase_heading("Running pod")

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -22,13 +22,13 @@ module Krane
     # @param namespace [String] Kubernetes namespace
     # @param context [String] Kubernetes context / cluster
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
-    # @param max_watch_seconds [Integer] Timeout in seconds
-    def initialize(namespace:, context:, logger: nil, max_watch_seconds: nil)
+    # @param global_timeout [Integer] Timeout in seconds
+    def initialize(namespace:, context:, logger: nil, global_timeout: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
       @task_config = Krane::TaskConfig.new(context, namespace, @logger)
       @namespace = namespace
       @context = context
-      @max_watch_seconds = max_watch_seconds
+      @global_timeout = global_timeout
     end
 
     # Runs the task, returning a boolean representing success or failure
@@ -43,24 +43,24 @@ module Krane
 
     # Runs the task, raising exceptions in case of issues
     #
-    # @param task_template [String] The template file you'll be rendering
-    # @param entrypoint [Array<String>] Override the default command in the container image
-    # @param args [Array<String>] Override the default arguments for the command
+    # @param template [String] The template file you'll be rendering
+    # @param command [Array<String>] Override the default command in the container image
+    # @param arguments [Array<String>] Override the default arguments for the command
     # @param env_vars [Array<String>] List of env vars
     # @param verify_result [Boolean] Wait for completion and verify pod success
     #
     # @return [nil]
-    def run!(task_template:, entrypoint:, args:, env_vars: [], verify_result: true)
+    def run!(template:, command:, arguments:, env_vars: [], verify_result: true)
       start = Time.now.utc
       @logger.reset
 
       @logger.phase_heading("Initializing task")
 
       @logger.info("Validating configuration")
-      verify_config!(task_template, args)
+      verify_config!(template)
       @logger.info("Using namespace '#{@namespace}' in context '#{@context}'")
 
-      pod = build_pod(task_template, entrypoint, args, env_vars, verify_result)
+      pod = build_pod(template, command, arguments, env_vars, verify_result)
       validate_pod(pod)
 
       @logger.phase_heading("Running pod")
@@ -98,11 +98,11 @@ module Krane
       raise FatalDeploymentError, msg
     end
 
-    def build_pod(template_name, entrypoint, args, env_vars, verify_result)
+    def build_pod(template_name, command, args, env_vars, verify_result)
       task_template = get_template(template_name)
       @logger.info("Using template '#{template_name}'")
       pod_template = build_pod_definition(task_template)
-      set_container_overrides!(pod_template, entrypoint, args, env_vars)
+      set_container_overrides!(pod_template, command, args, env_vars)
       ensure_valid_restart_policy!(pod_template, verify_result)
       Pod.new(namespace: @namespace, context: @context, logger: @logger, stream_logs: true,
                     definition: pod_template.to_hash.deep_stringify_keys, statsd_tags: [])
@@ -113,7 +113,7 @@ module Krane
     end
 
     def watch_pod(pod)
-      rw = ResourceWatcher.new(resources: [pod], timeout: @max_watch_seconds,
+      rw = ResourceWatcher.new(resources: [pod], timeout: @global_timeout,
         operation_name: "run", task_config: @task_config)
       rw.run(delay_sync: 1, reminder_interval: 30.seconds)
       raise DeploymentTimeoutError if pod.deploy_timed_out?
@@ -131,8 +131,8 @@ module Krane
       @logger.summary.add_paragraph(warning)
     end
 
-    def verify_config!(task_template, args)
-      task_config_validator = RunnerTaskConfigValidator.new(task_template, args, @task_config, kubectl,
+    def verify_config!(task_template)
+      task_config_validator = RunnerTaskConfigValidator.new(task_template, @task_config, kubectl,
         kubeclient_builder)
       unless task_config_validator.valid?
         @logger.summary.add_action("Configuration invalid")
@@ -165,7 +165,7 @@ module Krane
       pod_definition
     end
 
-    def set_container_overrides!(pod_definition, entrypoint, args, env_vars)
+    def set_container_overrides!(pod_definition, command, args, env_vars)
       container = pod_definition.spec.containers.find { |cont| cont.name == 'task-runner' }
       if container.nil?
         message = "Pod spec does not contain a template container called 'task-runner'"
@@ -173,7 +173,7 @@ module Krane
         raise TaskConfigurationError, message
       end
 
-      container.command = entrypoint if entrypoint
+      container.command = command if command
       container.args = args if args
 
       env_args = env_vars.map do |env|

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -43,24 +43,24 @@ module Krane
 
     # Runs the task, raising exceptions in case of issues
     #
-    # @param template [String] The template file you'll be rendering (*required*)
+    # @param filename [String] The filename of the template you'll be rendering (*required*)
     # @param command [Array<String>] Override the default command in the container image
     # @param arguments [Array<String>] Override the default arguments for the command
     # @param env_vars [Array<String>] List of env vars
     # @param verify_result [Boolean] Wait for completion and verify pod success
     #
     # @return [nil]
-    def run!(template:, command:, arguments:, env_vars: [], verify_result: true)
+    def run!(filename:, command:, arguments:, env_vars: [], verify_result: true)
       start = Time.now.utc
       @logger.reset
 
       @logger.phase_heading("Initializing task")
 
       @logger.info("Validating configuration")
-      verify_config!(template)
+      verify_config!(filename)
       @logger.info("Using namespace '#{@namespace}' in context '#{@context}'")
 
-      pod = build_pod(template, command, arguments, env_vars, verify_result)
+      pod = build_pod(filename, command, arguments, env_vars, verify_result)
       validate_pod(pod)
 
       @logger.phase_heading("Running pod")

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -19,8 +19,8 @@ module Krane
 
     # Initializes the runner task
     #
-    # @param namespace [String] Kubernetes namespace
-    # @param context [String] Kubernetes context / cluster
+    # @param namespace [String] Kubernetes namespace (*required*)
+    # @param context [String] Kubernetes context / cluster (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
     def initialize(namespace:, context:, logger: nil, global_timeout: nil)
@@ -43,7 +43,7 @@ module Krane
 
     # Runs the task, raising exceptions in case of issues
     #
-    # @param template [String] The template file you'll be rendering
+    # @param template [String] The template file you'll be rendering (*required*)
     # @param command [Array<String>] Override the default command in the container image
     # @param arguments [Array<String>] Override the default arguments for the command
     # @param env_vars [Array<String>] List of env vars

--- a/lib/krane/runner_task_config_validator.rb
+++ b/lib/krane/runner_task_config_validator.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 module Krane
   class RunnerTaskConfigValidator < TaskConfigValidator
-    def initialize(template, args, *arguments)
+    def initialize(template, *arguments)
       super(*arguments)
       @template = template
-      @args = args
       @validations += %i(validate_template)
     end
 

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -63,7 +63,7 @@ class DeployTest < Krane::TestCase
     Dir.mktmpdir do |tmp_path|
       $stdin.expects("read").returns("")
       Dir.expects(:mktmpdir).with("krane").yields(tmp_path)
-      set_krane_deploy_expectations(new_args: { template_paths: [tmp_path] })
+      set_krane_deploy_expectations(new_args: { filenames: [tmp_path] })
       krane_deploy!(flags: '--stdin')
     end
   end
@@ -79,7 +79,7 @@ class DeployTest < Krane::TestCase
     Dir.mktmpdir do |tmp_path|
       $stdin.expects("read").returns("")
       Dir.expects(:mktmpdir).with("krane").yields(tmp_path)
-      set_krane_deploy_expectations(new_args: { template_paths: ['/my/file/path', tmp_path] })
+      set_krane_deploy_expectations(new_args: { filenames: ['/my/file/path', tmp_path] })
       krane_deploy!(flags: '-f /my/file/path --stdin')
     end
   end

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -10,9 +10,9 @@ class DeployTest < Krane::TestCase
   end
 
   def test_deploy_parses_global_timeout
-    set_krane_deploy_expectations(new_args: { max_watch_seconds: 10 })
+    set_krane_deploy_expectations(new_args: { global_timeout: 10 })
     krane_deploy!(flags: '--global-timeout 10s')
-    set_krane_deploy_expectations(new_args: { max_watch_seconds: 60**2 })
+    set_krane_deploy_expectations(new_args: { global_timeout: 60**2 })
     krane_deploy!(flags: '--global-timeout 1h')
   end
 
@@ -69,9 +69,9 @@ class DeployTest < Krane::TestCase
   end
 
   def test_deploy_passes_filename
-    set_krane_deploy_expectations(new_args: { template_paths: ['/my/file/path'] })
+    set_krane_deploy_expectations(new_args: { filenames: ['/my/file/path'] })
     krane_deploy!(flags: '-f /my/file/path')
-    set_krane_deploy_expectations(new_args: { template_paths: ['/my/other/file/path'] })
+    set_krane_deploy_expectations(new_args: { filenames: ['/my/other/file/path'] })
     krane_deploy!(flags: '--filenames /my/other/file/path')
   end
 
@@ -129,10 +129,10 @@ class DeployTest < Krane::TestCase
         namespace: deploy_task_config.namespace,
         context: deploy_task_config.context,
         current_sha: nil,
-        template_paths: ['/tmp'],
+        filenames: ['/tmp'],
         bindings: {},
         logger: logger,
-        max_watch_seconds: 300,
+        global_timeout: 300,
         selector: nil,
         protected_namespaces: ["default", "kube-system", "kube-public"],
       }.merge(new_args),

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -22,7 +22,7 @@ class RenderTest < Krane::TestCase
       file_path = "/dev/null"
       $stdin.expects("read").returns("")
       Dir.expects(:mktmpdir).with("krane").yields(tmp_path)
-      install_krane_render_expectations(template_paths: [file_path, tmp_path])
+      install_krane_render_expectations(filenames: [file_path, tmp_path])
       krane_render!("--filenames #{file_path} --stdin")
     end
   end
@@ -31,7 +31,7 @@ class RenderTest < Krane::TestCase
     Dir.mktmpdir do |tmp_path|
       $stdin.expects("read").returns("")
       Dir.expects(:mktmpdir).with("krane").yields(tmp_path).once
-      install_krane_render_expectations(template_paths: [tmp_path])
+      install_krane_render_expectations(filenames: [tmp_path])
       krane_render!("--stdin")
     end
   end

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 require 'krane/cli/krane'
 
-class RendertTest < Krane::TestCase
+class RenderTest < Krane::TestCase
   def test_render_with_default_options
     install_krane_render_expectations
     krane_render!
@@ -10,10 +10,10 @@ class RendertTest < Krane::TestCase
 
   def test_render_parses_paths
     paths = "/dev/null /dev/yes /dev/no"
-    install_krane_render_expectations(template_paths: paths.split)
+    install_krane_render_expectations(filenames: paths.split)
     krane_render!("-f #{paths}")
 
-    install_krane_render_expectations(template_paths: paths.split)
+    install_krane_render_expectations(filenames: paths.split)
     krane_render!("--filenames #{paths}")
   end
 
@@ -76,7 +76,7 @@ class RendertTest < Krane::TestCase
   def default_options(new_args = {})
     {
       current_sha: ENV["REVISION"],
-      template_paths: ["/dev/null"],
+      filenames: ["/dev/null"],
       bindings: {},
     }.merge(new_args)
   end

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -60,7 +60,7 @@ class RenderTest < Krane::TestCase
   def install_krane_render_expectations(new_args = {})
     options = default_options(new_args)
     response = mock('RenderTask')
-    response.expects(:run!).with(STDOUT).returns(true)
+    response.expects(:run!).with(stream: STDOUT).returns(true)
     Krane::RenderTask.expects(:new).with(options).returns(response)
   end
 

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -16,17 +16,16 @@ class RestartTest < Krane::TestCase
   end
 
   def test_restart_passes_deployments_transparently
-    set_krane_restart_expectations(deployments: ['web'])
+    set_krane_restart_expectations(run_args: { deployments: ['web'] })
     krane_restart!(flags: '--deployments web')
-    set_krane_restart_expectations(deployments: ['web', 'jobs'])
+    set_krane_restart_expectations(run_args: { deployments: ['web', 'jobs'] })
     krane_restart!(flags: '--deployments web jobs')
   end
 
   def test_restart_parses_selector
     options = default_options
     response = mock('RestartTask')
-    response.expects(:run!).returns(true).with(options[:deployments],
-      has_entries(selector: is_a(Krane::LabelSelector), verify_result: true))
+    response.expects(:run!).returns(true).with(has_entries(selector: is_a(Krane::LabelSelector), verify_result: true))
     Krane::RestartTask.expects(:new).with(options[:new_args]).returns(response)
 
     krane_restart!(flags: '--selector name:web')
@@ -48,10 +47,10 @@ class RestartTest < Krane::TestCase
 
   private
 
-  def set_krane_restart_expectations(new_args: {}, deployments: nil, run_args: {})
-    options = default_options(new_args, deployments, run_args)
+  def set_krane_restart_expectations(new_args: {}, run_args: {})
+    options = default_options(new_args, run_args)
     response = mock('RestartTask')
-    response.expects(:run!).with(options[:deployments], options[:run_args]).returns(true)
+    response.expects(:run!).with(options[:run_args]).returns(true)
     Krane::RestartTask.expects(:new).with(options[:new_args]).returns(response)
   end
 
@@ -67,15 +66,15 @@ class RestartTest < Krane::TestCase
     @restart_config ||= task_config(namespace: 'test-namespace')
   end
 
-  def default_options(new_args = {}, deployments = nil, run_args = {})
+  def default_options(new_args = {}, run_args = {})
     {
       new_args: {
         namespace: restart_task_config.namespace,
         context: restart_task_config.context,
         global_timeout: 300,
       }.merge(new_args),
-      deployments: deployments,
       run_args: {
+        deployments: nil,
         selector: nil,
         verify_result: true,
       }.merge(run_args),

--- a/test/exe/restart_test.rb
+++ b/test/exe/restart_test.rb
@@ -9,9 +9,9 @@ class RestartTest < Krane::TestCase
   end
 
   def test_restart_parses_global_timeout
-    set_krane_restart_expectations(new_args: { max_watch_seconds: 10 })
+    set_krane_restart_expectations(new_args: { global_timeout: 10 })
     krane_restart!(flags: '--global-timeout 10s')
-    set_krane_restart_expectations(new_args: { max_watch_seconds: 60**2 })
+    set_krane_restart_expectations(new_args: { global_timeout: 60**2 })
     krane_restart!(flags: '--global-timeout 1h')
   end
 
@@ -72,7 +72,7 @@ class RestartTest < Krane::TestCase
       new_args: {
         namespace: restart_task_config.namespace,
         context: restart_task_config.context,
-        max_watch_seconds: 300,
+        global_timeout: 300,
       }.merge(new_args),
       deployments: deployments,
       run_args: {

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -34,9 +34,9 @@ class RunTest < Krane::TestCase
     krane_run!(flags: '--arguments hello')
   end
 
-  def test_run_parses_filename
-    set_krane_run_expectations(run_args: { filename: 'some-name' })
-    krane_run!(flags: '--filename some-name')
+  def test_run_parses_template
+    set_krane_run_expectations(run_args: { template: 'some-name' })
+    krane_run!(flags: '--template some-name')
   end
 
   def test_run_parses_env_vars
@@ -45,21 +45,21 @@ class RunTest < Krane::TestCase
   end
 
   def test_run_failure_with_not_enough_arguments_as_black_box
-    out, err, status = krane_black_box('run', '--filename some_template not_enough_arguments')
+    out, err, status = krane_black_box('run', '--template some_template not_enough_arguments')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
   end
 
   def test_run_failure_with_too_many_args_as_black_box
-    out, err, status = krane_black_box('run', '--filename some_template ns ctx some_extra_arg')
+    out, err, status = krane_black_box('run', '--template some_template ns ctx some_extra_arg')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
   end
 
   def test_run_failure_with_bad_timeout_as_black_box
-    out, err, status = krane_black_box('run', '--filename some_template ns ctx --global-timeout=mittens')
+    out, err, status = krane_black_box('run', '--template some_template ns ctx --global-timeout=mittens')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("Error parsing duration", err)
@@ -75,7 +75,7 @@ class RunTest < Krane::TestCase
   end
 
   def krane_run!(flags: '')
-    flags += " --filename #{TASK_TEMPLATE}" unless flags.include?('--filename')
+    flags += " --template #{TASK_TEMPLATE}" unless flags.include?('--template')
     krane = Krane::CLI::Krane.new(
       [run_task_config.namespace, run_task_config.context],
       flags.split
@@ -96,7 +96,7 @@ class RunTest < Krane::TestCase
       }.merge(new_args),
       run_args: {
         verify_result: true,
-        filename: TASK_TEMPLATE,
+        template: TASK_TEMPLATE,
         command: nil,
         arguments: nil,
         env_vars: [],

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -34,9 +34,9 @@ class RunTest < Krane::TestCase
     krane_run!(flags: '--arguments hello')
   end
 
-  def test_run_parses_template
-    set_krane_run_expectations(run_args: { template: 'some-name' })
-    krane_run!(flags: '--template some-name')
+  def test_run_parses_filename
+    set_krane_run_expectations(run_args: { filename: 'some-name' })
+    krane_run!(flags: '--filename some-name')
   end
 
   def test_run_parses_env_vars
@@ -45,21 +45,21 @@ class RunTest < Krane::TestCase
   end
 
   def test_run_failure_with_not_enough_arguments_as_black_box
-    out, err, status = krane_black_box('run', '--template some_template not_enough_arguments')
+    out, err, status = krane_black_box('run', '--filename some_template not_enough_arguments')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
   end
 
   def test_run_failure_with_too_many_args_as_black_box
-    out, err, status = krane_black_box('run', '--template some_template ns ctx some_extra_arg')
+    out, err, status = krane_black_box('run', '--filename some_template ns ctx some_extra_arg')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("ERROR", err)
   end
 
   def test_run_failure_with_bad_timeout_as_black_box
-    out, err, status = krane_black_box('run', '--template some_template ns ctx --global-timeout=mittens')
+    out, err, status = krane_black_box('run', '--filename some_template ns ctx --global-timeout=mittens')
     assert_equal(1, status.exitstatus)
     assert_empty(out)
     assert_match("Error parsing duration", err)
@@ -75,7 +75,7 @@ class RunTest < Krane::TestCase
   end
 
   def krane_run!(flags: '')
-    flags += " --template #{TASK_TEMPLATE}" unless flags.include?('--template')
+    flags += " --filename #{TASK_TEMPLATE}" unless flags.include?('--filename')
     krane = Krane::CLI::Krane.new(
       [run_task_config.namespace, run_task_config.context],
       flags.split
@@ -96,7 +96,7 @@ class RunTest < Krane::TestCase
       }.merge(new_args),
       run_args: {
         verify_result: true,
-        template: TASK_TEMPLATE,
+        filename: TASK_TEMPLATE,
         command: nil,
         arguments: nil,
         env_vars: [],

--- a/test/exe/run_test.rb
+++ b/test/exe/run_test.rb
@@ -11,9 +11,9 @@ class RunTest < Krane::TestCase
   end
 
   def test_run_parses_global_timeout
-    set_krane_run_expectations(new_args: { max_watch_seconds: 10 })
+    set_krane_run_expectations(new_args: { global_timeout: 10 })
     krane_run!(flags: '--global-timeout 10s')
-    set_krane_run_expectations(new_args: { max_watch_seconds: 60**2 })
+    set_krane_run_expectations(new_args: { global_timeout: 60**2 })
     krane_run!(flags: '--global-timeout 1h')
   end
 
@@ -25,17 +25,17 @@ class RunTest < Krane::TestCase
   end
 
   def test_run_parses_command
-    set_krane_run_expectations(run_args: { entrypoint: %w(/bin/sh) })
+    set_krane_run_expectations(run_args: { command: %w(/bin/sh) })
     krane_run!(flags: '--command /bin/sh')
   end
 
   def test_run_parses_arguments
-    set_krane_run_expectations(run_args: { args: %w(hello) })
+    set_krane_run_expectations(run_args: { arguments: %w(hello) })
     krane_run!(flags: '--arguments hello')
   end
 
   def test_run_parses_template
-    set_krane_run_expectations(run_args: { task_template: 'some-name' })
+    set_krane_run_expectations(run_args: { template: 'some-name' })
     krane_run!(flags: '--template some-name')
   end
 
@@ -92,13 +92,13 @@ class RunTest < Krane::TestCase
       new_args: {
         namespace: run_task_config.namespace,
         context: run_task_config.context,
-        max_watch_seconds: 300,
+        global_timeout: 300,
       }.merge(new_args),
       run_args: {
         verify_result: true,
-        task_template: TASK_TEMPLATE,
-        entrypoint: nil,
-        args: nil,
+        template: TASK_TEMPLATE,
+        command: nil,
+        arguments: nil,
         env_vars: [],
       }.merge(run_args),
     }

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -84,7 +84,7 @@ module FixtureDeployHelper
   end
 
   def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
-    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
+    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil,
     protected_namespaces: nil, render_erb: false)
     kubectl_instance ||= build_kubectl
 
@@ -92,11 +92,11 @@ module FixtureDeployHelper
       namespace: @namespace,
       current_sha: sha,
       context: KubeclientHelper::TEST_CONTEXT,
-      template_paths: dirs,
+      filenames: dirs,
       logger: logger,
       kubectl_instance: kubectl_instance,
       bindings: bindings,
-      max_watch_seconds: max_watch_seconds,
+      global_timeout: global_timeout,
       selector: selector,
       protected_namespaces: protected_namespaces,
       render_erb: render_erb

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -21,7 +21,7 @@ module TaskRunnerTestHelper
 
   def run_params(log_lines: 5, log_interval: 0.1, verify_result: true)
     {
-      template: 'hello-cloud-template-runner',
+      filename: 'hello-cloud-template-runner',
       command: ['/bin/sh', '-c'],
       arguments: [
         "i=1; " \

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -14,16 +14,16 @@ module TaskRunnerTestHelper
     reset_logger
   end
 
-  def build_task_runner(context: KubeclientHelper::TEST_CONTEXT, ns: @namespace, max_watch_seconds: nil)
+  def build_task_runner(context: KubeclientHelper::TEST_CONTEXT, ns: @namespace, global_timeout: nil)
     Krane::RunnerTask.new(context: context, namespace: ns, logger: logger,
-      max_watch_seconds: max_watch_seconds)
+      global_timeout: global_timeout)
   end
 
   def run_params(log_lines: 5, log_interval: 0.1, verify_result: true)
     {
-      task_template: 'hello-cloud-template-runner',
-      entrypoint: ['/bin/sh', '-c'],
-      args: [
+      template: 'hello-cloud-template-runner',
+      command: ['/bin/sh', '-c'],
+      arguments: [
         "i=1; " \
         "while [ $i -le #{log_lines} ]; do " \
           "echo \"Line $i\"; " \

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -21,7 +21,7 @@ module TaskRunnerTestHelper
 
   def run_params(log_lines: 5, log_interval: 0.1, verify_result: true)
     {
-      filename: 'hello-cloud-template-runner',
+      template: 'hello-cloud-template-runner',
       command: ['/bin/sh', '-c'],
       arguments: [
         "i=1; " \

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -67,7 +67,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
 
   def test_timedout_statsd_metric_emitted
     deploy_task_template
-    task_runner = build_task_runner(max_watch_seconds: 0)
+    task_runner = build_task_runner(global_timeout: 0)
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
       result = task_runner.run(run_params.merge(args: ["sleep 5"]))

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -70,7 +70,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     task_runner = build_task_runner(global_timeout: 0)
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(run_params.merge(args: ["sleep 5"]))
+      result = task_runner.run(run_params.merge(arguments: ["sleep 5"]))
       assert_task_run_failure(result, :timed_out)
     end
 

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -1318,7 +1318,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     result = deploy_fixtures(
       "invalid",
       subset: ["bad_probe.yml", "cannot_run.yml", "missing_volumes.yml", "config_map.yml"],
-      max_watch_seconds: 20
+      global_timeout: 20
     ) do |f|
       bad_probe = f["bad_probe.yml"]["Deployment"].first
       bad_probe["spec"]["progressDeadlineSeconds"] = 5
@@ -1340,7 +1340,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
   end
 
   def test_resource_watcher_raises_after_timeout_seconds
-    result = deploy_fixtures("long-running", subset: ['undying-deployment.yml.erb'], max_watch_seconds: 5,
+    result = deploy_fixtures("long-running", subset: ['undying-deployment.yml.erb'], global_timeout: 5,
       render_erb: true) do |fixtures|
       deployment = fixtures['undying-deployment.yml.erb']['Deployment'].first
       deployment['spec']['progressDeadlineSeconds'] = 100
@@ -1596,9 +1596,9 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
   private
 
-  def build_deploy_runner(context: KubeclientHelper::TEST_CONTEXT, ns: @namespace, max_watch_seconds: nil)
+  def build_deploy_runner(context: KubeclientHelper::TEST_CONTEXT, ns: @namespace, global_timeout: nil)
     Krane::DeployTask.new(context: context, namespace: ns, logger: logger,
-      max_watch_seconds: max_watch_seconds, template_paths: ['./test/fixtures/hello-cloud'], current_sha: '123')
+      global_timeout: global_timeout, filenames: ['./test/fixtures/hello-cloud'], current_sha: '123')
   end
 
   def run_params

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -21,7 +21,7 @@ class KraneTest < Krane::IntegrationTest
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["template-runner.yml", "configmap-data.yml"]))
     template = "hello-cloud-template-runner"
     out, err, status = krane_black_box("run",
-      "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --filename #{template} --command ls --arguments '-a /'")
+      "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --template #{template} --command ls --arguments '-a /'")
     assert_match("Success", err)
     assert_empty(out)
     assert_predicate(status, :success?)

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -21,7 +21,7 @@ class KraneTest < Krane::IntegrationTest
     assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["template-runner.yml", "configmap-data.yml"]))
     template = "hello-cloud-template-runner"
     out, err, status = krane_black_box("run",
-      "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --template #{template} --command ls --arguments '-a /'")
+      "#{@namespace} #{KubeclientHelper::TEST_CONTEXT} --filename #{template} --command ls --arguments '-a /'")
     assert_match("Success", err)
     assert_empty(out)
     assert_predicate(status, :success?)

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -327,12 +327,12 @@ class RenderTaskTest < Krane::TestCase
 
   private
 
-  def build_render_task(template_paths, bindings = {})
+  def build_render_task(filenames, bindings = {})
     Krane::RenderTask.new(
       logger: logger,
       current_sha: "k#{SecureRandom.hex(6)}",
       bindings: bindings,
-      template_paths: Array(template_paths)
+      filenames: Array(filenames)
     )
   end
 

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -10,7 +10,7 @@ class RenderTaskTest < Krane::TestCase
       File.join(fixture_path('hello-cloud'), 'configmap-data.yml')
     )
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
       assert_equal output, <<~RENDERED
@@ -36,7 +36,7 @@ class RenderTaskTest < Krane::TestCase
       File.join(fixture_path('hello-cloud'), 'configmap-data.yml'),
       File.join(fixture_path('hello-cloud'), 'unmanaged-pod-1.yml.erb'),
     ])
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
       expected = <<~RENDERED
@@ -87,7 +87,7 @@ class RenderTaskTest < Krane::TestCase
       'supports_partials': 'yep'
     )
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       expected = <<~RENDERED
         ---
@@ -167,7 +167,7 @@ class RenderTaskTest < Krane::TestCase
   def test_render_task_rendering_all_files
     render = build_render_task(fixture_path('hello-cloud'))
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       assert_match(/name: bare-replica-set/, output)
       assert_match(/name: hello-cloud-configmap-data/, output)
@@ -192,7 +192,7 @@ class RenderTaskTest < Krane::TestCase
       File.join(fixture_path('some-invalid'), 'yaml-error.yml'),
       File.join(fixture_path('some-invalid'), 'stateful_set.yml'),
     ])
-    assert_render_failure(render.run(mock_output_stream))
+    assert_render_failure(render.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
       assert_match(/name: hello-cloud-configmap-data/, output)
@@ -210,7 +210,7 @@ class RenderTaskTest < Krane::TestCase
       'a': 'binding-a',
       'b': 'binding-b'
     )
-    assert_render_failure(render.run(mock_output_stream))
+    assert_render_failure(render.run(stream: mock_output_stream))
     assert_logs_match_all([
       /Invalid template: .*deployment.yaml.erb/,
       "> Error message:",
@@ -224,7 +224,7 @@ class RenderTaskTest < Krane::TestCase
     render = build_render_task(
       File.join(fixture_path('invalid'), 'raise_inside.yml.erb')
     )
-    assert_render_failure(render.run(mock_output_stream))
+    assert_render_failure(render.run(stream: mock_output_stream))
     assert_logs_match_all([
       /Invalid template: .*raise_inside.yml.erb/,
       "> Error message:",
@@ -237,7 +237,7 @@ class RenderTaskTest < Krane::TestCase
   def test_render_empty_template_dir
     tmp_dir = Dir.mktmpdir
     render = build_render_task(tmp_dir)
-    assert_render_failure(render.run(mock_output_stream))
+    assert_render_failure(render.run(stream: mock_output_stream))
     assert_logs_match_all([
       "Template directory #{tmp_dir} does not contain any valid templates",
     ])
@@ -248,7 +248,7 @@ class RenderTaskTest < Krane::TestCase
       File.join(fixture_path('invalid'), 'yaml-error.yml'),
       data: "data"
     )
-    assert_render_failure(render.run(mock_output_stream))
+    assert_render_failure(render.run(stream: mock_output_stream))
     assert_logs_match_all([
       /Invalid template: .*yaml-error.yml/,
       "> Error message:",
@@ -261,7 +261,7 @@ class RenderTaskTest < Krane::TestCase
       render = build_render_task(
         File.join(fixture_path('hello-cloud'), basename)
       )
-      assert_render_success render.run(mock_output_stream)
+      assert_render_success render.run(stream: mock_output_stream)
       stdout_assertion do |output|
         assert !output.empty?
       end
@@ -275,7 +275,7 @@ class RenderTaskTest < Krane::TestCase
     ])
     expected = "---\n# The first doc has no yaml separator\nkey1: foo\n---\nkey2: bar\n"
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       assert_equal "#{expected}#{expected}", output
     end
@@ -296,7 +296,7 @@ class RenderTaskTest < Krane::TestCase
         value: "data"
       RENDERED
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       assert_equal expected, output
     end
@@ -308,7 +308,7 @@ class RenderTaskTest < Krane::TestCase
     )
     expected = "---\nkey1: \"0\"\nkey1: \"1\"\nkey1: \"2\"\n"
 
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       assert_equal expected, output
     end
@@ -318,7 +318,7 @@ class RenderTaskTest < Krane::TestCase
     render = build_render_task(
       File.join(fixture_path('collection-with-erb'), 'effectively_empty.yml.erb')
     )
-    assert_render_success(render.run(mock_output_stream))
+    assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
       assert_equal "", output.strip
     end

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -206,7 +206,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
   def test_run_fails_if_template_is_blank
     task_runner = build_task_runner
-    result = task_runner.run(template: '',
+    result = task_runner.run(filename: '',
       command: ['/bin/sh', '-c'],
       arguments: nil,
       env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
@@ -224,7 +224,7 @@ class RunnerTaskTest < Krane::IntegrationTest
   def test_run_bang_fails_if_template_is_invalid
     task_runner = build_task_runner
     assert_raises(Krane::TaskConfigurationError) do
-      task_runner.run!(template: '',
+      task_runner.run!(filename: '',
         command: ['/bin/sh', '-c'],
         arguments: nil,
         env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
@@ -271,7 +271,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
     task_runner = build_task_runner
     result = task_runner.run(
-      template: 'hello-cloud-template-runner',
+      filename: 'hello-cloud-template-runner',
       command: ['/bin/sh', '-c'],
       arguments: ['echo "The value is: $MY_CUSTOM_VARIABLE"'],
       env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"]

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -206,7 +206,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
   def test_run_fails_if_template_is_blank
     task_runner = build_task_runner
-    result = task_runner.run(filename: '',
+    result = task_runner.run(template: '',
       command: ['/bin/sh', '-c'],
       arguments: nil,
       env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
@@ -224,7 +224,7 @@ class RunnerTaskTest < Krane::IntegrationTest
   def test_run_bang_fails_if_template_is_invalid
     task_runner = build_task_runner
     assert_raises(Krane::TaskConfigurationError) do
-      task_runner.run!(filename: '',
+      task_runner.run!(template: '',
         command: ['/bin/sh', '-c'],
         arguments: nil,
         env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
@@ -271,7 +271,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
     task_runner = build_task_runner
     result = task_runner.run(
-      filename: 'hello-cloud-template-runner',
+      template: 'hello-cloud-template-runner',
       command: ['/bin/sh', '-c'],
       arguments: ['echo "The value is: $MY_CUSTOM_VARIABLE"'],
       env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"]

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -18,7 +18,7 @@ class DeployTaskTest < Krane::TestCase
       context: KubeclientHelper::TEST_CONTEXT,
       logger: logger,
       current_sha: "",
-      template_paths: ["unknown"],
+      filenames: ["unknown"],
     ).run
     assert_logs_match("Configuration invalid")
     assert_logs_match(/File (\S+) does not exist/)

--- a/test/unit/krane/resource_deployer_test.rb
+++ b/test/unit/krane/resource_deployer_test.rb
@@ -90,7 +90,7 @@ class ResourceDeployerTest < Krane::TestCase
     end
     @deployer = Krane::ResourceDeployer.new(current_sha: 'test-sha',
       statsd_tags: [], task_config: task_config, prune_whitelist: prune_whitelist,
-      max_watch_seconds: 1, selector: nil)
+      global_timeout: 1, selector: nil)
   end
 
   def build_mock_resource(final_status: "success", hits_to_complete: 0, name: "web-pod")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

- Make sure task arguments match the new flag names so we have a consistent interface both in the API and in the CLI (https://github.com/Shopify/kubernetes-deploy/pull/602#discussion_r339247531).
- Be explicit about which arguments are required.

**How is this accomplished?**

By changing the public task interfaces so their argument names would match the respective flag names, and updating the test setup accordingly.