### PR TITLE
fix: validate that contexts exists before trying to build client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## next
 
+- Skip kubeconfig files with no contexts defined instead of crashing when building the Kubernetes client
+
 ## 3.9.1
+
 - Test against k8s 1.34
 
 ## 3.9.0

--- a/test/fixtures/kube-config/empty_config.yml
+++ b/test/fixtures/kube-config/empty_config.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+clusters: null
+contexts: null
+current-context: something
+kind: Config
+preferences: {}
+users: null

--- a/test/unit/krane/kubeclient_builder_test.rb
+++ b/test/unit/krane/kubeclient_builder_test.rb
@@ -64,4 +64,16 @@ class KubeClientBuilderTest < Krane::TestCase
     assert(!client.nil?, "Expected Kubeclient is built for context " \
       "#{context_name} with success.")
   end
+
+  def test_empty_contexts_kubeconfig_file
+    # Should ignore kubeconfig files with no contexts defined
+    Kubeclient::Client.any_instance.stubs(:discover)
+    empty_config = File.join(__dir__, '../../fixtures/kube-config/empty_config.yml')
+    dummy_config = File.join(__dir__, '../../fixtures/kube-config/dummy_config.yml')
+
+    # When combined with a valid config, the empty one is silently ignored
+    kubeclient_builder = Krane::KubeclientBuilder.new(kubeconfig: "#{empty_config}:#{dummy_config}")
+    client = kubeclient_builder.build_v1_kubeclient("docker-for-desktop")
+    assert(!client.nil?, "Expected Kubeclient to be built successfully, ignoring empty config")
+  end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

If the first file in environment variable `KUBECONFIG` is "empty" with simply the following structure

```yaml
apiVersion: v1
clusters: null
contexts: null
current-context: some-cluster
kind: Config
preferences: {}
users: null
```

`krane` will crash with the following error [when trying to access `contexts` in gem `kubeclient`](https://github.com/ManageIQ/kubeclient/blob/c6e29f9ce9bff133099da01e239dfbdd9710d95a/lib/kubeclient/config.rb#L45) because `contexts` is set to `null` in the empty config. 

```
'Kubeclient::Config#contexts': undefined method 'map' for nil (NoMethodError)

      @kcfg['contexts'].map { |x| x['name'] }
```

**How is this accomplished?**
By adding validation when creating `@kubeclient_configs` to simply skip files in `$KUBECONFIG` that have `null` contexts. This does parse the file twice tough (once in `krane` for validation then in `kubeclient`).

Is this the right approach? 

**What could go wrong?**
Nothing really, file with `null` contexts will be ignored when building the kube client.
