### PR TITLE
allow specifying additional/default labels via command line

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -29,6 +29,8 @@ module Krane
                                   desc: "Use --selector as a label filter to deploy only a subset "\
                                     "of the provided resources",
                                   default: false },
+        "extra-labels" => { type: :string, banner: "'label=value,foo=bar'",
+                            desc: "Labels to set on resources that don't have them" },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: false },
         "verify-result" => { type: :boolean, default: true,
@@ -39,6 +41,7 @@ module Krane
         require 'krane/deploy_task'
         require 'krane/options_helper'
         require 'krane/label_selector'
+        require 'krane/extra_labels'
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
         selector_as_filter = options['selector-as-filter']
@@ -46,6 +49,8 @@ module Krane
         if selector_as_filter && !selector
           raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
         end
+
+        extra_labels = ::Krane::ExtraLabels.parse(options['extra-labels']) if options['extra-labels']
 
         logger = ::Krane::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])
@@ -71,6 +76,7 @@ module Krane
             selector: selector,
             selector_as_filter: selector_as_filter,
             protected_namespaces: protected_namespaces,
+            extra_labels: extra_labels,
           )
 
           deploy.run!(

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -20,6 +20,8 @@ module Krane
                                   desc: "Use --selector as a label filter to deploy only a subset "\
                                     "of the provided resources",
                                   default: false },
+        "extra-labels" => { type: :string, banner: "'label=value,foo=bar'",
+                            desc: "Labels to set on resources that don't have them" },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that match"\
                      " the provided selector and do not appear in the provided templates",
                      default: true },
@@ -29,6 +31,7 @@ module Krane
         require 'krane/global_deploy_task'
         require 'krane/options_helper'
         require 'krane/label_selector'
+        require 'krane/extra_labels'
         require 'krane/duration_parser'
 
         selector = ::Krane::LabelSelector.parse(options[:selector])
@@ -37,6 +40,8 @@ module Krane
         if selector_as_filter && !selector
           raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
         end
+
+        extra_labels = ::Krane::ExtraLabels.parse(options['extra-labels']) if options['extra-labels']
 
         filenames = options[:filenames].dup
         filenames << "-" if options[:stdin]
@@ -51,6 +56,7 @@ module Krane
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
             selector_as_filter: selector_as_filter,
+            extra_labels: extra_labels,
           )
 
           deploy.run!(

--- a/lib/krane/ejson_secret_provisioner.rb
+++ b/lib/krane/ejson_secret_provisioner.rb
@@ -18,11 +18,12 @@ module Krane
 
     delegate :namespace, :context, :logger, to: :@task_config
 
-    def initialize(task_config:, ejson_keys_secret:, ejson_file:, statsd_tags:, selector: nil)
+    def initialize(task_config:, ejson_keys_secret:, ejson_file:, statsd_tags:, selector: nil, extra_labels: {})
       @ejson_keys_secret = ejson_keys_secret
       @ejson_file = ejson_file
       @statsd_tags = statsd_tags
       @selector = selector
+      @extra_labels = extra_labels
       @task_config = task_config
       @kubectl = Kubectl.new(
         task_config: @task_config,
@@ -97,6 +98,7 @@ module Krane
 
       labels = { "name" => secret_name }
       labels.reverse_merge!(@selector.to_h) if @selector
+      labels.reverse_merge!(@extra_labels)
 
       secret = {
         'kind' => 'Secret',

--- a/lib/krane/extra_labels.rb
+++ b/lib/krane/extra_labels.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Krane
+  class ExtraLabels
+    def self.parse(string)
+      extra_labels = {}
+
+      string.split(',').each do |kvp|
+        key, value = kvp.split('=', 2)
+
+        if key.blank?
+          raise ArgumentError, "key is blank"
+        end
+
+        extra_labels[key] = value
+      end
+
+      extra_labels
+    end
+  end
+end

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -34,9 +34,10 @@ module Krane
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector (*required*)
     # @param selector_as_filter [Boolean] Allow selecting a subset of Kubernetes resource templates to deploy
+    # @param extra_labels [Hash] labels to set on resources that don't have them
     # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
     def initialize(context:, global_timeout: nil, selector: nil, selector_as_filter: false,
-      filenames: [], logger: nil, kubeconfig: nil)
+      extra_labels: {}, filenames: [], logger: nil, kubeconfig: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 
       @task_config = TaskConfig.new(context, nil, logger, kubeconfig)
@@ -45,6 +46,7 @@ module Krane
       @global_timeout = global_timeout
       @selector = selector
       @selector_as_filter = selector_as_filter
+      @extra_labels = extra_labels
     end
 
     # Runs the task, returning a boolean representing success or failure
@@ -168,7 +170,7 @@ module Krane
       @template_sets.with_resource_definitions do |r_def|
         crd = crds_by_kind[r_def["kind"]]&.first
         r = KubernetesResource.build(context: context, logger: logger, definition: r_def,
-          crd: crd, global_names: global_kinds, statsd_tags: statsd_tags)
+          crd: crd, global_names: global_kinds, statsd_tags: statsd_tags, extra_labels: @extra_labels)
         resources << r
         logger.info("  - #{r.id}")
       end

--- a/lib/krane/kubernetes_resource/custom_resource.rb
+++ b/lib/krane/kubernetes_resource/custom_resource.rb
@@ -8,9 +8,9 @@ module Krane
       (.metadata.generation != .status.observedGeneration).
     MSG
 
-    def initialize(namespace:, context:, definition:, logger:, statsd_tags: [], crd:)
+    def initialize(namespace:, context:, definition:, logger:, statsd_tags: [], crd:, extra_labels: {})
       super(namespace: namespace, context: context, definition: definition,
-            logger: logger, statsd_tags: statsd_tags)
+            logger: logger, statsd_tags: statsd_tags, extra_labels: extra_labels)
       @crd = crd
     end
 

--- a/lib/krane/kubernetes_resource/pod.rb
+++ b/lib/krane/kubernetes_resource/pod.rb
@@ -13,7 +13,7 @@ module Krane
     attr_reader :definition
 
     def initialize(namespace:, context:, definition:, logger:,
-      statsd_tags: nil, parent: nil, deploy_started_at: nil, stream_logs: false)
+      statsd_tags: nil, parent: nil, deploy_started_at: nil, stream_logs: false, extra_labels: {})
       @parent = parent
       @deploy_started_at = deploy_started_at
 
