### PR TITLE
Require active_support

### DIFF
--- a/lib/krane/common.rb
+++ b/lib/krane/common.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/hash/slice'


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Seems like we need to require `active_support` first.

https://github.com/rails/rails/issues/43889

This started failing with [Rails 7 in shopify-build](https://buildkite.com/shopify/shopify-build/builds/11431#cc3b8528-4f15-4794-ba24-e1aed2612f14).

**How is this accomplished?**
`require 'active_support'

**What could go wrong?**
n/a
