### PR TITLE
Update the gemspec for Krane 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in kubernetes-deploy.gemspec
+# Specify your gem's dependencies in krane.gemspec
 gemspec
 
 gem 'pry'

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -5,14 +5,15 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'krane/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "kubernetes-deploy"
+  spec.name          = "krane"
   spec.version       = Krane::VERSION
-  spec.authors       = ["Katrina Verey", "Kir Shatrov"]
+  spec.authors       = ["Katrina Verey", "Daniel Turner", "Kir Shatrov"]
   spec.email         = ["ops-accounts+shipit@shopify.com"]
 
-  spec.summary       = 'Kubernetes deploy scripts'
+  spec.summary       = 'A command line tool that helps you ship changes to a Kubernetes' \
+    ' namespace and understand the result'
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/Shopify/kubernetes-deploy"
+  spec.homepage      = "https://github.com/Shopify/krane"
   spec.license       = "MIT"
 
   spec.files         = %x(git ls-files -z).split("\x0").reject do |f|


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
One of the last steps for releasing Krane 1.0.0 is updating the gemspec.

**How is this accomplished?**
Update the gemspec and use the existing description from https://rubygems.org/gems/krane

There is no rubygem rename ability, its just create a new one: https://help.rubygems.org/discussions/questions/104-how-should-i-handle-the-rename-of-a-gem

Shipit will automatically figure out the new gemspec. 

**What could go wrong?**
Not much, worst case we quickly yank 1.0.0 while we fix the issue and create it again.