### PR TITLE
[bug fix] Render corner cases

### DIFF
--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -8,7 +8,8 @@ module Krane
         "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                          required: false, default: [], aliases: 'f', desc: 'Directories and files to render' },
         "stdin" => { type: :boolean, desc: "Read resources from stdin", default: false },
-        "current-sha" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
+        "current-sha" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings",
+                           lazy_default: '' },
       }
 
       def self.from_options(options)
@@ -26,7 +27,7 @@ module Krane
           raise Thor::RequiredArgumentMissingError, 'At least one of --filenames or --stdin must be set'
         end
 
-        ::Krane::OptionsHelper.with_processed_template_paths(filenames) do |paths|
+        ::Krane::OptionsHelper.with_processed_template_paths(filenames, render_erb: true) do |paths|
           renderer = ::Krane::RenderTask.new(
             current_sha: options['current-sha'],
             filenames: paths,

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -98,7 +98,7 @@ module Krane
     # @param render_erb [Boolean] Enable ERB rendering
     def initialize(namespace:, context:, current_sha: nil, logger: nil, kubectl_instance: nil, bindings: {},
       global_timeout: nil, selector: nil, filenames: [], protected_namespaces: nil,
-      render_erb: true)
+      render_erb: false)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
       @template_sets = TemplateSets.from_dirs_and_files(paths: filenames, logger: @logger, render_erb: render_erb)
       @task_config = Krane::TaskConfig.new(context, namespace, @logger)

--- a/lib/krane/options_helper.rb
+++ b/lib/krane/options_helper.rb
@@ -4,9 +4,9 @@ module Krane
   module OptionsHelper
     class OptionsError < StandardError; end
 
-    STDIN_TEMP_FILE = "from_stdin.yml.erb"
+    STDIN_TEMP_FILE = "from_stdin.yml"
     class << self
-      def with_processed_template_paths(template_paths)
+      def with_processed_template_paths(template_paths, render_erb: false)
         validated_paths = []
         template_paths.uniq!
         template_paths.each do |template_path|
@@ -16,7 +16,7 @@ module Krane
 
         if template_paths.include?("-")
           Dir.mktmpdir("krane") do |dir|
-            template_dir_from_stdin(temp_dir: dir)
+            template_dir_from_stdin(temp_dir: dir, render_erb: render_erb)
             validated_paths << dir
             yield validated_paths
           end
@@ -27,8 +27,10 @@ module Krane
 
       private
 
-      def template_dir_from_stdin(temp_dir:)
-        File.open(File.join(temp_dir, STDIN_TEMP_FILE), 'w+') { |f| f.print($stdin.read) }
+      def template_dir_from_stdin(temp_dir:, render_erb:)
+        tempfile = STDIN_TEMP_FILE
+        tempfile += ".erb" if render_erb
+        File.open(File.join(temp_dir, tempfile), 'w+') { |f| f.print($stdin.read) }
       rescue IOError, Errno::ENOENT => e
         raise OptionsError, e.message
       end

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -91,6 +91,10 @@ module Krane
       if @filenames.blank?
         errors << "filenames must be set"
       end
+
+      if !@current_sha.nil? && @current_sha.empty?
+        errors << "current-sha is optional but can not be blank"
+      end
       errors += template_sets.validate
 
       unless errors.empty?

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -75,7 +75,7 @@ class RenderTest < Krane::TestCase
 
   def default_options(new_args = {})
     {
-      current_sha: ENV["REVISION"],
+      current_sha: nil,
       filenames: ["/dev/null"],
       bindings: {},
     }.merge(new_args)

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -325,6 +325,18 @@ class RenderTaskTest < Krane::TestCase
     assert_logs_match("Rendered effectively_empty.yml.erb successfully, but the result was blank")
   end
 
+  def test_render_errors_empty_sha
+    render = Krane::RenderTask.new(logger: logger, current_sha: "", bindings: {},
+      filenames: [fixture_path('test-partials')])
+
+    assert_render_failure(render.run(stream: mock_output_stream))
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Configuration invalid",
+      "- current-sha is optional but can not be blank",
+    ], in_order: true)
+  end
+
   private
 
   def build_render_task(filenames, bindings = {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -227,9 +227,9 @@ module Krane
       @task_config ||= Krane::TaskConfig.new(context, namespace, logger)
     end
 
-    def krane_black_box(command, args = "")
+    def krane_black_box(command, args = "", stdin: nil)
       path = File.expand_path("../../exe/krane", __FILE__)
-      Open3.capture3("#{path} #{command} #{args}")
+      Open3.capture3("#{path} #{command} #{args}", stdin_data: stdin)
     end
 
     private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

1. Disable rendering by default in DeployTask.

2. Fix bugs with the render task:

(a) Thor defaults the value of a flag with no values passes as the flag name, e.g. `--current-sha ` sets the value of of `options['current-sha'] == "current-sha"`
(b) `krane render --std-in` doesn't actually render

**How is this accomplished?**
1. flip the default to false
2.a set a lazy default
2.b pass information `OptionsHelper` that the file name for data from stdin needs to end in `.erb`

**What could go wrong?**

Not much with the bug fixes. The default flip is part of the 1.0 breaking changes.