### PR TITLE
Prevent render failure from leaking secrets

### DIFF
--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -8,6 +8,8 @@ require 'krane/template_sets'
 module Krane
   # Render templates
   class RenderTask
+    include Krane::TemplateReporting
+
     # Initializes the render task
     #
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
@@ -67,7 +69,12 @@ module Krane
 
       count
     rescue Krane::InvalidTemplateError => exception
-      log_invalid_template(exception)
+      record_invalid_template(
+        logger: @logger,
+        err: exception.to_s,
+        filename: exception.filename,
+        content: exception.content
+      )
       raise
     end
 
@@ -104,17 +111,6 @@ module Krane
         @logger.summary.add_paragraph(errors.map { |err| "- #{err}" }.join("\n"))
         raise Krane::TaskConfigurationError, "Configuration invalid: #{errors.join(', ')}"
       end
-    end
-
-    def log_invalid_template(exception)
-      @logger.error("Failed to render #{exception.filename}")
-
-      debug_msg = ColorizedString.new("Invalid template: #{exception.filename}\n").red
-      debug_msg += "> Error message:\n#{FormattedLogger.indent_four(exception.to_s)}"
-      if exception.content
-        debug_msg += "\n> Template content:\n#{FormattedLogger.indent_four(exception.content)}"
-      end
-      @logger.summary.add_paragraph(debug_msg)
     end
   end
 end

--- a/test/fixtures/invalid/secret.yaml.erb
+++ b/test/fixtures/invalid/secret.yaml.erb
@@ -1,0 +1,10 @@
+<%- invalid_secret_with_newlines = Base64.encode64("*" * 70) -%>
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: invalid-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: <%= invalid_secret_with_newlines %>

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -234,6 +234,19 @@ class RenderTaskTest < Krane::TestCase
     ], in_order: true)
   end
 
+  def test_render_runtime_error_when_rendering_secrets
+    render = build_render_task(
+      File.join(fixture_path('invalid'), 'secret.yaml.erb')
+    )
+    assert_render_failure(render.run(stream: mock_output_stream))
+    assert_logs_match_all([
+      /Invalid template: secret.yaml.erb/,
+      "> Error message:",
+      /\(<rendered> secret.yaml.erb\): could not find expected ':' while scanning a simple key at line \d+ column \d+/,
+      "> Template content: Suppressed because it may contain a Secret",
+    ], in_order: true)
+  end
+
   def test_render_empty_template_dir
     tmp_dir = Dir.mktmpdir
     render = build_render_task(tmp_dir)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
> We handle Kubernetes secrets, so it is critical that changes do not
cause the contents of any secrets in the template set to be logged.[^1]

When a `krane render` task fails it can potentially leak base64 encoded secrets in the clear.

**How is this accomplished?**

This was discovered when a developer used Ruby's `Base64.encode64` method to produce a secret value. The value was long enough to produced an encoded string longer than 60 characters.

> The returned string ends with a newline character, and if
sufficiently long will have one or more embedded newline characters...[^2]

> An encoded string returned by Base64.encode64 or
Base64.urlsafe_encode64 has an embedded newline character after each 60-character sequence, and, if non-empty, at the end: [^3]

This caused krane to dump the base64 encoded secrets to the deployment logs.

Deployment tasks take action to prevent secrets leaking in this way, and we can reuse that logic for rendering failures.

🎩

Example before:

```
[INFO][2025-07-09 10:14:03 -0400]
[INFO][2025-07-09 10:14:03 -0400]	---------------------------------Phase 1: Initializing render task----------------------------------
[INFO][2025-07-09 10:14:03 -0400]	Validating configuration
[INFO][2025-07-09 10:14:03 -0400]
[INFO][2025-07-09 10:14:03 -0400]	-----------------------------------Phase 2: Rendering template(s)-----------------------------------
[ERROR][2025-07-09 10:14:03 -0400]	Failed to render secret.yaml.erb
[INFO][2025-07-09 10:14:03 -0400]
[INFO][2025-07-09 10:14:03 -0400]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2025-07-09 10:14:03 -0400]	Invalid template: secret.yaml.erb
[FATAL][2025-07-09 10:14:03 -0400]	> Error message:
[FATAL][2025-07-09 10:14:03 -0400]      (<rendered> secret.yaml.erb): could not find expected ':' while scanning a simple key at line 10 column 1
[FATAL][2025-07-09 10:14:03 -0400]	> Template content:
[FATAL][2025-07-09 10:14:03 -0400]
[FATAL][2025-07-09 10:14:03 -0400]      apiVersion: v1
[FATAL][2025-07-09 10:14:03 -0400]      kind: Secret
[FATAL][2025-07-09 10:14:03 -0400]      metadata:
[FATAL][2025-07-09 10:14:03 -0400]        name: invalid-secret
[FATAL][2025-07-09 10:14:03 -0400]      type: Opaque
[FATAL][2025-07-09 10:14:03 -0400]      data:
[FATAL][2025-07-09 10:14:03 -0400]        username: YWRtaW4=
[FATAL][2025-07-09 10:14:03 -0400]        password: KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioq
[FATAL][2025-07-09 10:14:03 -0400]      KioqKioqKioqKioqKioqKioqKioqKioqKg==
[FATAL][2025-07-09 10:14:03 -0400]
[FATAL][2025-07-09 10:14:03 -0400]
```

Example After:

```
[INFO][2025-07-09 10:27:04 -0400]
[INFO][2025-07-09 10:27:04 -0400]	---------------------------------Phase 1: Initializing render task----------------------------------
[INFO][2025-07-09 10:27:04 -0400]	Validating configuration
[INFO][2025-07-09 10:27:04 -0400]
[INFO][2025-07-09 10:27:04 -0400]	-----------------------------------Phase 2: Rendering template(s)-----------------------------------
[INFO][2025-07-09 10:27:04 -0400]
[INFO][2025-07-09 10:27:04 -0400]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2025-07-09 10:27:04 -0400]	Invalid template: secret.yaml.erb
[FATAL][2025-07-09 10:27:04 -0400]	> Error message:
[FATAL][2025-07-09 10:27:04 -0400]      (<rendered> secret.yaml.erb): could not find expected ':' while scanning a simple key at line 10 column 1
[FATAL][2025-07-09 10:27:04 -0400]	> Template content: Suppressed because it may contain a Secret
```


**What could go wrong?**

From the outside, this doesn't seem to open krane up to any additional runtime risk.

[^1]: https://github.com/Shopify/krane/blob/72ee07a311442751535b87a23ea843b71190e618/CONTRIBUTING.md?plain=1#L44
[^2]: https://ruby-doc.org/3.4.1/gems/base64/Base64.html#method-i-encode64
[^3]: https://ruby-doc.org/3.4.1/gems/base64/Base64.html#module-Base64-label-Newlines
