### PR TITLE
v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 3.7.0
+
+- Annotate individual resources with `last-applied-configuration` when using `krane deploy` with `--annotate-individuals`. Previously, eligible resources that were made with `create` or `replace` were applied along with the rest of the resources. However, this causes issues when a mutating admission controller modifies otherwise immutable fields.
+
 ## 3.6.3
 
 - Test against k8s 1.31
@@ -12,7 +16,7 @@
 
 *Features*
 
-- Enable the option to bypass endpoint validation for a service by using the annotation `krane.shopify.io/skip-endpoint-validation: true`. 
+- Enable the option to bypass endpoint validation for a service by using the annotation `krane.shopify.io/skip-endpoint-validation: true`.
 
 ## 3.6.0
 

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.6.3"
+  VERSION = "3.7.0"
 end


### PR DESCRIPTION
Minor version bump as we have a non-breaking change to a public API while still preserving behaviour (though a slight difference in failure mode)

See CHANGELOG