### PR TITLE
Remove defunct @Shopify/infrastructure-tooling from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Shopify/infrastructure-tooling @Shopify/application-infrastructure
+* @Shopify/application-infrastructure


### PR DESCRIPTION
## Summary

The `@Shopify/infrastructure-tooling` team no longer exists and should be removed from CODEOWNERS files across Shopify repositories. This PR removes references to the defunct team from this repository's CODEOWNERS file.

## Changes

- **Line 1**: Removed `@Shopify/infrastructure-tooling` from default owners

## Impact

No impact on code review process. `@Shopify/application-infrastructure` is already present as a codeowner and will continue to receive review requests.

## Testing

- Verified CODEOWNERS file syntax is correct
- Confirmed `@Shopify/application-infrastructure` remains as owner

---

Part of organization-wide CODEOWNERS cleanup to remove defunct team references.

Generated with Claude Code (https://claude.com/claude-code)