### PR TITLE
Remove rendering from krane deploy cli

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -10,9 +10,6 @@ module Krane
         kube-public
       )
       OPTIONS = {
-        "bindings" => { type: :array, banner: "foo=bar abc=def",
-                        desc: "Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file "\
-                          "(JSON or YAML) path prefixed by '@')" },
         "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                          aliases: :f, required: false, default: [],
                          desc: "Directories and files that contains the configuration to apply" },
@@ -26,25 +23,18 @@ module Krane
                                     default: PROTECTED_NAMESPACES },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that do not appear in the template dir",
                      default: true },
-        "render-erb" => { type: :boolean, desc: "Enable ERB rendering", default: false },
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: true },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
-        "current-sha" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
-
       }
 
       def self.from_options(namespace, context, options)
         require 'krane/deploy_task'
         require 'krane/options_helper'
-        require 'krane/bindings_parser'
         require 'krane/label_selector'
-
-        bindings_parser = ::Krane::BindingsParser.new
-        options[:bindings]&.each { |binding_pair| bindings_parser.add(binding_pair) }
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
 
@@ -67,9 +57,7 @@ module Krane
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,
             context: context,
-            current_sha: options['current-sha'],
             filenames: paths,
-            bindings: bindings_parser.parse,
             logger: logger,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -96,7 +96,7 @@ module Krane
     # @param protected_namespaces [Array<String>] Array of protected Kubernetes namespaces (defaults
     #   to Krane::DeployTask::PROTECTED_NAMESPACES)
     # @param render_erb [Boolean] Enable ERB rendering
-    def initialize(namespace:, context:, current_sha:, logger: nil, kubectl_instance: nil, bindings: {},
+    def initialize(namespace:, context:, current_sha: nil, logger: nil, kubectl_instance: nil, bindings: {},
       global_timeout: nil, selector: nil, filenames: [], protected_namespaces: nil,
       render_erb: true)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'test_helper'
 require 'krane/cli/krane'
-require 'krane/bindings_parser'
 
 class DeployTest < Krane::TestCase
   def test_deploy_with_default_options
@@ -21,16 +20,6 @@ class DeployTest < Krane::TestCase
     Krane::LabelSelector.expects(:parse).returns(selector)
     set_krane_deploy_expectations(new_args: { selector: selector })
     krane_deploy!(flags: '--selector name:web')
-  end
-
-  def test_deploy_parses_bindings
-    bindings_parser = Krane::BindingsParser.new
-    bindings_parser.expects(:add).with('foo=bar')
-    bindings_parser.expects(:add).with('abc=def')
-    bindings_parser.expects(:parse).returns(true)
-    Krane::BindingsParser.expects(:new).returns(bindings_parser)
-    set_krane_deploy_expectations(new_args: { bindings: true })
-    krane_deploy!(flags: '--bindings foo=bar abc=def')
   end
 
   def test_deploy_passes_verify_result
@@ -94,12 +83,6 @@ class DeployTest < Krane::TestCase
     end
   end
 
-  def test_deploy_uses_current_sha
-    test_sha = "TEST"
-    set_krane_deploy_expectations(new_args: { current_sha: test_sha })
-    krane_deploy!(flags: "--current-sha #{test_sha}")
-  end
-
   private
 
   def set_krane_deploy_expectations(new_args: {}, run_args: {})
@@ -128,9 +111,7 @@ class DeployTest < Krane::TestCase
       new_args: {
         namespace: deploy_task_config.namespace,
         context: deploy_task_config.context,
-        current_sha: nil,
         filenames: ['/tmp'],
-        bindings: {},
         logger: logger,
         global_timeout: 300,
         selector: nil,


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Remove the ability of krane deploy cli to render erb

Ideally the deploy task will not render erb either, #626 is a start down that path, but its a large change and one we likely don't have time to ship before 1.0 this is a stop-gap idea. 

**How is this accomplished?**
Remove the flags, allow current_sha to be nil

**What could go wrong?**

* current-sha gets fed to statsd tags, we could leave the flag just for that, but I'd rather add an explicit flag for extra statsd tags if desired.

* We have to keep the rendering in the task, though removing it later is less difficult than removing it from the cli tool later. 