@@ -25,7 +25,7 @@ module Krane
       @containers += definition["spec"].fetch("initContainers", []).map { |c| Container.new(c, init_container: true) }
       @stream_logs = stream_logs
       super(namespace: namespace, context: context, definition: definition,
-            logger: logger, statsd_tags: statsd_tags)
+            logger: logger, statsd_tags: statsd_tags, extra_labels: extra_labels)
     end
 
     def sync(_cache)

--- a/lib/krane/kubernetes_resource/replica_set.rb
+++ b/lib/krane/kubernetes_resource/replica_set.rb
@@ -8,12 +8,12 @@ module Krane
     attr_reader :pods
 
     def initialize(namespace:, context:, definition:, logger:, statsd_tags: nil,
-      parent: nil, deploy_started_at: nil)
+      parent: nil, deploy_started_at: nil, extra_labels: {})
       @parent = parent
       @deploy_started_at = deploy_started_at
       @pods = []
       super(namespace: namespace, context: context, definition: definition,
-            logger: logger, statsd_tags: statsd_tags)
+            logger: logger, statsd_tags: statsd_tags, extra_labels: extra_labels)
     end
 
     def sync(cache)

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -14,7 +14,7 @@ module Krane
     # @param current_sha [String] The SHA of the commit
     # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
     # @param bindings [Hash] Bindings parsed by Krane::BindingsParser
-    def initialize(logger: nil, current_sha:, filenames: [], bindings:)
+    def initialize(logger: nil, current_sha:, filenames: [], bindings:, extra_labels: {})
       @logger = logger || Krane::FormattedLogger.build
       @filenames = filenames.map { |path| File.expand_path(path) }
       @bindings = bindings

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -164,6 +164,7 @@ class DeployTest < Krane::TestCase
         selector: nil,
         selector_as_filter: false,
         protected_namespaces: ["default", "kube-system", "kube-public"],
