### PR TITLE
convert generation to integer

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -204,13 +204,13 @@ module Krane
 
     def current_generation
       return -1 unless exists? # must be different default than observed_generation
-      @instance_data.dig("metadata", "generation").to_i
+      @instance_data.dig("metadata", "generation")&.to_i
     end
 
     def observed_generation
       return -2 unless exists?
       # populating this is a best practice, but not all controllers actually do it
-      @instance_data.dig('status', 'observedGeneration').to_i
+      @instance_data.dig('status', 'observedGeneration')&.to_i
     end
 
     def status


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

part of https://vault.shopify.io/gsd/projects/44508-Canary-Optimization-for-Cardserver-Friends

This PR addresses an issue identified during testing with ArgoCD rollouts, where `generation` (an integer) and `observedGeneration` (a string) had different data types. This discrepancy caused the condition for a successful deployment, `generation == observedGeneration`, to never evaluate as true.

**How is this accomplished?**
converting both of those values to an integer would ensure we are doing a proper comparison between the two.

**What could go wrong?**

