### PR TITLE
Update StatsD Prefix

### DIFF
--- a/lib/krane/statsd.rb
+++ b/lib/krane/statsd.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module Krane
   class StatsD
-    PREFIX = "KubernetesDeploy"
+    PREFIX = "Krane"
 
     def self.duration(start_time)
       (Time.now.utc - start_time).round(1)

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -279,14 +279,14 @@ class SerialDeployTest < Krane::IntegrationTest
     end
 
     %w(
-      KubernetesDeploy.validate_configuration.duration
-      KubernetesDeploy.discover_resources.duration
-      KubernetesDeploy.validate_resources.duration
-      KubernetesDeploy.initial_status.duration
-      KubernetesDeploy.priority_resources.duration
-      KubernetesDeploy.apply_all.duration
-      KubernetesDeploy.normal_resources.duration
-      KubernetesDeploy.all_resources.duration
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.validate_resources.duration
+      Krane.initial_status.duration
+      Krane.priority_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.all_resources.duration
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
       refute_nil metric, "Metric #{expected_metric} not emitted"
@@ -303,15 +303,15 @@ class SerialDeployTest < Krane::IntegrationTest
     assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
 
     %w(
-      KubernetesDeploy.validate_configuration.duration
-      KubernetesDeploy.discover_resources.duration
-      KubernetesDeploy.initial_status.duration
-      KubernetesDeploy.validate_resources.duration
-      KubernetesDeploy.priority_resources.duration
-      KubernetesDeploy.apply_all.duration
-      KubernetesDeploy.normal_resources.duration
-      KubernetesDeploy.sync.duration
-      KubernetesDeploy.all_resources.duration
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.initial_status.duration
+      Krane.validate_resources.duration
+      Krane.priority_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.sync.duration
+      Krane.all_resources.duration
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
       refute_nil metric, "Metric #{expected_metric} not emitted"
@@ -329,14 +329,14 @@ class SerialDeployTest < Krane::IntegrationTest
     assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
 
     %w(
-      KubernetesDeploy.validate_configuration.duration
-      KubernetesDeploy.discover_resources.duration
-      KubernetesDeploy.initial_status.duration
-      KubernetesDeploy.validate_resources.duration
-      KubernetesDeploy.apply_all.duration
-      KubernetesDeploy.normal_resources.duration
-      KubernetesDeploy.sync.duration
-      KubernetesDeploy.all_resources.duration
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.initial_status.duration
+      Krane.validate_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.sync.duration
+      Krane.all_resources.duration
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
       refute_nil metric, "Metric #{expected_metric} not emitted"

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -41,7 +41,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     end
 
     metric = metrics.find do |m|
-      m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
     end
     assert(metric, "No result metric found for this test")
     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
@@ -58,7 +58,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     end
 
     metric = metrics.find do |m|
-      m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
     end
     assert(metric, "No result metric found for this test")
     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
@@ -75,7 +75,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     end
 
     metric = metrics.find do |m|
-      m.name == "KubernetesDeploy.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
     end
     assert(metric, "No result metric found for this test")
     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -114,7 +114,7 @@ class KubectlTest < Krane::TestCase
       refute_predicate st, :success?
     end
     assert_equal(5, metrics.length)
-    assert_equal(["KubernetesDeploy.kubectl.error"], metrics.map(&:name).uniq)
+    assert_equal(["Krane.kubectl.error"], metrics.map(&:name).uniq)
 
     expected_messages = (1..5).map { |n| "(attempt #{n}/5" }
     assert_logs_match_all(expected_messages, in_order: true)

--- a/test/unit/krane/statsd_test.rb
+++ b/test/unit/krane/statsd_test.rb
@@ -47,7 +47,7 @@ class StatsDTest < Krane::TestCase
       TestMeasureClass.new.thing_to_measure
     end
     assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
-    assert_equal("KubernetesDeploy.thing_to_measure.duration", metrics.first.name)
+    assert_equal("Krane.thing_to_measure.duration", metrics.first.name)
     assert_equal(["test:true"], metrics.first.tags)
   end
 
@@ -56,7 +56,7 @@ class StatsDTest < Krane::TestCase
       TestMeasureClass.new.measure_with_custom_metric
     end
     assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
-    assert_equal("KubernetesDeploy.customized", metrics.first.name)
+    assert_equal("Krane.customized", metrics.first.name)
     assert_equal(["test:true"], metrics.first.tags)
   end
 
@@ -65,7 +65,7 @@ class StatsDTest < Krane::TestCase
       TestMeasureNoTags.new.thing_to_measure
     end
     assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
-    assert_equal("KubernetesDeploy.thing_to_measure.duration", metrics.first.name)
+    assert_equal("Krane.thing_to_measure.duration", metrics.first.name)
     assert_nil(metrics.first.tags)
   end
 
@@ -78,7 +78,7 @@ class StatsDTest < Krane::TestCase
       end
     end
     assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
-    assert_equal("KubernetesDeploy.measured_method_raises.duration", metrics.first.name)
+    assert_equal("Krane.measured_method_raises.duration", metrics.first.name)
     assert_equal(["test:true", "error:true"], metrics.first.tags)
   end
 
@@ -91,7 +91,7 @@ class StatsDTest < Krane::TestCase
       end
     end
     assert_predicate(metrics, :one?, "Expected 1 metric, got #{metrics.length}")
-    assert_equal("KubernetesDeploy.measured_method_raises.duration", metrics.first.name)
+    assert_equal("Krane.measured_method_raises.duration", metrics.first.name)
     assert_equal(["test:true", "error:true"], metrics.first.tags)
   end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
As part of the 1.0 migration we need to update the StatsD prefix to match the gem name. This PR is to be merged before 1.0 release but is a breaking change and should be done as late as possible.

**How is this accomplished?**
Update the prefix and tests.

**What could go wrong?**
People fail to read the transition guide and miss this change. But this change will not impact deploy behavior just metrics. 