+        extra_labels: nil,
       }.merge(new_args),
       run_args: {
         verify_result: true,

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -143,6 +143,7 @@ class GlobalDeployTest < Krane::TestCase
         global_timeout: 300,
         selector: 'name=web',
         selector_as_filter: false,
+        extra_labels: nil,
       }.merge(new_args),
       run_args: {
         verify_result: true,

--- a/test/unit/krane/extra_labels_test.rb
+++ b/test/unit/krane/extra_labels_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'krane/extra_labels'
+
+class ExtraLabelsTest < ::Minitest::Test
+  def test_parse_extra_labels
+    expected = { "foo" => "42", "bar" => "17" }
+    assert_equal(expected, parse("foo=42,bar=17"))
+  end
+
+  def test_parse_extra_labels_with_equality_sign
+    expected = { "foo" => "1=2=3", "bar" => "3", "bla" => "4=7" }
+    assert_equal(expected, parse("foo=1=2=3,bar=3,bla=4=7"))
+  end
+
+  def test_parse_extra_labels_with_no_value
+    expected = { "bla" => nil, "foo" => "" }
+    assert_equal(expected, parse("bla,foo="))
+  end
+
+  def test_parse_extra_labels_with_no_key
+    assert_raises(ArgumentError, "key is blank") do
+      parse("=17,foo=42")
+    end
+  end
+
+  private
+
+  def parse(string)
+    Krane::ExtraLabels.parse(string).to_h
+  end
+end

--- a/test/unit/krane/kubernetes_resource/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource/kubernetes_resource_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class KubernetesResourceTest < Krane::TestCase
+  def test_extra_labels
+    [
+      {kind: "ConfigMap"},
+      {kind: "CronJob"},
+      {kind: "CustomResourceDefinition"},
+      {kind: "DaemonSet"},
+      {kind: "Deployment"},
+      {kind: "HorizontalPodAutoscaler"},
+      {kind: "Ingress"},
+      {kind: "Job"},
+      {kind: "NetworkPolicy"},
+      {kind: "PersistentVolumeClaim"},
+      {kind: "PodDisruptionBudget"},
+      {kind: "PodSetBase"},
+      {kind: "PodTemplate"},
+      {kind: "ReplicaSet"},
+      {kind: "ResourceQuota"},
+      {kind: "Role"},
+      {kind: "RoleBinding"},
+      {kind: "Secret"},
+      {kind: "Service"},
+      {kind: "ServiceAccount"},
+      {kind: "StatefulSet"},
+
+      {kind: "Pod", spec: {"containers" => [{"name" => "someContainer"}]}},
+      {kind: "SomeCustomResource", init_args: {crd: "SomeCRD"}},
+      {kind: "ResourceUnknownToKrane"},
+    ].each do |resource|
+      args = {
+        namespace: 'test',
+        context: 'nope',
+        logger: @logger,
+        statsd_tags: [],
+        extra_labels: {
+          "extra" => "label",
+          "overwritten" => "yes"
+        },
+        definition: {
+          "kind" => resource.fetch(:kind),
+          "metadata" => {
+            "name" => "testsuite",
+            "labels" => {
+              "overwritten" => "no"
+            },
+          },
+          "spec" => resource.fetch(:spec, {})
+        }
+      }
+      args.merge!(resource.fetch(:init_args, {}))
+
+      resource = begin
+        Krane::KubernetesResource.build(**args)
+      rescue ArgumentError => e
+        flunk("failed to build #{resource.fetch(:kind)}: #{e.message}")
+      end
+
+      assert_equal(resource.send(:labels),
+        {"extra"=>"label", "overwritten"=>"no"},
+        "expected #{resource} to apply extra_labels")
+    end
+  end
+end


### PR DESCRIPTION
This change adds the ability to set additional labels or provide default values for deployment commands. This also works for ejson secrets. `ejson-keys` as shared secret will not be labled.

The functionality was not made available on `krane render` due to potentially confusing behaviour around labels on secrets when using `krane render … | krane deploy -f secrets.ejson -f -` .

Allowing labels specified in the templates take precedence is an intentional choice. It is the more flexible approach and allows customization for edge cases like migrations and "nested" deployments.

see https://github.com/Shopify/krane/issues/682

**What are you trying to accomplish with this PR?**

Setting standard/well known labels like `app.kubernetes.io/name` on all Kubernetes objects, but especially Secrets created through the secrets.ejson handling.

**How is this accomplished?**

New top-level CLI parameter on `krane deploy` and `krane global-deploy` that is passed through to the resource or ejson provider, where it they get merged into the object definition.

**What could go wrong?**

Edge cases around `nil` handling from the extra_labels side, as well as the `.metadata.labels` definition on the k8s object/resource side. In practice this shows up as "failed to deploy" type of error, if and only if the resource is part of the deployment templates. This might happen again if new special handlers for Resources are written that are not covered by the test in [test/unit/krane/kubernetes_resource/kubernetes_resource_test.rb](https://github.com/Shopify/krane/compare/main...breunigs:krane:allow-setting-labels-from-cli?expand=1#diff-3a3c2beabbe93438817b399e371126128e10e41e40b1ee3b78cc9499de7bcc98).

**Considered Alternatives**

* re-using the `selector`: The dual use for pruning makes it undesirable. If the `selector` and old k8s objects are removed in the same deployment run, the old objects will not be pruned. Expecting the user to remember this edge case is unrealistic, especially since it's unlikely to happen often.
* adding a `.metadata.labels` like key to `secrets.ejson` (perhaps at at `.kubernetes_secrets.*._labels`): I didn't test this, but it's probably possible. The reason we didn't go for this was our need to set labels on all objects, not just secrets. It would imply we need either a) manual effort of adding labels to all object definitions, or b) tooling to update these in source control in ERB files, or c) some extra tool that patches the `secrets.ejson` before passing it to `krane render … | krane deploy -f secrets.ejson -f -`. So while conceptually simpler in krane, it has limited utility in organically grown systems – or at least ours. Hence it was discarded early on.

**On CLA**
Your CLA flow claims someone signed for my account already, although we're not sure who anymore. I also have recent permission by someone with signing power from my org. Therefore I expect this at most to require some bureaucratic cleanup, but not present a blocker.