### PR TITLE
Allow configuring kubectl --request-timeout via env

### DIFF
--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -9,7 +9,8 @@ module Krane
       empty: /\A\z/,
       context_deadline: /context deadline exceeded/,
     }
-    DEFAULT_TIMEOUT = (ENV["KUBECTL_DEFAULT_REQUEST_TIMEOUT"] || 15).to_i
+    ENV_DEFAULT_TIMEOUT = ENV["KUBECTL_DEFAULT_REQUEST_TIMEOUT"]
+    DEFAULT_TIMEOUT = (ENV_DEFAULT_TIMEOUT if Integer(ENV_DEFAULT_TIMEOUT) rescue 15).to_i
     MAX_RETRY_DELAY = 16
     SERVER_DRY_RUN_MIN_VERSION = "1.13"
 


### PR DESCRIPTION
For example,

```
KUBECTL_DEFAULT_REQUEST_TIMEOUT=30 krane deploy ...
```

**What are you trying to accomplish with this PR?**
Configurable timeout for deploys not to fail in a setup where the currently unconfigurable 15 seconds is not always enough

**How is this accomplished?**
Add support for configuring this through an environment variable, with the suggeste name `KUBECTL_DEFAULT_REQUEST_TIMEOUT`

**What could go wrong?**
Hmm, not much? Maybe env var naming conflicts in some fringe cases, but doesn't seem very likely.
